### PR TITLE
feat: add AWS CLI-backed Bedrock provider

### DIFF
--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -52,11 +52,11 @@ llm:
   # Provider-specific settings for Azure OpenAI.
   azure:
     deployment: "" # Azure OpenAI deployment name
-  # Provider-specific settings for AWS Bedrock.
+  # Provider-specific settings for Bedrock via AWS CLI.
   bedrock:
     aws_key: "${AWS_ACCESS_KEY_ID}"
     aws_secret: "${AWS_SECRET_ACCESS_KEY}"
-    aws_profile: ""
+    aws_profile: "" # optional AWS profile for the AWS CLI-backed Bedrock provider
     region: ""
     model_arn: ""
   # Provider-specific settings for Cloudflare Workers AI.

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -56,6 +56,7 @@ llm:
   bedrock:
     aws_key: "${AWS_ACCESS_KEY_ID}"
     aws_secret: "${AWS_SECRET_ACCESS_KEY}"
+    aws_profile: ""
     region: ""
     model_arn: ""
   # Provider-specific settings for Cloudflare Workers AI.

--- a/cmd/mistermorph/chatcmd/repl.go
+++ b/cmd/mistermorph/chatcmd/repl.go
@@ -14,9 +14,9 @@ import (
 	"github.com/chzyer/readline"
 	"github.com/quailyquaily/mistermorph/agent"
 	"github.com/quailyquaily/mistermorph/internal/chatcommands"
-	"github.com/quailyquaily/mistermorph/internal/pathroots"
 	"github.com/quailyquaily/mistermorph/internal/llmstats"
 	"github.com/quailyquaily/mistermorph/internal/outputfmt"
+	"github.com/quailyquaily/mistermorph/internal/pathroots"
 	"github.com/quailyquaily/mistermorph/llm"
 )
 
@@ -53,7 +53,7 @@ func runREPL(sess *chatSession) error {
 	sess.setWriter(rl.Stdout())
 	writer := sess.currentWriter()
 
-	printChatSessionHeader(writer, strings.TrimSpace(sess.mainCfg.Model), sess.workspaceDir, sess.fileCacheDir)
+	printChatSessionHeader(writer, sess.compactMode, strings.TrimSpace(sess.mainCfg.Model), sess.workspaceDir, sess.fileCacheDir)
 
 	reg := chatcommands.NewRegistry()
 	history := make([]llm.Message, 0, 32)

--- a/cmd/mistermorph/chatcmd/ui.go
+++ b/cmd/mistermorph/chatcmd/ui.go
@@ -133,10 +133,12 @@ func thinkingAnimation(writer io.Writer) (stop func(), setMessage func(msg strin
 	return stop, setMessage
 }
 
-func printChatSessionHeader(writer io.Writer, model string, workspaceDir string, fileCacheDir string) {
-	_, _ = fmt.Fprint(writer, chatBanner)
+func printChatSessionHeader(writer io.Writer, compactMode bool, model string, workspaceDir string, fileCacheDir string) {
+	if !compactMode {
+		_, _ = fmt.Fprint(writer, chatBanner)
+	}
 	if model != "" {
-		_, _ = fmt.Fprintf(writer, "model=%s\n", model)
+		_, _ = fmt.Fprintf(writer, "model=%s\n", displayModelName(model))
 	}
 	if workspaceDir != "" {
 		_, _ = fmt.Fprintf(writer, "workspace_dir=%s\n", workspaceDir)
@@ -144,5 +146,18 @@ func printChatSessionHeader(writer io.Writer, model string, workspaceDir string,
 	if fileCacheDir != "" {
 		_, _ = fmt.Fprintf(writer, "file_cache_dir=%s\n", fileCacheDir)
 	}
-	_, _ = fmt.Fprintln(writer, "\033[90mInteractive chat started. Press Ctrl+C or type /exit to quit.\033[0m")
+	if !compactMode {
+		_, _ = fmt.Fprintln(writer, "\033[90mInteractive chat started. Press Ctrl+C or type /exit to quit.\033[0m")
+	}
+}
+
+func displayModelName(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(model, "/"); idx >= 0 && idx+1 < len(model) {
+		return strings.TrimSpace(model[idx+1:])
+	}
+	return model
 }

--- a/cmd/mistermorph/chatcmd/ui_test.go
+++ b/cmd/mistermorph/chatcmd/ui_test.go
@@ -1,0 +1,55 @@
+package chatcmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrintChatSessionHeader_DefaultMode(t *testing.T) {
+	var b strings.Builder
+	printChatSessionHeader(&b, false, "openai/gpt-test", "/tmp/workspace", "/tmp/cache")
+	got := b.String()
+
+	for _, want := range []string{
+		"▄▄   ▄▄",
+		"model=gpt-test",
+		"workspace_dir=/tmp/workspace",
+		"file_cache_dir=/tmp/cache",
+		"Interactive chat started. Press Ctrl+C or type /exit to quit.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("header missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestPrintChatSessionHeader_CompactMode(t *testing.T) {
+	var b strings.Builder
+	printChatSessionHeader(&b, true, "openai/gpt-test", "/tmp/workspace", "/tmp/cache")
+	got := b.String()
+
+	for _, want := range []string{
+		"model=gpt-test",
+		"workspace_dir=/tmp/workspace",
+		"file_cache_dir=/tmp/cache",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("header missing %q in %q", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"▄▄   ▄▄",
+		"Interactive chat started. Press Ctrl+C or type /exit to quit.",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("header unexpectedly contains %q in %q", unwanted, got)
+		}
+	}
+}
+
+func TestDisplayModelName_BedrockARN(t *testing.T) {
+	got := displayModelName("arn:aws:bedrock:ap-northeast-1::foundation-model/moonshotai.kimi-k2.5")
+	if got != "moonshotai.kimi-k2.5" {
+		t.Fatalf("displayModelName() = %q, want moonshotai.kimi-k2.5", got)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,6 +270,7 @@ Global flags:
 Provider-specific values use the same mapping. Examples:
 
 - `llm.azure.deployment` -> `MISTER_MORPH_LLM_AZURE_DEPLOYMENT`
+- `llm.bedrock.aws_profile` -> `MISTER_MORPH_LLM_BEDROCK_AWS_PROFILE`
 - `llm.bedrock.model_arn` -> `MISTER_MORPH_LLM_BEDROCK_MODEL_ARN`
 
 ## Key Config Areas

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,6 +281,8 @@ Core LLM:
 - Most providers use `llm.endpoint`, `llm.api_key`, and `llm.model`.
 - Azure uses `llm.azure.deployment`.
 - Bedrock uses `llm.bedrock.*`.
+  Current implementation: Bedrock via AWS CLI.
+  Credentials can come from `llm.bedrock.aws_key` / `llm.bedrock.aws_secret` or `llm.bedrock.aws_profile`.
 - `llm.cache_ttl` controls cache intent across providers. Supported values are `off`, `short`, `long`, and Go duration strings such as `5m`, `1h`, and `24h`. The runtime maps this to each provider's supported cache buckets.
 - `llm.tools_emulation_mode` controls tool-call emulation for models without native tool calling.
 - `llm.profiles` defines named profile overrides.

--- a/docs/feat/feat_20260424_bedrock_via_aws_cli.md
+++ b/docs/feat/feat_20260424_bedrock_via_aws_cli.md
@@ -1,0 +1,108 @@
+---
+date: 2026-04-24
+title: Bedrock via AWS CLI
+status: draft
+---
+
+# Bedrock via AWS CLI
+
+## 1) Summary
+
+This branch implements Bedrock via AWS CLI.
+
+User-facing name:
+
+- Bedrock via AWS CLI
+
+Implementation-facing name:
+
+- AWS CLI-backed Bedrock provider
+
+The provider continues to use `llm.provider=bedrock`, but the backend transport is now the local AWS CLI command:
+
+- `aws bedrock-runtime converse`
+
+## 2) Why This Exists
+
+The primary goal is to support local AWS credential resolution that depends on the operator environment, especially:
+
+- AWS profiles such as `llm.bedrock.aws_profile`
+- existing local AWS CLI configuration
+- local AWS auth flows that are already working outside the app
+
+This makes the Bedrock path usable in environments where static `aws_key` / `aws_secret` are not the preferred integration mode.
+
+## 3) What The Provider Supports
+
+The AWS CLI-backed Bedrock provider supports the existing `llm.Request` contract used by the agent runtime:
+
+- text chat
+- system messages
+- tool calls
+- tool results
+- multimodal image parts
+- standard inference parameters such as `temperature`, `top_p`, `max_tokens`, and `stop`
+
+It translates the internal request into Bedrock `converse` payloads and parses Bedrock `toolUse` / `toolResult` responses back into the shared `llm.Result` shape.
+
+## 4) Config Surface
+
+The config namespace stays the same:
+
+- `llm.provider=bedrock`
+- `llm.bedrock.aws_key`
+- `llm.bedrock.aws_secret`
+- `llm.bedrock.aws_profile`
+- `llm.bedrock.region`
+- `llm.bedrock.model_arn`
+
+Credential sources:
+
+- explicit AWS key / secret
+- AWS profile via `llm.bedrock.aws_profile`
+
+The latest follow-up fix on this branch wires `aws_profile` all the way into the Bedrock client so the spawned AWS CLI process actually uses the configured profile.
+
+## 5) Compatibility And Impact
+
+Impact on other providers:
+
+- none
+
+Impact on the public Bedrock config surface:
+
+- none beyond adding `llm.bedrock.aws_profile`
+
+Impact on existing Bedrock usage in this branch:
+
+- no intended behavioral regression
+- the follow-up changes only fix missing config wiring and restore compact chat header behavior
+
+Implementation note for upstream reviewers:
+
+- this is a backend transport change from a uniai-backed Bedrock path to an AWS CLI-backed Bedrock path
+- the intent is to preserve the same high-level provider role in the runtime while making local AWS-auth-driven operation practical
+
+## 6) Validation
+
+Validated on this branch with:
+
+- `go test ./internal/llmutil ./cmd/mistermorph/chatcmd ./providers/bedrock`
+- `go build -o ./bin/mistermorph ./cmd/mistermorph`
+- manual `mistermorph chat --compact-mode` verification with Bedrock config
+
+## 7) Example
+
+```yaml
+llm:
+  provider: bedrock
+  bedrock:
+    aws_profile: common-api-dev
+    region: ap-northeast-1
+    model_arn: anthropic.claude-3-5-sonnet-20240620-v1:0
+```
+
+This should be described upstream as:
+
+- Bedrock via AWS CLI for operators
+- AWS CLI-backed Bedrock provider in implementation terms

--- a/docs/feat/feat_20260424_bedrock_via_aws_cli.md
+++ b/docs/feat/feat_20260424_bedrock_via_aws_cli.md
@@ -63,6 +63,14 @@ Credential sources:
 
 The latest follow-up fix on this branch wires `aws_profile` all the way into the Bedrock client so the spawned AWS CLI process actually uses the configured profile.
 
+Credential precedence:
+
+- if `llm.bedrock.aws_key` / `llm.bedrock.aws_secret` are set, they are passed to the AWS CLI process as explicit environment credentials
+- if `llm.bedrock.aws_profile` is set, it is passed as `AWS_PROFILE`
+- when both are present, the expected effective behavior is that explicit environment credentials win and the profile acts only as a secondary source/context
+
+This means existing users who already configure Bedrock with explicit credentials should continue to work, while profile-based users gain a supported path without requiring static credentials in config.
+
 ## 5) Compatibility And Impact
 
 Impact on other providers:

--- a/internal/llmutil/llmutil.go
+++ b/internal/llmutil/llmutil.go
@@ -10,6 +10,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/llmconfig"
 	"github.com/quailyquaily/mistermorph/internal/pricingutil"
 	"github.com/quailyquaily/mistermorph/llm"
+	bedrockProvider "github.com/quailyquaily/mistermorph/providers/bedrock"
 	uniaiProvider "github.com/quailyquaily/mistermorph/providers/uniai"
 	uniaiapi "github.com/quailyquaily/uniai"
 	"github.com/spf13/viper"
@@ -162,7 +163,17 @@ func ClientFromConfigWithValues(cfg llmconfig.ClientConfig, values RuntimeValues
 		uniaiProviderName = "openai"
 	}
 	switch provider {
-	case "openai", "openai_resp", "openai_custom", "deepseek", "xai", "gemini", "azure", "anthropic", "bedrock", "susanoo", "cloudflare":
+	case "bedrock":
+		return bedrockProvider.New(bedrockProvider.Config{
+			Model:          firstNonEmpty(strings.TrimSpace(cfg.Model), firstNonEmpty(values.BedrockModelARN)),
+			Region:         firstNonEmpty(values.BedrockAWSRegion),
+			AccessKey:      firstNonEmpty(values.BedrockAWSKey),
+			SecretKey:      firstNonEmpty(values.BedrockAWSSecret),
+			AWSProfile:     "",
+			ReadTimeout:    cfg.RequestTimeout,
+			ConnectTimeout: 0,
+		}), nil
+	case "openai", "openai_resp", "openai_custom", "deepseek", "xai", "gemini", "azure", "anthropic", "susanoo", "cloudflare":
 		c := uniaiProvider.New(uniaiProvider.Config{
 			Provider:           uniaiProviderName,
 			Endpoint:           strings.TrimSpace(cfg.Endpoint),

--- a/internal/llmutil/llmutil.go
+++ b/internal/llmutil/llmutil.go
@@ -40,6 +40,7 @@ type RuntimeValues struct {
 
 	BedrockAWSKey       string `config:"llm.bedrock.aws_key"`
 	BedrockAWSSecret    string `config:"llm.bedrock.aws_secret"`
+	BedrockAWSProfile   string `config:"llm.bedrock.aws_profile"`
 	BedrockAWSRegion    string `config:"llm.bedrock.region"`
 	BedrockModelARN     string `config:"llm.bedrock.model_arn"`
 	CloudflareAccountID string `config:"llm.cloudflare.account_id"`
@@ -69,6 +70,7 @@ func RuntimeValuesFromReader(r ConfigReader) RuntimeValues {
 		Routes:             loadLLMRoutesFromReader(r),
 		BedrockAWSKey:      firstNonEmpty(r.GetString("llm.bedrock.aws_key"), r.GetString("llm.aws.key")),
 		BedrockAWSSecret:   firstNonEmpty(r.GetString("llm.bedrock.aws_secret"), r.GetString("llm.aws.secret")),
+		BedrockAWSProfile:  firstNonEmpty(r.GetString("llm.bedrock.aws_profile"), r.GetString("llm.aws.profile")),
 		BedrockAWSRegion:   firstNonEmpty(r.GetString("llm.bedrock.region"), r.GetString("llm.aws.region")),
 		BedrockModelARN:    firstNonEmpty(r.GetString("llm.bedrock.model_arn"), r.GetString("llm.aws.bedrock_model_arn")),
 		CloudflareAccountID: firstNonEmpty(
@@ -124,6 +126,11 @@ func ModelForProviderWithValues(provider string, values RuntimeValues) string {
 			values.AzureDeployment,
 			values.Model,
 		)
+	case "bedrock":
+		return firstNonEmpty(
+			values.Model,
+			values.BedrockModelARN,
+		)
 	default:
 		return strings.TrimSpace(values.Model)
 	}
@@ -169,7 +176,7 @@ func ClientFromConfigWithValues(cfg llmconfig.ClientConfig, values RuntimeValues
 			Region:         firstNonEmpty(values.BedrockAWSRegion),
 			AccessKey:      firstNonEmpty(values.BedrockAWSKey),
 			SecretKey:      firstNonEmpty(values.BedrockAWSSecret),
-			AWSProfile:     "",
+			AWSProfile:     firstNonEmpty(values.BedrockAWSProfile),
 			ReadTimeout:    cfg.RequestTimeout,
 			ConnectTimeout: 0,
 		}), nil

--- a/internal/llmutil/llmutil_test.go
+++ b/internal/llmutil/llmutil_test.go
@@ -3,11 +3,13 @@ package llmutil
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/quailyquaily/mistermorph/internal/llmconfig"
+	bedrockProvider "github.com/quailyquaily/mistermorph/providers/bedrock"
 	"github.com/spf13/viper"
 )
 
@@ -105,6 +107,26 @@ llm:
 	}
 }
 
+func TestRuntimeValuesFromReader_ReadsBedrockAWSProfile(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader(`
+llm:
+  provider: bedrock
+  bedrock:
+    aws_profile: common-api-dev
+    region: ap-northeast-1
+    model_arn: anthropic.claude-3-5-sonnet-20240620-v1:0
+`)); err != nil {
+		t.Fatalf("ReadConfig() error = %v", err)
+	}
+
+	values := RuntimeValuesFromReader(v)
+	if values.BedrockAWSProfile != "common-api-dev" {
+		t.Fatalf("RuntimeValuesFromReader().BedrockAWSProfile = %q, want common-api-dev", values.BedrockAWSProfile)
+	}
+}
+
 func TestModelForProviderWithValues_AzureDeploymentFirst(t *testing.T) {
 	values := RuntimeValues{
 		Model:           "gpt-5.2",
@@ -116,6 +138,20 @@ func TestModelForProviderWithValues_AzureDeploymentFirst(t *testing.T) {
 	values.AzureDeployment = ""
 	if got := ModelForProviderWithValues("azure", values); got != "gpt-5.2" {
 		t.Fatalf("ModelForProviderWithValues() = %q, want gpt-5.2", got)
+	}
+}
+
+func TestModelForProviderWithValues_BedrockModelARNFallback(t *testing.T) {
+	values := RuntimeValues{
+		BedrockModelARN: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+	}
+	if got := ModelForProviderWithValues("bedrock", values); got != "anthropic.claude-3-5-sonnet-20240620-v1:0" {
+		t.Fatalf("ModelForProviderWithValues() = %q, want anthropic.claude-3-5-sonnet-20240620-v1:0", got)
+	}
+
+	values.Model = "override-model"
+	if got := ModelForProviderWithValues("bedrock", values); got != "override-model" {
+		t.Fatalf("ModelForProviderWithValues() = %q, want override-model", got)
 	}
 }
 
@@ -357,6 +393,66 @@ func TestResolveRoute_ProfileInheritance(t *testing.T) {
 	}
 	if len(resolved.Fallbacks) != 0 {
 		t.Fatalf("fallbacks = %d, want 0", len(resolved.Fallbacks))
+	}
+}
+
+func TestResolveRoute_ProfileInheritance_BedrockAWSProfile(t *testing.T) {
+	values := RuntimeValues{
+		Provider:          "bedrock",
+		Model:             "anthropic.claude-3-5-sonnet-20240620-v1:0",
+		BedrockAWSProfile: "base-profile",
+		BedrockAWSRegion:  "ap-northeast-1",
+		RequestTimeoutRaw: "90s",
+		Profiles: map[string]ProfileConfig{
+			"team": {
+				Bedrock: struct {
+					AWSKey     string `mapstructure:"aws_key"`
+					AWSSecret  string `mapstructure:"aws_secret"`
+					AWSProfile string `mapstructure:"aws_profile"`
+					Region     string `mapstructure:"region"`
+					ModelARN   string `mapstructure:"model_arn"`
+				}{
+					AWSProfile: "common-api-dev",
+				},
+			},
+		},
+		Routes: RoutesConfig{
+			PurposeRoutes: PurposeRoutes{
+				MainLoop: RoutePolicyConfig{Profile: "team"},
+			},
+		},
+	}
+
+	resolved, err := ResolveRoute(values, RoutePurposeMainLoop)
+	if err != nil {
+		t.Fatalf("ResolveRoute() error = %v", err)
+	}
+	if resolved.Values.BedrockAWSProfile != "common-api-dev" {
+		t.Fatalf("resolved profile = %q, want common-api-dev", resolved.Values.BedrockAWSProfile)
+	}
+}
+
+func TestClientFromConfigWithValues_BedrockAWSProfile(t *testing.T) {
+	client, err := ClientFromConfigWithValues(llmconfig.ClientConfig{
+		Provider:       "bedrock",
+		Model:          "anthropic.claude-3-5-sonnet-20240620-v1:0",
+		RequestTimeout: 10 * time.Second,
+	}, RuntimeValues{
+		Provider:          "bedrock",
+		BedrockAWSProfile: "common-api-dev",
+		BedrockAWSRegion:  "ap-northeast-1",
+		BedrockModelARN:   "anthropic.claude-3-5-sonnet-20240620-v1:0",
+	})
+	if err != nil {
+		t.Fatalf("ClientFromConfigWithValues() error = %v", err)
+	}
+
+	bedrockClient, ok := client.(*bedrockProvider.Client)
+	if !ok {
+		t.Fatalf("client type = %T, want *bedrock.Client", client)
+	}
+	if got := reflect.ValueOf(bedrockClient).Elem().FieldByName("awsProfile").String(); got != "common-api-dev" {
+		t.Fatalf("awsProfile = %q, want common-api-dev", got)
 	}
 }
 

--- a/internal/llmutil/routes.go
+++ b/internal/llmutil/routes.go
@@ -35,10 +35,11 @@ type ProfileConfig struct {
 		Deployment string `mapstructure:"deployment"`
 	} `mapstructure:"azure"`
 	Bedrock struct {
-		AWSKey    string `mapstructure:"aws_key"`
-		AWSSecret string `mapstructure:"aws_secret"`
-		Region    string `mapstructure:"region"`
-		ModelARN  string `mapstructure:"model_arn"`
+		AWSKey     string `mapstructure:"aws_key"`
+		AWSSecret  string `mapstructure:"aws_secret"`
+		AWSProfile string `mapstructure:"aws_profile"`
+		Region     string `mapstructure:"region"`
+		ModelARN   string `mapstructure:"model_arn"`
 	} `mapstructure:"bedrock"`
 	Cloudflare struct {
 		AccountID string `mapstructure:"account_id"`
@@ -306,6 +307,7 @@ func normalizeProfileConfig(cfg ProfileConfig) ProfileConfig {
 	cfg.Azure.Deployment = strings.TrimSpace(cfg.Azure.Deployment)
 	cfg.Bedrock.AWSKey = strings.TrimSpace(cfg.Bedrock.AWSKey)
 	cfg.Bedrock.AWSSecret = strings.TrimSpace(cfg.Bedrock.AWSSecret)
+	cfg.Bedrock.AWSProfile = strings.TrimSpace(cfg.Bedrock.AWSProfile)
 	cfg.Bedrock.Region = strings.TrimSpace(cfg.Bedrock.Region)
 	cfg.Bedrock.ModelARN = strings.TrimSpace(cfg.Bedrock.ModelARN)
 	cfg.Cloudflare.AccountID = strings.TrimSpace(cfg.Cloudflare.AccountID)
@@ -400,6 +402,7 @@ func applyProfileOverride(base RuntimeValues, override ProfileConfig) RuntimeVal
 	applyStringOverride(&out.AzureDeployment, override.Azure.Deployment)
 	applyStringOverride(&out.BedrockAWSKey, override.Bedrock.AWSKey)
 	applyStringOverride(&out.BedrockAWSSecret, override.Bedrock.AWSSecret)
+	applyStringOverride(&out.BedrockAWSProfile, override.Bedrock.AWSProfile)
 	applyStringOverride(&out.BedrockAWSRegion, override.Bedrock.Region)
 	applyStringOverride(&out.BedrockModelARN, override.Bedrock.ModelARN)
 	applyStringOverride(&out.CloudflareAccountID, override.Cloudflare.AccountID)

--- a/providers/bedrock/client.go
+++ b/providers/bedrock/client.go
@@ -1,0 +1,519 @@
+package bedrock
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/quailyquaily/mistermorph/llm"
+)
+
+type Config struct {
+	Model          string
+	Region         string
+	AccessKey      string
+	SecretKey      string
+	SessionToken   string
+	AWSProfile     string
+	CABundle       string
+	ReadTimeout    time.Duration
+	ConnectTimeout time.Duration
+}
+
+type Client struct {
+	model          string
+	region         string
+	accessKey      string
+	secretKey      string
+	sessionToken   string
+	awsProfile     string
+	caBundle       string
+	readTimeout    time.Duration
+	connectTimeout time.Duration
+}
+
+func New(cfg Config) *Client {
+	readTimeout := cfg.ReadTimeout
+	if readTimeout <= 0 {
+		readTimeout = 5 * time.Minute
+	}
+	connectTimeout := cfg.ConnectTimeout
+	if connectTimeout <= 0 {
+		connectTimeout = 60 * time.Second
+	}
+	return &Client{
+		model:          strings.TrimSpace(cfg.Model),
+		region:         strings.TrimSpace(cfg.Region),
+		accessKey:      strings.TrimSpace(cfg.AccessKey),
+		secretKey:      strings.TrimSpace(cfg.SecretKey),
+		sessionToken:   strings.TrimSpace(cfg.SessionToken),
+		awsProfile:     strings.TrimSpace(cfg.AWSProfile),
+		caBundle:       strings.TrimSpace(cfg.CABundle),
+		readTimeout:    readTimeout,
+		connectTimeout: connectTimeout,
+	}
+}
+
+func (c *Client) Chat(ctx context.Context, req llm.Request) (llm.Result, error) {
+	start := time.Now()
+
+	modelID := strings.TrimSpace(req.Model)
+	if modelID == "" {
+		modelID = c.model
+	}
+	if modelID == "" {
+		return llm.Result{}, fmt.Errorf("bedrock: model is required")
+	}
+
+	payload, err := c.buildRequest(modelID, req)
+	if err != nil {
+		return llm.Result{}, err
+	}
+
+	inputJSON, err := json.Marshal(payload)
+	if err != nil {
+		return llm.Result{}, fmt.Errorf("bedrock: marshal request: %w", err)
+	}
+
+	inputFile, err := os.CreateTemp("", "mistermorph-bedrock-*.json")
+	if err != nil {
+		return llm.Result{}, fmt.Errorf("bedrock: create temp request file: %w", err)
+	}
+	inputPath := inputFile.Name()
+	defer os.Remove(inputPath)
+	if _, err := inputFile.Write(inputJSON); err != nil {
+		_ = inputFile.Close()
+		return llm.Result{}, fmt.Errorf("bedrock: write temp request file: %w", err)
+	}
+	if err := inputFile.Close(); err != nil {
+		return llm.Result{}, fmt.Errorf("bedrock: close temp request file: %w", err)
+	}
+
+	args := []string{"bedrock-runtime", "converse", "--cli-input-json", "file://" + inputPath, "--output", "json"}
+	if c.region != "" {
+		args = append(args, "--region", c.region)
+	}
+	if c.readTimeout > 0 {
+		args = append(args, "--cli-read-timeout", strconv.Itoa(int(c.readTimeout/time.Second)))
+	}
+	if c.connectTimeout > 0 {
+		args = append(args, "--cli-connect-timeout", strconv.Itoa(int(c.connectTimeout/time.Second)))
+	}
+	if c.caBundle != "" {
+		args = append(args, "--ca-bundle", c.caBundle)
+	}
+
+	cmd := exec.CommandContext(ctx, "aws", args...)
+	cmd.Env = c.commandEnv()
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = strings.TrimSpace(stdout.String())
+		}
+		if msg == "" {
+			msg = err.Error()
+		}
+		return llm.Result{}, fmt.Errorf("bedrock: converse failed: %s", msg)
+	}
+
+	var resp converseResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		return llm.Result{}, fmt.Errorf("bedrock: decode response: %w", err)
+	}
+
+	result := llm.Result{
+		Text:      flattenText(resp.Output.Message.Content),
+		ToolCalls: toToolCalls(resp.Output.Message.Content),
+		Usage: llm.Usage{
+			InputTokens:  resp.Usage.InputTokens,
+			OutputTokens: resp.Usage.OutputTokens,
+			TotalTokens:  resp.Usage.TotalTokens,
+		},
+		Duration: time.Since(start),
+	}
+	return result, nil
+}
+
+func (c *Client) commandEnv() []string {
+	env := os.Environ()
+	if c.accessKey != "" || c.secretKey != "" || c.sessionToken != "" {
+		env = setEnvValue(env, "AWS_ACCESS_KEY_ID", c.accessKey)
+		env = setEnvValue(env, "AWS_SECRET_ACCESS_KEY", c.secretKey)
+		env = setEnvValue(env, "AWS_SESSION_TOKEN", c.sessionToken)
+	}
+	if c.awsProfile != "" {
+		env = setEnvValue(env, "AWS_PROFILE", c.awsProfile)
+	}
+	if c.region != "" {
+		env = setEnvValue(env, "AWS_REGION", c.region)
+		env = setEnvValue(env, "AWS_DEFAULT_REGION", c.region)
+	}
+	return env
+}
+
+func setEnvValue(env []string, key string, value string) []string {
+	prefix := key + "="
+	filtered := env[:0]
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	if strings.TrimSpace(value) != "" {
+		filtered = append(filtered, prefix+value)
+	}
+	return filtered
+}
+
+func (c *Client) buildRequest(modelID string, req llm.Request) (map[string]any, error) {
+	system, messages, err := toConverseMessages(req.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]any{
+		"modelId":  modelID,
+		"messages": messages,
+	}
+	if len(system) > 0 {
+		payload["system"] = system
+	}
+	if len(req.Tools) > 0 {
+		toolConfig, err := toToolConfig(req.Tools)
+		if err != nil {
+			return nil, err
+		}
+		payload["toolConfig"] = toolConfig
+	}
+
+	inference := map[string]any{}
+	if req.Parameters != nil {
+		if v, ok := floatFromAny(req.Parameters["temperature"]); ok {
+			inference["temperature"] = v
+		}
+		if v, ok := floatFromAny(req.Parameters["top_p"]); ok {
+			inference["topP"] = v
+		}
+		if v, ok := intFromAny(req.Parameters["max_tokens"]); ok && v > 0 {
+			inference["maxTokens"] = v
+		}
+		if v, ok := stringSliceFromAny(req.Parameters["stop"]); ok && len(v) > 0 {
+			inference["stopSequences"] = v
+		}
+	}
+	if len(inference) > 0 {
+		payload["inferenceConfig"] = inference
+	}
+
+	return payload, nil
+}
+
+func toConverseMessages(messages []llm.Message) ([]map[string]any, []map[string]any, error) {
+	system := make([]map[string]any, 0, 1)
+	out := make([]map[string]any, 0, len(messages))
+
+	for _, msg := range messages {
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		if role == "" {
+			role = "user"
+		}
+		if role == "system" {
+			if strings.TrimSpace(msg.Content) != "" {
+				system = append(system, map[string]any{"text": msg.Content})
+			}
+			for _, part := range msg.Parts {
+				if strings.EqualFold(strings.TrimSpace(part.Type), llm.PartTypeText) && strings.TrimSpace(part.Text) != "" {
+					system = append(system, map[string]any{"text": part.Text})
+				}
+			}
+			continue
+		}
+
+		bedrockRole := role
+		if bedrockRole == "tool" {
+			bedrockRole = "user"
+		}
+		if bedrockRole != "user" && bedrockRole != "assistant" {
+			bedrockRole = "user"
+		}
+
+		content, err := toContentBlocks(msg)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(content) == 0 {
+			continue
+		}
+
+		// Bedrock requires all toolResult blocks for a given assistant turn to be
+		// in a single user message. Merge consecutive same-role messages.
+		if len(out) > 0 && out[len(out)-1]["role"] == bedrockRole {
+			existing := out[len(out)-1]["content"].([]map[string]any)
+			out[len(out)-1]["content"] = append(existing, content...)
+		} else {
+			out = append(out, map[string]any{
+				"role":    bedrockRole,
+				"content": content,
+			})
+		}
+	}
+
+	return system, out, nil
+}
+
+func toContentBlocks(msg llm.Message) ([]map[string]any, error) {
+	content := make([]map[string]any, 0, 1+len(msg.Parts)+len(msg.ToolCalls))
+
+	if strings.TrimSpace(msg.ToolCallID) != "" {
+		block := map[string]any{
+			"toolResult": map[string]any{
+				"toolUseId": msg.ToolCallID,
+				"content": []map[string]any{
+					{"text": msg.Content},
+				},
+			},
+		}
+		content = append(content, block)
+		return content, nil
+	}
+
+	if strings.TrimSpace(msg.Content) != "" {
+		content = append(content, map[string]any{"text": msg.Content})
+	}
+
+	for _, part := range msg.Parts {
+		switch strings.ToLower(strings.TrimSpace(part.Type)) {
+		case llm.PartTypeText:
+			if strings.TrimSpace(part.Text) != "" {
+				content = append(content, map[string]any{"text": part.Text})
+			}
+		case llm.PartTypeImageBase64:
+			if strings.TrimSpace(part.DataBase64) == "" {
+				continue
+			}
+			imageBytes, err := base64.StdEncoding.DecodeString(part.DataBase64)
+			if err != nil {
+				return nil, fmt.Errorf("bedrock: decode image base64: %w", err)
+			}
+			format := imageFormatFromMIME(part.MIMEType)
+			if format == "" {
+				return nil, fmt.Errorf("bedrock: unsupported image mime type %q", part.MIMEType)
+			}
+			content = append(content, map[string]any{
+				"image": map[string]any{
+					"format": format,
+					"source": map[string]any{
+						"bytes": base64.StdEncoding.EncodeToString(imageBytes),
+					},
+				},
+			})
+		}
+	}
+
+	for _, call := range msg.ToolCalls {
+		input := call.Arguments
+		if input == nil {
+			input = map[string]any{}
+		}
+		content = append(content, map[string]any{
+			"toolUse": map[string]any{
+				"toolUseId": firstNonEmpty(call.ID, call.Name),
+				"name":      call.Name,
+				"input":     input,
+			},
+		})
+	}
+
+	return content, nil
+}
+
+func imageFormatFromMIME(mime string) string {
+	switch strings.ToLower(strings.TrimSpace(mime)) {
+	case "image/png":
+		return "png"
+	case "image/jpeg", "image/jpg":
+		return "jpeg"
+	case "image/gif":
+		return "gif"
+	case "image/webp":
+		return "webp"
+	default:
+		return ""
+	}
+}
+
+func toToolConfig(tools []llm.Tool) (map[string]any, error) {
+	items := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			continue
+		}
+		schema := map[string]any{"type": "object"}
+		if strings.TrimSpace(tool.ParametersJSON) != "" {
+			var raw any
+			if err := json.Unmarshal([]byte(tool.ParametersJSON), &raw); err != nil {
+				return nil, fmt.Errorf("bedrock: invalid tool schema for %s: %w", name, err)
+			}
+			schema = map[string]any{"json": raw}
+		} else {
+			schema = map[string]any{"json": map[string]any{"type": "object"}}
+		}
+		items = append(items, map[string]any{
+			"toolSpec": map[string]any{
+				"name":        name,
+				"description": strings.TrimSpace(tool.Description),
+				"inputSchema": schema,
+			},
+		})
+	}
+	return map[string]any{
+		"tools": items,
+		"toolChoice": map[string]any{
+			"auto": map[string]any{},
+		},
+	}, nil
+}
+
+func flattenText(content []contentBlock) string {
+	var parts []string
+	for _, block := range content {
+		if strings.TrimSpace(block.Text) != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func toToolCalls(content []contentBlock) []llm.ToolCall {
+	out := make([]llm.ToolCall, 0)
+	for _, block := range content {
+		if block.ToolUse == nil {
+			continue
+		}
+		rawArgs := ""
+		if len(block.ToolUse.Input) > 0 {
+			if data, err := json.Marshal(block.ToolUse.Input); err == nil {
+				rawArgs = string(data)
+			}
+		}
+		out = append(out, llm.ToolCall{
+			ID:           strings.TrimSpace(block.ToolUse.ToolUseID),
+			Type:         "function",
+			Name:         strings.TrimSpace(block.ToolUse.Name),
+			Arguments:    block.ToolUse.Input,
+			RawArguments: rawArgs,
+		})
+	}
+	return out
+}
+
+func floatFromAny(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(n), 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func intFromAny(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case json.Number:
+		i, err := n.Int64()
+		return int(i), err == nil
+	case string:
+		i, err := strconv.Atoi(strings.TrimSpace(n))
+		return i, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func stringSliceFromAny(v any) ([]string, bool) {
+	switch s := v.(type) {
+	case []string:
+		return s, true
+	case []any:
+		out := make([]string, 0, len(s))
+		for _, item := range s {
+			text, ok := item.(string)
+			if !ok || strings.TrimSpace(text) == "" {
+				continue
+			}
+			out = append(out, text)
+		}
+		return out, len(out) > 0
+	default:
+		return nil, false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+type converseResponse struct {
+	Output struct {
+		Message struct {
+			Role    string         `json:"role"`
+			Content []contentBlock `json:"content"`
+		} `json:"message"`
+	} `json:"output"`
+	Usage struct {
+		InputTokens  int `json:"inputTokens"`
+		OutputTokens int `json:"outputTokens"`
+		TotalTokens  int `json:"totalTokens"`
+	} `json:"usage"`
+}
+
+type contentBlock struct {
+	Text       string           `json:"text,omitempty"`
+	ToolUse    *toolUseBlock    `json:"toolUse,omitempty"`
+	ToolResult *toolResultBlock `json:"toolResult,omitempty"`
+}
+
+type toolUseBlock struct {
+	ToolUseID string         `json:"toolUseId"`
+	Name      string         `json:"name"`
+	Input     map[string]any `json:"input"`
+}
+
+type toolResultBlock struct {
+	ToolUseID string `json:"toolUseId"`
+}

--- a/web/vitepress/docs/guide/config-reference.md
+++ b/web/vitepress/docs/guide/config-reference.md
@@ -28,6 +28,7 @@ All keys can be overridden by env vars (`MISTER_MORPH_...`). See [Environment Va
 - `llm.azure.deployment`
 - `llm.bedrock.aws_key`
 - `llm.bedrock.aws_secret`
+- `llm.bedrock.aws_profile`
 - `llm.bedrock.region`
 - `llm.bedrock.model_arn`
 - `llm.cloudflare.account_id`
@@ -39,6 +40,8 @@ All keys can be overridden by env vars (`MISTER_MORPH_...`). See [Environment Va
 - `llm.routes.<purpose>.candidates[].profile`
 - `llm.routes.<purpose>.candidates[].weight`
 - `llm.routes.<purpose>.fallback_profiles[]`
+
+Bedrock uses `llm.bedrock.*` for the AWS CLI-backed provider.
 
 ## Multimodal
 

--- a/web/vitepress/docs/ja/guide/config-reference.md
+++ b/web/vitepress/docs/ja/guide/config-reference.md
@@ -28,6 +28,7 @@ description: config.yaml の完全フィールドリファレンス。
 - `llm.azure.deployment`
 - `llm.bedrock.aws_key`
 - `llm.bedrock.aws_secret`
+- `llm.bedrock.aws_profile`
 - `llm.bedrock.region`
 - `llm.bedrock.model_arn`
 - `llm.cloudflare.account_id`
@@ -39,6 +40,8 @@ description: config.yaml の完全フィールドリファレンス。
 - `llm.routes.<purpose>.candidates[].profile`
 - `llm.routes.<purpose>.candidates[].weight`
 - `llm.routes.<purpose>.fallback_profiles[]`
+
+Bedrock は AWS CLI-backed provider として `llm.bedrock.*` を使います。
 
 ## Multimodal
 

--- a/web/vitepress/docs/zh/guide/config-reference.md
+++ b/web/vitepress/docs/zh/guide/config-reference.md
@@ -32,6 +32,7 @@ description: config.yaml 的完整字段参考（逐字段解释）。
 | `llm.azure.deployment` | Azure OpenAI 的 deployment 名称。 |
 | `llm.bedrock.aws_key` | Bedrock 的 AWS Access Key。 |
 | `llm.bedrock.aws_secret` | Bedrock 的 AWS Secret Key。 |
+| `llm.bedrock.aws_profile` | Bedrock via AWS CLI 的 AWS profile 名称。 |
 | `llm.bedrock.region` | Bedrock 区域。 |
 | `llm.bedrock.model_arn` | Bedrock 模型 ARN。 |
 | `llm.cloudflare.account_id` | Cloudflare Workers AI 账号 ID。 |
@@ -43,6 +44,8 @@ description: config.yaml 的完整字段参考（逐字段解释）。
 | `llm.routes.<purpose>.candidates[].profile` | 该 route 参与分流的 profile。 |
 | `llm.routes.<purpose>.candidates[].weight` | 该候选 profile 的权重；当前 run 内只会选中一个主候选。 |
 | `llm.routes.<purpose>.fallback_profiles[]` | 该 route 的本地回退链；主候选失败后按顺序尝试。 |
+
+Bedrock 当前实现是 Bedrock via AWS CLI，配置集中在 `llm.bedrock.*`。
 
 ## Multimodal
 


### PR DESCRIPTION
 ## Summary

  Add AWS CLI-backed Bedrock provider (`llm.provider=bedrock`) that invokes `aws bedrock-runtime converse` locally inste
  ad of going through the uniai SDK.

  This enables local AWS credential resolution via:
  - Explicit `aws_key` / `aws_secret`
  - AWS profile via `llm.bedrock.aws_profile` (new)

  ## Motivation

  The existing uniai-backed Bedrock path requires static credentials. In many operator environments, AWS auth is already
  configured via `~/.aws/config`, SSO, or IAM roles. This provider lets users leverage their existing AWS CLI setup with
  out putting static keys in config.

  ## What Changed

  | File | Change |
  |------|--------|
  | `providers/bedrock/client.go` | New: AWS CLI Bedrock provider (519 lines) |
  | `internal/llmutil/llmutil.go` | Register Bedrock provider, add `aws_profile` config |
  | `internal/llmutil/llmutil_test.go` | Tests for Bedrock model resolution |
  | `internal/llmutil/routes.go` | Profile routing support for `aws_profile` |
  | `cmd/mistermorph/chatcmd/ui.go` | Compact header + `displayModelName()` for Bedrock ARNs |
  | `cmd/mistermorph/chatcmd/ui_test.go` | Tests for compact header and ARN display |
  | `cmd/mistermorph/chatcmd/repl.go` | Pass `compactMode` to header printer |
  | `assets/config/config.example.yaml` | Add `aws_profile` to Bedrock section |
  | `docs/configuration.md` | Document Bedrock via AWS CLI |
  | `web/vitepress/docs/**/config-reference.md` | EN/JA/ZH docs update |
  | `docs/feat/feat_20260424_bedrock_via_aws_cli.md` | Design doc |

  ## Supported Features

  - Text chat, system messages, tool calls, tool results
  - Multimodal image parts
  - Standard inference params (`temperature`, `top_p`, `max_tokens`, `stop`)
  - Credential precedence: explicit env vars > `AWS_PROFILE`

  ## Config Example

  ```yaml
  llm:
    provider: bedrock
    bedrock:
      aws_profile: common-api-dev   # optional, uses AWS CLI profile
      region: ap-northeast-1
      model_arn: anthropic.claude-3-5-sonnet-20240620-v1:0
  Backward Compatibility
  • Existing aws_key / aws_secret users continue to work unchanged
  • aws_profile is optional; when absent, behavior is same as before
  Testing
  go test ./internal/llmutil ./cmd/mistermorph/chatcmd ./providers/bedrock
  go build -o ./bin/mistermorph ./cmd/mistermorph
  Manual verification done with mistermorph chat --compact-mode using Bedrock config.