### PR TITLE
feat: add Slack and Lark multimodal images

### DIFF
--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -104,7 +104,7 @@ llm:
 multimodal:
   image:
     # Enabled source whitelist.
-    # Supported values: telegram, slack, line, remote_download.
+    # Supported values: telegram, slack, line, lark, remote_download.
     sources: ["telegram", "line"]
 
 logging:

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -105,6 +105,8 @@ multimodal:
   image:
     # Enabled source whitelist.
     # Supported values: telegram, slack, line, lark, remote_download.
+    # Slack image input also needs Slack bot scope files:read.
+    # Lark image input also needs message resource permission, commonly im:resource.
     sources: ["telegram", "line"]
 
 logging:
@@ -494,7 +496,8 @@ telegram:
 slack:
   # Slack Web API base URL (override for mock/testing only).
   base_url: "https://slack.com/api"
-  # Bot token with chat:write + history scopes. Prefer env var: MISTER_MORPH_SLACK_BOT_TOKEN
+  # Bot token with chat:write + history scopes. Add files:read when enabling Slack image input.
+  # Prefer env var: MISTER_MORPH_SLACK_BOT_TOKEN
   bot_token: ""
   # App-level token for Socket Mode. Prefer env var: MISTER_MORPH_SLACK_APP_TOKEN
   app_token: ""
@@ -567,6 +570,8 @@ lark:
   verification_token: ""
   # Event subscription encrypt key.
   encrypt_key: ""
+  # For image input, grant message resource permission in the Feishu/Lark developer console
+  # (commonly im:resource) and subscribe to im.message.receive_v1.
   # Optional allowlist of chat IDs. Empty means allow all chats.
   allowed_chat_ids: []
   # Group trigger mode:

--- a/cmd/mistermorph/consolecmd/agent_settings.go
+++ b/cmd/mistermorph/consolecmd/agent_settings.go
@@ -33,7 +33,7 @@ const (
 	toolsSettingsKey      = "tools"
 )
 
-var supportedMultimodalSources = []string{"telegram", "slack", "line", "remote_download"}
+var supportedMultimodalSources = []string{"telegram", "slack", "line", "lark", "remote_download"}
 
 var agentSettingsEnvRefPattern = regexp.MustCompile(`^\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}$`)
 

--- a/docs/feat/feat_20260430_slack_lark_multimodal_images.md
+++ b/docs/feat/feat_20260430_slack_lark_multimodal_images.md
@@ -1,0 +1,357 @@
+---
+date: 2026-04-30
+title: Slack and Lark Multimodal Image Input
+status: draft
+---
+
+# Slack and Lark Multimodal Image Input
+
+## 1) Scope
+
+Add inbound image understanding for Slack and Lark runtime messages.
+
+V1 should only support images that arrive with the current user message. It should not add generic attachment browsing, arbitrary file reading, video, audio, OCR-specific tools, or outbound rich media changes.
+
+The target behavior:
+
+- If the runtime source is enabled in `multimodal.image.sources`, inbound images are downloaded to the runtime file cache and passed to the main LLM request as image parts.
+- If the source is disabled, the runtime should produce a clear text-only fallback prompt, aligned with LINE.
+- If the selected model does not support image parts, the message should still run as text-only.
+
+## 2) Current State
+
+Telegram and LINE already have the working shape:
+
+- Inbound runtime stores image paths on the job.
+- `build*PromptMessages(...)` receives `ImageRecognitionEnabled`.
+- Image files are converted into `llm.PartTypeImageBase64` parts.
+- Size, count, and MIME checks happen before building the LLM message.
+
+Slack does not yet have this path:
+
+- `slackEvent`, `slackInboundEvent`, `slackJob`, and `slackbus.InboundMessage` only carry text and message metadata.
+- `BuildSlackRunOptions` does not read `multimodal.image.sources`.
+- `buildSlackPromptMessages(...)` always builds plain text messages.
+
+Lark does not yet have this path:
+
+- `inboundMessageFromWebhookEvent(...)` only accepts text messages.
+- `larkbus.InboundMessage` and `larkJob` do not carry image paths.
+- `BuildLarkRunOptions` reads `multimodal.image.sources` for LINE only; Lark has no image flag.
+- `buildLarkPromptMessages(...)` always builds plain text messages.
+
+The config example currently lists `slack` as a supported image source, but Slack is not implemented. Lark is not listed.
+
+## 3) First Principles
+
+1. Runtime input decides whether an image exists.
+   The LLM layer should only receive local image paths or ready-made `llm.Part` values. It should not know Slack or Lark file APIs.
+
+2. Download belongs at the channel edge.
+   Slack token handling and Lark token handling must stay in their runtime API layers.
+
+3. Image handling should converge after download.
+   After a platform image is stored in `file_cache_dir/<runtime>/`, Slack and Lark should reuse the same kind of local-image-to-LLM-parts logic used by Telegram and LINE.
+
+4. No image content in memory by default.
+   Chat history and memory should record that an image was present, but should not store base64 image data.
+
+5. Failing to read an image should not crash the runtime.
+   The user task can continue with a short text note such as "image attachment could not be read" unless the whole inbound event is malformed.
+
+## 4) Config
+
+Use the existing setting:
+
+```yaml
+multimodal:
+  image:
+    sources: ["telegram", "line", "slack", "lark"]
+```
+
+Update `assets/config/config.example.yaml` so the documented supported values match implementation.
+
+Runtime behavior:
+
+- `slack` present: Slack inbound image recognition enabled.
+- `lark` present: Lark inbound image recognition enabled.
+- Missing source: do not download image for LLM input; provide a text fallback when the user sent only images.
+
+No new channel-specific config is needed in V1.
+
+## 5) Shared Data Model
+
+The smallest useful shape is still `[]string` of local image paths.
+
+Add image path fields to channel-specific inbound/job structs:
+
+- Slack:
+  - `slackInboundEvent.ImagePaths []string`
+  - `slackbus.InboundMessage.ImagePaths []string`
+  - `slackJob.ImagePaths []string`
+
+- Lark:
+  - `larkbus.InboundMessage.ImagePaths []string`
+  - `larkJob.ImagePaths []string`
+
+If a platform needs delayed download, add `ImagePending bool` only where it is actually needed. LINE needs it because webhook processing and image download are split by message content API timing. Do not copy `ImagePending` into Slack or Lark unless their event flow needs the same delay.
+
+For bus messages, reuse `MessageExtensions.ImagePaths`.
+
+History items can remain text-first. If needed, add a short textual marker to the rendered current message:
+
+```text
+[image attachments: 2]
+```
+
+Do not add base64 to `ChatHistoryItem`.
+
+## 6) Shared Image Builder
+
+Telegram and LINE currently duplicate local image conversion rules. Slack and Lark should not add two more copies.
+
+Add a small shared helper under a runtime-neutral internal package, for example:
+
+```go
+func BuildImageMessage(baseText string, model string, imagePaths []string, opts ImageMessageOptions) (llm.Message, error)
+```
+
+Suggested options:
+
+- max images: `3`
+- max bytes per image: `5 MiB`
+- supported MIME types: PNG, JPEG, WebP where provider/model supports it
+- optional WebP conversion hook only for Telegram if still needed
+
+Keep this helper about local files and `llm.Part` construction only. It should not download remote files and should not import Slack, Lark, Telegram, or LINE packages.
+
+If this extraction becomes too noisy, implement Slack/Lark with a minimal local helper first, then collapse duplication in a follow-up PR. Do not block image support on a broad refactor.
+
+## 7) Slack Plan
+
+### 7.1 Parse Image Metadata
+
+Extend Slack event parsing to capture image files from message events.
+
+Required fields should be the minimum needed to download and validate:
+
+- file id
+- MIME type or mimetype
+- private download URL
+- size when present
+- filename when present
+
+Ignore non-image files in V1.
+
+### 7.2 Download to Cache
+
+Add Slack API method for authenticated file download.
+
+Rules:
+
+- Use the bot token.
+- Save under `file_cache_dir/slack/`.
+- Enforce max image bytes before or during download.
+- Only accept image MIME types.
+- Use secure child directory creation, matching existing cache rules.
+
+### 7.3 Runtime Wiring
+
+Add `ImageRecognitionEnabled` to Slack run options and runtime task options.
+
+In `BuildSlackRunOptions`, compute it with:
+
+```go
+sourceEnabled(cfg.MultimodalImageSources, "slack")
+```
+
+In the worker path:
+
+- Parse Slack file metadata from the inbound event.
+- If enabled, download images before enqueueing/running the job.
+- Put local paths on `slackJob.ImagePaths`.
+- Pass image paths into `buildSlackPromptMessages(...)`.
+
+### 7.4 Prompt Message
+
+Change:
+
+```go
+buildSlackPromptMessages(history, job)
+```
+
+to include model and image flag, aligned with Telegram/LINE:
+
+```go
+buildSlackPromptMessages(history, job, model, imageRecognitionEnabled, logger)
+```
+
+Use image parts only for the current message, not old history.
+
+## 8) Lark Plan
+
+### 8.1 Accept Image Messages
+
+Extend webhook parsing beyond `message_type == "text"`.
+
+V1 should support:
+
+- text messages
+- image messages
+- image message with optional user text if Lark provides it in the event content
+
+If the message is image-only and image recognition is enabled, synthesize a small task text:
+
+```text
+User sent an image.
+```
+
+If image recognition is disabled, use a clear fallback text similar to LINE:
+
+```text
+User sent an image, but image recognition is disabled in the current Lark runtime. Reply briefly and ask the user to describe the image in text or enable lark in multimodal.image.sources.
+```
+
+### 8.2 Download to Cache
+
+Add the minimum Lark API method needed to download image binary content from the message content identifier.
+
+Rules:
+
+- Use the existing tenant token client.
+- Save under `file_cache_dir/lark/`.
+- Enforce max image bytes.
+- Only accept image MIME types.
+- Keep the API method local to Lark runtime; do not create a broad Lark SDK.
+
+### 8.3 Runtime Wiring
+
+Add `ImageRecognitionEnabled` to Lark run options and runtime task options.
+
+In `BuildLarkRunOptions`, compute it with:
+
+```go
+sourceEnabled(cfg.MultimodalImageSources, "lark")
+```
+
+Add `ImagePaths` to `larkbus.InboundMessage` and `larkJob`, then pass them to prompt message building.
+
+### 8.4 Prompt Message
+
+Change:
+
+```go
+buildLarkPromptMessages(history, job)
+```
+
+to:
+
+```go
+buildLarkPromptMessages(history, job, model, imageRecognitionEnabled, logger)
+```
+
+Use image parts only for the current message.
+
+## 9) Error Handling
+
+Use text fallback instead of hard failures for normal media issues:
+
+- unsupported MIME type
+- image too large
+- download failed
+- model does not support image parts
+
+Hard failure is acceptable for malformed runtime state:
+
+- missing Slack channel/message identifiers
+- missing Lark chat/message identifiers
+- invalid configured cache directory
+
+Log enough context to debug:
+
+- channel
+- message id
+- image count
+- skipped count
+- reason
+
+Do not log private download URLs or base64 image data.
+
+## 10) Tests
+
+### Slack
+
+- Parse Slack message events with image files.
+- Ignore non-image files.
+- `BuildSlackRunOptions` enables image recognition when `slack` is in `multimodal.image.sources`.
+- Download helper rejects non-image MIME and oversized images.
+- `buildSlackPromptMessages` adds `llm.PartTypeImageBase64` for supported image models.
+- Unsupported image models degrade to text-only.
+- Bus adapter preserves `ImagePaths`.
+
+### Lark
+
+- Parse Lark text event as before.
+- Parse Lark image event into inbound message.
+- Ignore unsupported message types.
+- `BuildLarkRunOptions` enables image recognition when `lark` is in `multimodal.image.sources`.
+- Download helper rejects non-image MIME and oversized images.
+- `buildLarkPromptMessages` adds image parts for supported image models.
+- Unsupported image models degrade to text-only.
+- Bus adapter preserves `ImagePaths`.
+
+### Shared
+
+- Shared image builder covers:
+  - max image count
+  - max bytes
+  - MIME detection
+  - base64 part generation
+  - empty image list
+
+## 11) Suggested PR Split
+
+1. Shared local image builder extraction.
+   No Slack/Lark behavior change.
+
+2. Slack image input.
+   Event parsing, download, config flag, prompt message parts, tests.
+
+3. Lark image input.
+   Webhook parsing, download, config flag, prompt message parts, tests.
+
+4. Docs/config cleanup.
+   Update user docs and `config.example.yaml` supported source list.
+
+If the shared helper extraction starts to pull too much code around, split it after Slack and Lark work instead. The feature is the image input path, not a new media framework.
+
+## 12) Acceptance Criteria
+
+- With `multimodal.image.sources` containing `slack`, a Slack user can send an image and ask a question about it; the selected image-capable model receives an image part.
+- With `multimodal.image.sources` containing `lark`, a Lark user can send an image and ask a question about it; the selected image-capable model receives an image part.
+- With the source disabled, the runtime replies with a short text fallback instead of silently ignoring the image.
+- Existing text-only Slack and Lark tests continue to pass.
+- Telegram and LINE image behavior remains unchanged.
+
+## 13) Implementation Tasks
+
+1. Add shared local image message building.
+   Extract only the file-to-`llm.Part` path after an image is already local. Keep platform download code outside this helper.
+
+2. Wire Slack image metadata through runtime structs.
+   Parse Slack file metadata, add image paths to inbound messages and jobs, and keep non-image files out of the image path.
+
+3. Add Slack authenticated image download.
+   Download only supported image MIME types into `file_cache_dir/slack/`, enforce size limits, and pass local paths into the current LLM message.
+
+4. Wire Lark image metadata through runtime structs.
+   Accept text and image message events, add image paths to inbound messages and jobs, and keep history text-only.
+
+5. Add Lark authenticated image download.
+   Download only supported image MIME types into `file_cache_dir/lark/`, enforce size limits, and pass local paths into the current LLM message.
+
+6. Update config support lists.
+   Add `lark` where the UI or config template lists supported image sources.
+
+7. Add focused tests.
+   Cover parsing, config flags, download validation, bus image path preservation, prompt image parts, disabled image fallback, and text-only model fallback.

--- a/docs/feat/feat_20260430_slack_lark_multimodal_images.md
+++ b/docs/feat/feat_20260430_slack_lark_multimodal_images.md
@@ -79,6 +79,12 @@ Runtime behavior:
 
 No new channel-specific config is needed in V1.
 
+Required platform permissions:
+
+- Slack: add bot scope `files:read` when `slack` is enabled in `multimodal.image.sources`; Slack file URLs such as `url_private` and `url_private_download` require a bearer token with that scope. Keep existing message scopes and Socket Mode `connections:write`.
+- Lark/Feishu: grant the message resource permission used by the `/im/v1/messages/:message_id/resources/:file_key` API. In current consoles this is usually found by searching for `im:resource` or the label for getting/uploading image or file resources. Keep message send/reply permissions and `im.message.receive_v1` event subscription.
+- After changing permissions, publish/reinstall the app so the runtime token receives the new grants.
+
 ## 5) Shared Data Model
 
 The smallest useful shape is still `[]string` of local image paths.
@@ -154,6 +160,7 @@ Rules:
 - Enforce max image bytes before or during download.
 - Only accept image MIME types.
 - Use secure child directory creation, matching existing cache rules.
+- Document that Slack image download needs bot scope `files:read`.
 
 ### 7.3 Runtime Wiring
 
@@ -223,6 +230,7 @@ Rules:
 - Enforce max image bytes.
 - Only accept image MIME types.
 - Keep the API method local to Lark runtime; do not create a broad Lark SDK.
+- Document that Lark image download needs the app permission for message resources, commonly surfaced as `im:resource`.
 
 ### 8.3 Runtime Wiring
 
@@ -351,7 +359,7 @@ If the shared helper extraction starts to pull too much code around, split it af
    Download only supported image MIME types into `file_cache_dir/lark/`, enforce size limits, and pass local paths into the current LLM message.
 
 6. Update config support lists.
-   Add `lark` where the UI or config template lists supported image sources.
+   Add `lark` where the UI or config template lists supported image sources, and document Slack/Lark platform permissions.
 
 7. Add focused tests.
    Cover parsing, config flags, download validation, bus image path preservation, prompt image parts, disabled image fallback, and text-only model fallback.

--- a/docs/lark.md
+++ b/docs/lark.md
@@ -1,11 +1,14 @@
-# Lark (Feishu) Support Plan
+# Lark (Feishu) Runtime
 
-This document defines the implemented `mistermorph lark` runtime shape for V1.
+This document defines the implemented `mistermorph lark` runtime shape.
 
 Status on 2026-03-06:
 - implemented for `private + group` text messaging
 - webhook ingress, token exchange, bus runtime, delivery adapter, contacts integration, and manual sender routing are in place
-- V1 intentionally excludes cards, files, images, reactions, and extra identity namespaces
+
+Status on 2026-04-30:
+- inbound image messages can be downloaded and sent to image-capable models when `lark` is enabled in `multimodal.image.sources`
+- V1 still excludes cards, generic file browsing, outbound rich media, reactions, and extra identity namespaces
 
 ## 1. Verified Platform Facts
 
@@ -15,6 +18,7 @@ Checked against official Feishu docs on 2026-03-06:
 - `tenant_access_token` is valid for 2 hours
 - bot apps can subscribe to the message receive event and get messages from both private and group chats
 - outbound delivery has both a general send API and a dedicated reply API
+- message resources, including images, are fetched through the message resource API with the app tenant token
 - the same API family is exposed under both:
   - `open.feishu.cn`
   - `open.larksuite.com`
@@ -36,7 +40,8 @@ Current confidence boundary on 2026-03-06:
 ## 2. Scope
 
 - Add `mistermorph lark` as a long-running webhook runtime.
-- Support `private + group` text conversations in V1.
+- Support `private + group` text conversations.
+- Support inbound image understanding for the current user message when `lark` is listed in `multimodal.image.sources`.
 - Reuse the existing channel pipeline:
   - inbound event -> bus -> per-conversation worker -> `run*Task` -> outbound bus -> delivery adapter
 - Reuse shared group-trigger logic: `strict | smart | talkative`.
@@ -45,7 +50,7 @@ Current confidence boundary on 2026-03-06:
 
 ## 3. Non-Goals (V1)
 
-- No cards, rich post bodies, files, or image multimodal input in the first pass.
+- No cards, rich post bodies, generic file browsing, video, audio, or outbound rich media.
 - No `message_react` parity in V1.
 - No app-store or multi-tenant install flow in V1.
 - No separate execution architecture just for Lark.
@@ -114,9 +119,9 @@ V1 simplifications:
 - Start with `msg_type=text` only.
 - Keep reply/send selection in the delivery adapter, not in agent logic.
 
-## 8. Proposed CLI and Config Surface
+## 8. CLI and Config Surface
 
-Planned command:
+Run command:
 
 ```bash
 go run ./cmd/mistermorph lark \
@@ -126,7 +131,7 @@ go run ./cmd/mistermorph lark \
   --lark-webhook-path /lark/webhook
 ```
 
-Planned config:
+Config:
 
 ```yaml
 lark:
@@ -144,6 +149,10 @@ lark:
   addressing_interject_threshold: 0.6
   task_timeout: "0s"
   max_concurrency: 3
+
+multimodal:
+  image:
+    sources: ["telegram", "line", "lark"]
 ```
 
 Field notes:
@@ -155,6 +164,8 @@ Field notes:
 - typical deployment shape:
   - Feishu app -> one `mistermorph lark` instance with Feishu `base_url`
   - Lark app -> another `mistermorph lark` instance with Lark `base_url`
+- when `lark` is listed in `multimodal.image.sources`, inbound image messages are downloaded under `file_cache_dir/lark/` and passed to image-capable models as image parts
+- the current runtime accepts PNG, JPEG, and WebP images, keeps at most 3 images per message, and rejects images larger than 5 MiB each
 
 Environment note:
 
@@ -169,9 +180,19 @@ The implementation should assume:
 - a self-built app with bot capability enabled
 - event subscription enabled for message receive events
 - message send and reply permissions granted
+- message resource download permissions granted when image input is enabled
 - the app has been added to the target group chats or users can reach it in private chat
 
-We should not hard-code permission names into runtime logic. Validate them through startup checks and actionable logs.
+Set this up in the Feishu/Lark developer console:
+
+- Enable bot capability.
+- Subscribe to event `im.message.receive_v1`.
+- Grant message send/reply permission. In current Feishu/Lark consoles this is usually `im:message` or the equivalent send-as-bot message permission.
+- Grant receive-message permissions for the conversations you expect to handle. For group messages, use the console permission corresponding to `im:message.group_msg:readonly`; for private messages, use the corresponding P2P message permission when your tenant requires it.
+- Grant message resource permission for images. Search for `im:resource` or the current console label for "get/upload image or file resources".
+- Publish a new app version after changing permissions, then reinstall or refresh the app in the tenant.
+
+If image download fails with a "lack of permissions" style error, check `im:resource`, group/P2P message read permission, app publication status, and whether the bot is in the chat.
 
 ## 10. Implementation Plan
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -69,6 +69,7 @@ Required `Bot Token Scopes`:
 - `im:history`
 - `mpim:history`
 - `chat:write`
+- `files:read` (required for image attachments when `slack` is enabled in `multimodal.image.sources`)
 - `users:read`
 
 Optional `Bot Token Scopes`:
@@ -79,6 +80,16 @@ Optional `Bot Token Scopes`:
 Required `App-Level Token` scope:
 
 - `connections:write` (on `xapp-...`)
+
+Event subscriptions for Socket Mode:
+
+- `app_mention`
+- `message.channels`
+- `message.groups`
+- `message.im`
+- `message.mpim`
+
+Image attachments arrive through normal message events. The runtime reads Slack file objects from those events and downloads `url_private_download` or `url_private` with the bot token. Slack requires the token used for those URLs to have `files:read`.
 
 After adding or changing any scope:
 
@@ -113,7 +124,13 @@ slack:
   addressing_interject_threshold: 0.6
   task_timeout: "0s"
   max_concurrency: 3
+
+multimodal:
+  image:
+    sources: ["telegram", "line", "slack"]
 ```
+
+When `slack` is listed in `multimodal.image.sources`, inbound Slack images are downloaded under `file_cache_dir/slack/` and passed to image-capable models as image parts. The current runtime accepts PNG, JPEG, and WebP images, keeps at most 3 images per message, and rejects images larger than 5 MiB each. If `slack` is not listed, image-only messages get a text fallback asking the user to describe the image.
 
 ## 7. Run Example
 
@@ -131,6 +148,8 @@ go run ./cmd/mistermorph slack \
   - `xoxb` is invalid/expired/mis-copied, or installed in the wrong workspace.
 - `slack users.info failed: missing_scope`
   - Bot token is missing `users:read`, or scope changed without reinstall/token refresh.
+- `slack image download http 403` or image-only messages cannot be read
+  - Bot token is missing `files:read`, the app was not reinstalled after adding it, or the bot is not in the conversation where the file was shared.
 - `slack_emoji_catalog_load_failed ... slack emoji.list failed: missing_scope`
   - Bot token is missing `emoji:read`; `message_react` will not be registered until emoji catalog can be loaded.
 - `slack apps.connections.open failed: not_allowed_token_type`

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -89,7 +89,7 @@ Event subscriptions for Socket Mode:
 - `message.im`
 - `message.mpim`
 
-Image attachments arrive through normal message events. The runtime reads Slack file objects from those events and downloads `url_private_download` or `url_private` with the bot token. Slack requires the token used for those URLs to have `files:read`.
+Image attachments arrive through normal message events. The runtime reads Slack file objects from those events and downloads `url_private_download` or `url_private` with the bot token. For Slack Connect placeholder files, it calls `files.info` first to load the real file metadata. Slack requires the token used for these file APIs and URLs to have `files:read`.
 
 After adding or changing any scope:
 

--- a/internal/bus/adapters/lark/inbound.go
+++ b/internal/bus/adapters/lark/inbound.go
@@ -29,6 +29,7 @@ type InboundMessage struct {
 	Text         string
 	MentionUsers []string
 	EventID      string
+	ImagePaths   []string
 }
 
 type InboundAdapter struct {
@@ -84,6 +85,10 @@ func (a *InboundAdapter) HandleInboundMessage(ctx context.Context, msg InboundMe
 	if err != nil {
 		return false, err
 	}
+	imagePaths, err := normalizeImagePaths(msg.ImagePaths)
+	if err != nil {
+		return false, err
+	}
 
 	now := a.nowFn().UTC()
 	sentAt := msg.SentAt.UTC()
@@ -135,6 +140,7 @@ func (a *InboundAdapter) HandleInboundMessage(ctx context.Context, msg InboundMe
 			FromUserRef:       fromUserID,
 			EventID:           strings.TrimSpace(msg.EventID),
 			MentionUsers:      mentionUsers,
+			ImagePaths:        imagePaths,
 		},
 	}
 	return a.flow.PublishValidatedInbound(ctx, platformMessageID, busMsg)
@@ -181,6 +187,10 @@ func InboundMessageFromBusMessage(msg busruntime.BusMessage) (InboundMessage, er
 	if err != nil {
 		return InboundMessage{}, err
 	}
+	imagePaths, err := normalizeImagePaths(msg.Extensions.ImagePaths)
+	if err != nil {
+		return InboundMessage{}, err
+	}
 
 	return InboundMessage{
 		ChatID:       chatID,
@@ -192,6 +202,7 @@ func InboundMessageFromBusMessage(msg busruntime.BusMessage) (InboundMessage, er
 		Text:         strings.TrimSpace(env.Text),
 		MentionUsers: mentionUsers,
 		EventID:      strings.TrimSpace(msg.Extensions.EventID),
+		ImagePaths:   imagePaths,
 	}, nil
 }
 
@@ -250,6 +261,26 @@ func chatIDFromConversationKey(conversationKey string) (string, error) {
 		return "", fmt.Errorf("lark chat id is required")
 	}
 	return chatID, nil
+}
+
+func normalizeImagePaths(paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+	for _, raw := range paths {
+		path := strings.TrimSpace(raw)
+		if path == "" {
+			return nil, fmt.Errorf("image path is required")
+		}
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		out = append(out, path)
+	}
+	return out, nil
 }
 
 func normalizeLarkChatType(raw string) (string, error) {

--- a/internal/bus/adapters/lark/inbound.go
+++ b/internal/bus/adapters/lark/inbound.go
@@ -30,6 +30,7 @@ type InboundMessage struct {
 	MentionUsers []string
 	EventID      string
 	ImagePaths   []string
+	ImageKeys    []string
 }
 
 type InboundAdapter struct {
@@ -89,6 +90,10 @@ func (a *InboundAdapter) HandleInboundMessage(ctx context.Context, msg InboundMe
 	if err != nil {
 		return false, err
 	}
+	imageKeys, err := normalizeImageKeys(msg.ImageKeys)
+	if err != nil {
+		return false, err
+	}
 
 	now := a.nowFn().UTC()
 	sentAt := msg.SentAt.UTC()
@@ -141,6 +146,7 @@ func (a *InboundAdapter) HandleInboundMessage(ctx context.Context, msg InboundMe
 			EventID:           strings.TrimSpace(msg.EventID),
 			MentionUsers:      mentionUsers,
 			ImagePaths:        imagePaths,
+			ImageKeys:         imageKeys,
 		},
 	}
 	return a.flow.PublishValidatedInbound(ctx, platformMessageID, busMsg)
@@ -191,6 +197,10 @@ func InboundMessageFromBusMessage(msg busruntime.BusMessage) (InboundMessage, er
 	if err != nil {
 		return InboundMessage{}, err
 	}
+	imageKeys, err := normalizeImageKeys(msg.Extensions.ImageKeys)
+	if err != nil {
+		return InboundMessage{}, err
+	}
 
 	return InboundMessage{
 		ChatID:       chatID,
@@ -203,6 +213,7 @@ func InboundMessageFromBusMessage(msg busruntime.BusMessage) (InboundMessage, er
 		MentionUsers: mentionUsers,
 		EventID:      strings.TrimSpace(msg.Extensions.EventID),
 		ImagePaths:   imagePaths,
+		ImageKeys:    imageKeys,
 	}, nil
 }
 
@@ -279,6 +290,26 @@ func normalizeImagePaths(paths []string) ([]string, error) {
 		}
 		seen[path] = true
 		out = append(out, path)
+	}
+	return out, nil
+}
+
+func normalizeImageKeys(keys []string) ([]string, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(keys))
+	seen := make(map[string]bool, len(keys))
+	for _, raw := range keys {
+		key := strings.TrimSpace(raw)
+		if key == "" {
+			return nil, fmt.Errorf("image key is required")
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
 	}
 	return out, nil
 }

--- a/internal/bus/adapters/lark/inbound_test.go
+++ b/internal/bus/adapters/lark/inbound_test.go
@@ -50,6 +50,7 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		Text:         "hello lark",
 		MentionUsers: []string{"ou_123", "ou_456"},
 		EventID:      "ev_001",
+		ImagePaths:   []string{"/tmp/a.png", "/tmp/a.png", "/tmp/b.jpg"},
 		SentAt:       time.Date(2026, 3, 6, 1, 2, 3, 0, time.UTC),
 	})
 	if err != nil {
@@ -75,6 +76,9 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		}
 		if msg.Extensions.PlatformMessageID != "oc_group123:om_1001" {
 			t.Fatalf("platform_message_id mismatch: got %q", msg.Extensions.PlatformMessageID)
+		}
+		if len(msg.Extensions.ImagePaths) != 2 {
+			t.Fatalf("image_paths len = %d, want 2", len(msg.Extensions.ImagePaths))
 		}
 		env, envErr := msg.Envelope()
 		if envErr != nil {
@@ -134,6 +138,7 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 			ChannelID:         "oc_group123",
 			EventID:           "ev_001",
 			MentionUsers:      []string{"ou_123", "ou_456"},
+			ImagePaths:        []string{"/tmp/a.png", "/tmp/b.jpg"},
 		},
 	}
 
@@ -155,5 +160,8 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 	}
 	if inbound.Text != "hello lark" {
 		t.Fatalf("text mismatch: got %q want %q", inbound.Text, "hello lark")
+	}
+	if len(inbound.ImagePaths) != 2 {
+		t.Fatalf("image_paths len = %d, want 2", len(inbound.ImagePaths))
 	}
 }

--- a/internal/bus/adapters/lark/inbound_test.go
+++ b/internal/bus/adapters/lark/inbound_test.go
@@ -51,6 +51,7 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		MentionUsers: []string{"ou_123", "ou_456"},
 		EventID:      "ev_001",
 		ImagePaths:   []string{"/tmp/a.png", "/tmp/a.png", "/tmp/b.jpg"},
+		ImageKeys:    []string{"img_123", "img_123", "img_456"},
 		SentAt:       time.Date(2026, 3, 6, 1, 2, 3, 0, time.UTC),
 	})
 	if err != nil {
@@ -79,6 +80,9 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		}
 		if len(msg.Extensions.ImagePaths) != 2 {
 			t.Fatalf("image_paths len = %d, want 2", len(msg.Extensions.ImagePaths))
+		}
+		if len(msg.Extensions.ImageKeys) != 2 {
+			t.Fatalf("image_keys len = %d, want 2", len(msg.Extensions.ImageKeys))
 		}
 		env, envErr := msg.Envelope()
 		if envErr != nil {
@@ -139,6 +143,7 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 			EventID:           "ev_001",
 			MentionUsers:      []string{"ou_123", "ou_456"},
 			ImagePaths:        []string{"/tmp/a.png", "/tmp/b.jpg"},
+			ImageKeys:         []string{"img_123", "img_456"},
 		},
 	}
 
@@ -163,5 +168,8 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 	}
 	if len(inbound.ImagePaths) != 2 {
 		t.Fatalf("image_paths len = %d, want 2", len(inbound.ImagePaths))
+	}
+	if len(inbound.ImageKeys) != 2 {
+		t.Fatalf("image_keys len = %d, want 2", len(inbound.ImageKeys))
 	}
 }

--- a/internal/bus/adapters/slack/inbound.go
+++ b/internal/bus/adapters/slack/inbound.go
@@ -31,6 +31,7 @@ type InboundMessage struct {
 	SentAt       time.Time
 	MentionUsers []string
 	EventID      string
+	ImagePaths   []string
 }
 
 type InboundAdapter struct {
@@ -94,6 +95,10 @@ func (a *InboundAdapter) HandleInboundMessage(ctx context.Context, msg InboundMe
 	if err != nil {
 		return false, err
 	}
+	imagePaths, err := normalizeImagePaths(msg.ImagePaths)
+	if err != nil {
+		return false, err
+	}
 	now := a.nowFn().UTC()
 	sentAt := msg.SentAt.UTC()
 	if sentAt.IsZero() {
@@ -148,6 +153,7 @@ func (a *InboundAdapter) HandleInboundMessage(ctx context.Context, msg InboundMe
 			ThreadTS:          threadTS,
 			EventID:           strings.TrimSpace(msg.EventID),
 			MentionUsers:      mentionUsers,
+			ImagePaths:        imagePaths,
 		},
 	}
 	return a.flow.PublishValidatedInbound(ctx, platformMessageID, busMsg)
@@ -187,6 +193,10 @@ func InboundMessageFromBusMessage(msg busruntime.BusMessage) (InboundMessage, er
 	if err != nil {
 		return InboundMessage{}, err
 	}
+	imagePaths, err := normalizeImagePaths(msg.Extensions.ImagePaths)
+	if err != nil {
+		return InboundMessage{}, err
+	}
 	threadTS := strings.TrimSpace(msg.Extensions.ThreadTS)
 	if threadTS == "" {
 		threadTS = strings.TrimSpace(msg.Extensions.ReplyTo)
@@ -215,6 +225,7 @@ func InboundMessageFromBusMessage(msg busruntime.BusMessage) (InboundMessage, er
 		SentAt:       sentAt.UTC(),
 		MentionUsers: mentionUsers,
 		EventID:      strings.TrimSpace(msg.Extensions.EventID),
+		ImagePaths:   imagePaths,
 	}, nil
 }
 
@@ -229,6 +240,26 @@ func normalizeMentionUsers(items []string) ([]string, error) {
 			return nil, fmt.Errorf("mention user is required")
 		}
 		out = append(out, item)
+	}
+	return out, nil
+}
+
+func normalizeImagePaths(paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+	for _, raw := range paths {
+		path := strings.TrimSpace(raw)
+		if path == "" {
+			return nil, fmt.Errorf("image path is required")
+		}
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		out = append(out, path)
 	}
 	return out, nil
 }

--- a/internal/bus/adapters/slack/inbound_test.go
+++ b/internal/bus/adapters/slack/inbound_test.go
@@ -53,6 +53,7 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		Text:         "hello from slack",
 		MentionUsers: []string{"@alice", "@bob"},
 		EventID:      "Ev01",
+		ImagePaths:   []string{"/tmp/a.png", "/tmp/a.png", "/tmp/b.jpg"},
 	})
 	if err != nil {
 		t.Fatalf("HandleInboundMessage() error = %v", err)
@@ -86,6 +87,9 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		}
 		if msg.Extensions.EventID != "Ev01" {
 			t.Fatalf("event_id mismatch: got %q want %q", msg.Extensions.EventID, "Ev01")
+		}
+		if len(msg.Extensions.ImagePaths) != 2 {
+			t.Fatalf("image_paths len = %d, want 2", len(msg.Extensions.ImagePaths))
 		}
 		env, envErr := msg.Envelope()
 		if envErr != nil {
@@ -155,6 +159,7 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 			ThreadTS:          "1739667000.000050",
 			EventID:           "Ev01",
 			MentionUsers:      []string{"@alice", "@bob"},
+			ImagePaths:        []string{"/tmp/a.png", "/tmp/b.jpg"},
 		},
 	}
 	inbound, err := InboundMessageFromBusMessage(msg)
@@ -178,5 +183,8 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 	}
 	if inbound.Text != "hello from slack" {
 		t.Fatalf("text mismatch: got %q want %q", inbound.Text, "hello from slack")
+	}
+	if len(inbound.ImagePaths) != 2 {
+		t.Fatalf("image_paths len = %d, want 2", len(inbound.ImagePaths))
 	}
 }

--- a/internal/bus/message.go
+++ b/internal/bus/message.go
@@ -42,6 +42,7 @@ type MessageExtensions struct {
 	EventID           string   `json:"event_id,omitempty"`
 	MentionUsers      []string `json:"mention_users,omitempty"`
 	ImagePaths        []string `json:"image_paths,omitempty"`
+	ImageKeys         []string `json:"image_keys,omitempty"`
 	ImagePending      bool     `json:"image_pending,omitempty"`
 }
 
@@ -185,6 +186,11 @@ func (m BusMessage) Validate() error {
 	}
 	for i, path := range m.Extensions.ImagePaths {
 		if err := validateRequiredCanonicalString(fmt.Sprintf("extensions.image_paths[%d]", i), path); err != nil {
+			return err
+		}
+	}
+	for i, key := range m.Extensions.ImageKeys {
+		if err := validateRequiredCanonicalString(fmt.Sprintf("extensions.image_keys[%d]", i), key); err != nil {
 			return err
 		}
 	}

--- a/internal/bus/message_test.go
+++ b/internal/bus/message_test.go
@@ -216,6 +216,23 @@ func TestMessageValidate_RejectsInvalidImagePathExtension(t *testing.T) {
 	}
 }
 
+func TestMessageValidate_AllowsImageKeysExtension(t *testing.T) {
+	msg := validMessage(t)
+	msg.Extensions.ImageKeys = []string{"img_123", "img_456"}
+	if err := msg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestMessageValidate_RejectsInvalidImageKeyExtension(t *testing.T) {
+	msg := validMessage(t)
+	msg.Extensions.ImageKeys = []string{" img_123"}
+	err := msg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "extensions.image_keys[0]") {
+		t.Fatalf("Validate() error = %v, want extensions.image_keys[0] error", err)
+	}
+}
+
 func validMessage(t *testing.T) BusMessage {
 	t.Helper()
 	payload, err := EncodeMessageEnvelope(TopicChatMessage, MessageEnvelope{

--- a/internal/channelopts/options.go
+++ b/internal/channelopts/options.go
@@ -265,6 +265,7 @@ type SlackConfig struct {
 	MemoryShortTermDays                  int
 	MemoryInjectionEnabled               bool
 	MemoryInjectionMaxItems              int
+	MultimodalImageSources               []string
 }
 
 type SlackInput struct {
@@ -317,6 +318,7 @@ func SlackConfigFromReader(r ConfigReader) SlackConfig {
 		MemoryShortTermDays:     r.GetInt("memory.short_term_days"),
 		MemoryInjectionEnabled:  r.GetBool("memory.injection.enabled"),
 		MemoryInjectionMaxItems: r.GetInt("memory.injection.max_items"),
+		MultimodalImageSources:  append([]string(nil), r.GetStringSlice("multimodal.image.sources")...),
 	}
 }
 
@@ -359,6 +361,7 @@ func BuildSlackRunOptions(cfg SlackConfig, in SlackInput) slackruntime.RunOption
 	}
 	fileCacheDir := strings.TrimSpace(cfg.FileCacheDir)
 	serverListen := normalizeServerListen(cfg.ServerListen)
+	imageRecognitionEnabled := sourceEnabled(cfg.MultimodalImageSources, "slack")
 	baseURL := strings.TrimSpace(in.BaseURL)
 	if baseURL == "" {
 		baseURL = strings.TrimSpace(cfg.BaseURL)
@@ -389,6 +392,7 @@ func BuildSlackRunOptions(cfg SlackConfig, in SlackInput) slackruntime.RunOption
 		MemoryShortTermDays:     cfg.MemoryShortTermDays,
 		MemoryInjectionEnabled:  cfg.MemoryInjectionEnabled,
 		MemoryInjectionMaxItems: cfg.MemoryInjectionMaxItems,
+		ImageRecognitionEnabled: imageRecognitionEnabled,
 		Hooks:                   in.Hooks,
 		InspectPrompt:           in.InspectPrompt,
 		InspectRequest:          in.InspectRequest,
@@ -446,6 +450,7 @@ type LarkConfig struct {
 	TaskTimeout                          time.Duration
 	GlobalTaskTimeout                    time.Duration
 	MaxConcurrency                       int
+	FileCacheDir                         string
 	ServerListen                         string
 	ServerAuthToken                      string
 	ServerMaxQueue                       int
@@ -462,6 +467,7 @@ type LarkConfig struct {
 	MemoryShortTermDays                  int
 	MemoryInjectionEnabled               bool
 	MemoryInjectionMaxItems              int
+	MultimodalImageSources               []string
 }
 
 type LarkInput struct {
@@ -538,6 +544,7 @@ func LarkConfigFromReader(r ConfigReader) LarkConfig {
 		TaskTimeout:                          r.GetDuration("lark.task_timeout"),
 		GlobalTaskTimeout:                    r.GetDuration("timeout"),
 		MaxConcurrency:                       r.GetInt("lark.max_concurrency"),
+		FileCacheDir:                         strings.TrimSpace(r.GetString("file_cache_dir")),
 		ServerListen:                         resolveServeListen(r, "lark.serve_listen", defaultLarkServeListen),
 		ServerAuthToken:                      strings.TrimSpace(r.GetString("server.auth_token")),
 		ServerMaxQueue:                       r.GetInt("server.max_queue"),
@@ -562,6 +569,7 @@ func LarkConfigFromReader(r ConfigReader) LarkConfig {
 		MemoryShortTermDays:     r.GetInt("memory.short_term_days"),
 		MemoryInjectionEnabled:  r.GetBool("memory.injection.enabled"),
 		MemoryInjectionMaxItems: r.GetInt("memory.injection.max_items"),
+		MultimodalImageSources:  append([]string(nil), r.GetStringSlice("multimodal.image.sources")...),
 	}
 }
 
@@ -674,6 +682,7 @@ func BuildLarkRunOptions(cfg LarkConfig, in LarkInput) larkruntime.RunOptions {
 	if maxConcurrency <= 0 {
 		maxConcurrency = cfg.MaxConcurrency
 	}
+	fileCacheDir := strings.TrimSpace(cfg.FileCacheDir)
 	serverListen := normalizeServerListen(cfg.ServerListen)
 	baseURL := strings.TrimSpace(in.BaseURL)
 	if baseURL == "" {
@@ -695,6 +704,7 @@ func BuildLarkRunOptions(cfg LarkConfig, in LarkInput) larkruntime.RunOptions {
 	if encryptKey == "" {
 		encryptKey = strings.TrimSpace(cfg.EncryptKey)
 	}
+	imageRecognitionEnabled := sourceEnabled(cfg.MultimodalImageSources, "lark")
 
 	return larkruntime.RunOptions{
 		AppID:                         strings.TrimSpace(in.AppID),
@@ -705,6 +715,7 @@ func BuildLarkRunOptions(cfg LarkConfig, in LarkInput) larkruntime.RunOptions {
 		AddressingInterjectThreshold:  addressingInterjectThreshold,
 		TaskTimeout:                   taskTimeout,
 		MaxConcurrency:                maxConcurrency,
+		FileCacheDir:                  fileCacheDir,
 		ServerListen:                  serverListen,
 		ServerAuthToken:               cfg.ServerAuthToken,
 		ServerMaxQueue:                cfg.ServerMaxQueue,
@@ -721,6 +732,7 @@ func BuildLarkRunOptions(cfg LarkConfig, in LarkInput) larkruntime.RunOptions {
 		MemoryShortTermDays:           cfg.MemoryShortTermDays,
 		MemoryInjectionEnabled:        cfg.MemoryInjectionEnabled,
 		MemoryInjectionMaxItems:       cfg.MemoryInjectionMaxItems,
+		ImageRecognitionEnabled:       imageRecognitionEnabled,
 		Hooks:                         in.Hooks,
 		InspectPrompt:                 in.InspectPrompt,
 		InspectRequest:                in.InspectRequest,

--- a/internal/channelopts/options_test.go
+++ b/internal/channelopts/options_test.go
@@ -146,6 +146,7 @@ func TestBuildSlackRunOptionsTaskTimeoutFallback(t *testing.T) {
 			MemoryShortTermDays:                  9,
 			MemoryInjectionEnabled:               true,
 			MemoryInjectionMaxItems:              33,
+			MultimodalImageSources:               []string{"slack"},
 		},
 		SlackInput{
 			BotToken:    "xoxb-1",
@@ -167,6 +168,9 @@ func TestBuildSlackRunOptionsTaskTimeoutFallback(t *testing.T) {
 	}
 	if !opts.MemoryEnabled || opts.MemoryShortTermDays != 9 || !opts.MemoryInjectionEnabled || opts.MemoryInjectionMaxItems != 33 {
 		t.Fatalf("memory options mismatch: %#v", opts)
+	}
+	if !opts.ImageRecognitionEnabled {
+		t.Fatalf("ImageRecognitionEnabled = false, want true when slack is in sources")
 	}
 }
 
@@ -304,10 +308,12 @@ func TestBuildLarkRunOptionsTaskTimeoutFallback(t *testing.T) {
 			TaskTimeout:                          0,
 			GlobalTaskTimeout:                    5 * time.Minute,
 			MaxConcurrency:                       3,
+			FileCacheDir:                         "/tmp/morph-cache",
 			DefaultGroupTriggerMode:              "smart",
 			DefaultAddressingConfidenceThreshold: 0.6,
 			DefaultAddressingInterjectThreshold:  0.6,
 			AgentLimits:                          agent.Limits{ToolRepeatLimit: 13},
+			MultimodalImageSources:               []string{"lark"},
 		},
 		LarkInput{
 			AppID:       "cli_xxx",
@@ -323,6 +329,12 @@ func TestBuildLarkRunOptionsTaskTimeoutFallback(t *testing.T) {
 	}
 	if opts.AgentLimits.ToolRepeatLimit != 13 {
 		t.Fatalf("agent tool repeat limit = %d, want 13", opts.AgentLimits.ToolRepeatLimit)
+	}
+	if opts.FileCacheDir != "/tmp/morph-cache" {
+		t.Fatalf("file cache dir = %q, want %q", opts.FileCacheDir, "/tmp/morph-cache")
+	}
+	if !opts.ImageRecognitionEnabled {
+		t.Fatalf("ImageRecognitionEnabled = false, want true when lark is in sources")
 	}
 }
 

--- a/internal/channelruntime/imageinput/message.go
+++ b/internal/channelruntime/imageinput/message.go
@@ -1,0 +1,162 @@
+package imageinput
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/quailyquaily/mistermorph/llm"
+)
+
+type TranscodeFunc func(raw []byte, mimeType string) ([]byte, string, error)
+
+type MessageOptions struct {
+	MaxImages int
+	MaxBytes  int64
+	Logger    *slog.Logger
+	LogPrefix string
+	Transcode TranscodeFunc
+}
+
+func BuildUserMessage(content string, model string, imagePaths []string, opts MessageOptions) (llm.Message, error) {
+	msg := llm.Message{Role: "user", Content: content}
+	if !llm.ModelSupportsImageParts(model) || len(imagePaths) == 0 || opts.MaxImages <= 0 || opts.MaxBytes <= 0 {
+		return msg, nil
+	}
+
+	parts := make([]llm.Part, 0, 1+minInt(len(imagePaths), opts.MaxImages))
+	if strings.TrimSpace(content) != "" {
+		parts = append(parts, llm.Part{Type: llm.PartTypeText, Text: content})
+	}
+
+	seen := make(map[string]bool, len(imagePaths))
+	imageCount := 0
+	for _, rawPath := range imagePaths {
+		if imageCount >= opts.MaxImages {
+			break
+		}
+		path := strings.TrimSpace(rawPath)
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+
+		info, err := os.Stat(path)
+		if err != nil {
+			logWarn(opts, "image_part_skip", "path", path, "error", err.Error())
+			continue
+		}
+		if info.Size() <= 0 {
+			continue
+		}
+		if info.Size() > opts.MaxBytes {
+			return llm.Message{}, fmt.Errorf("图片太大: %s (%d bytes > %d bytes)", filepath.Base(path), info.Size(), opts.MaxBytes)
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			logWarn(opts, "image_part_read_error", "path", path, "error", err.Error())
+			continue
+		}
+		mimeType := MIMETypeFromPath(path)
+		if !SupportedUploadMIME(mimeType) {
+			logWarn(opts, "image_part_skip_unsupported_format", "path", path, "mime_type", mimeType)
+			continue
+		}
+		if opts.Transcode != nil {
+			transcodedRaw, transcodedMIME, transcodeErr := opts.Transcode(raw, mimeType)
+			if transcodeErr != nil {
+				return llm.Message{}, fmt.Errorf("图片转换失败: %s: %w", filepath.Base(path), transcodeErr)
+			}
+			raw = transcodedRaw
+			mimeType = strings.TrimSpace(strings.ToLower(transcodedMIME))
+			if !SupportedUploadMIME(mimeType) {
+				return llm.Message{}, fmt.Errorf("图片转换后格式不支持: %s (%s)", filepath.Base(path), mimeType)
+			}
+		}
+
+		parts = append(parts, llm.Part{
+			Type:       llm.PartTypeImageBase64,
+			MIMEType:   mimeType,
+			DataBase64: base64.StdEncoding.EncodeToString(raw),
+		})
+		imageCount++
+	}
+	if imageCount == 0 {
+		return msg, nil
+	}
+	msg.Parts = parts
+	return msg, nil
+}
+
+func MIMETypeFromPath(path string) string {
+	switch strings.ToLower(strings.TrimSpace(filepath.Ext(path))) {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	case ".gif":
+		return "image/gif"
+	case ".bmp":
+		return "image/bmp"
+	case ".heic":
+		return "image/heic"
+	case ".heif":
+		return "image/heif"
+	default:
+		return ""
+	}
+}
+
+func NormalizeMIMEType(mimeType string) string {
+	mimeType = strings.TrimSpace(strings.ToLower(mimeType))
+	if idx := strings.Index(mimeType, ";"); idx >= 0 {
+		mimeType = strings.TrimSpace(mimeType[:idx])
+	}
+	return mimeType
+}
+
+func SupportedUploadMIME(mimeType string) bool {
+	switch NormalizeMIMEType(mimeType) {
+	case "image/jpeg", "image/png", "image/webp":
+		return true
+	default:
+		return false
+	}
+}
+
+func ExtensionForMIMEType(mimeType string) string {
+	switch NormalizeMIMEType(mimeType) {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/webp":
+		return ".webp"
+	default:
+		return ""
+	}
+}
+
+func logWarn(opts MessageOptions, suffix string, args ...any) {
+	if opts.Logger == nil {
+		return
+	}
+	prefix := strings.TrimSpace(opts.LogPrefix)
+	if prefix == "" {
+		prefix = "image"
+	}
+	opts.Logger.Warn(prefix+"_"+suffix, args...)
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/channelruntime/imageinput/message_test.go
+++ b/internal/channelruntime/imageinput/message_test.go
@@ -1,0 +1,101 @@
+package imageinput
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/quailyquaily/mistermorph/llm"
+)
+
+func TestBuildUserMessageWithImageParts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "image.png")
+	raw := []byte("png-data")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	msg, err := BuildUserMessage("hello", "gpt-5.2", []string{path}, MessageOptions{
+		MaxImages: 3,
+		MaxBytes:  1024,
+	})
+	if err != nil {
+		t.Fatalf("BuildUserMessage() error = %v", err)
+	}
+	if len(msg.Parts) != 2 {
+		t.Fatalf("parts len = %d, want 2", len(msg.Parts))
+	}
+	if msg.Parts[0].Type != llm.PartTypeText || msg.Parts[0].Text != "hello" {
+		t.Fatalf("text part mismatch: %+v", msg.Parts[0])
+	}
+	if msg.Parts[1].Type != llm.PartTypeImageBase64 {
+		t.Fatalf("image part type = %q, want %q", msg.Parts[1].Type, llm.PartTypeImageBase64)
+	}
+	if msg.Parts[1].MIMEType != "image/png" {
+		t.Fatalf("image MIME = %q, want image/png", msg.Parts[1].MIMEType)
+	}
+	if msg.Parts[1].DataBase64 != base64.StdEncoding.EncodeToString(raw) {
+		t.Fatalf("image data mismatch")
+	}
+}
+
+func TestBuildUserMessageSkipsUnknownTypes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "image.bin")
+	if err := os.WriteFile(path, []byte("not-image"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	msg, err := BuildUserMessage("hello", "gpt-5.2", []string{path}, MessageOptions{
+		MaxImages: 3,
+		MaxBytes:  1024,
+	})
+	if err != nil {
+		t.Fatalf("BuildUserMessage() error = %v", err)
+	}
+	if len(msg.Parts) != 0 {
+		t.Fatalf("parts len = %d, want 0", len(msg.Parts))
+	}
+	if msg.Content != "hello" {
+		t.Fatalf("content = %q, want hello", msg.Content)
+	}
+}
+
+func TestBuildUserMessageTranscode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "image.jpg")
+	if err := os.WriteFile(path, []byte("jpg-data"), 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	msg, err := BuildUserMessage("hello", "gpt-5.2", []string{path}, MessageOptions{
+		MaxImages: 3,
+		MaxBytes:  1024,
+		Transcode: func(raw []byte, mimeType string) ([]byte, string, error) {
+			if mimeType != "image/jpeg" {
+				t.Fatalf("transcode MIME = %q, want image/jpeg", mimeType)
+			}
+			return []byte("webp-data"), "image/webp", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildUserMessage() error = %v", err)
+	}
+	if len(msg.Parts) != 2 {
+		t.Fatalf("parts len = %d, want 2", len(msg.Parts))
+	}
+	if msg.Parts[1].MIMEType != "image/webp" {
+		t.Fatalf("image MIME = %q, want image/webp", msg.Parts[1].MIMEType)
+	}
+	if msg.Parts[1].DataBase64 != base64.StdEncoding.EncodeToString([]byte("webp-data")) {
+		t.Fatalf("image data mismatch")
+	}
+}

--- a/internal/channelruntime/lark/images.go
+++ b/internal/channelruntime/lark/images.go
@@ -3,12 +3,14 @@ package lark
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	larkbus "github.com/quailyquaily/mistermorph/internal/bus/adapters/lark"
 	"github.com/quailyquaily/mistermorph/internal/channelruntime/imageinput"
 	"github.com/quailyquaily/mistermorph/internal/telegramutil"
 )
@@ -81,6 +83,36 @@ func downloadLarkImageToCache(ctx context.Context, api *larkAPI, cacheDir string
 		return "", err
 	}
 	return tmpPath, nil
+}
+
+func downloadLarkInboundImages(ctx context.Context, api *larkAPI, cacheDir string, inbound larkbus.InboundMessage, logger *slog.Logger) larkbus.InboundMessage {
+	if len(inbound.ImageKeys) == 0 {
+		return inbound
+	}
+	for _, imageKey := range inbound.ImageKeys {
+		if len(inbound.ImagePaths) >= larkLLMMaxImages {
+			break
+		}
+		imageCtx, cancelImage := larkImageDownloadContext(ctx)
+		path, imageErr := downloadLarkImageToCache(imageCtx, api, cacheDir, inbound.MessageID, imageKey, larkLLMMaxImageBytes)
+		cancelImage()
+		if imageErr != nil {
+			if logger != nil {
+				logger.Warn("lark_image_download_failed",
+					"chat_id", strings.TrimSpace(inbound.ChatID),
+					"message_id", strings.TrimSpace(inbound.MessageID),
+					"image_key", strings.TrimSpace(imageKey),
+					"error", imageErr.Error(),
+				)
+			}
+			continue
+		}
+		inbound.ImagePaths = append(inbound.ImagePaths, path)
+	}
+	if len(inbound.ImagePaths) == 0 {
+		inbound.Text = appendLarkImageReadFailure(inbound.Text)
+	}
+	return inbound
 }
 
 func larkImageCacheDir(fileCacheDir string) string {

--- a/internal/channelruntime/lark/images.go
+++ b/internal/channelruntime/lark/images.go
@@ -1,0 +1,149 @@
+package lark
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/quailyquaily/mistermorph/internal/channelruntime/imageinput"
+	"github.com/quailyquaily/mistermorph/internal/telegramutil"
+)
+
+const (
+	larkLLMMaxImages     = 3
+	larkLLMMaxImageBytes = int64(5 * 1024 * 1024)
+)
+
+const larkImageRecognitionDisabledPrompt = "User sent an image, but image recognition is disabled in the current Lark runtime. Reply briefly and ask the user to describe the image in text or enable lark in multimodal.image.sources."
+
+func downloadLarkImageToCache(ctx context.Context, api *larkAPI, cacheDir string, messageID string, imageKey string, maxBytes int64) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if api == nil {
+		return "", fmt.Errorf("lark api is not initialized")
+	}
+	cacheDir = strings.TrimSpace(cacheDir)
+	if cacheDir == "" {
+		return "", fmt.Errorf("lark image cache dir is required")
+	}
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return "", fmt.Errorf("lark message id is required")
+	}
+	imageKey = strings.TrimSpace(imageKey)
+	if imageKey == "" {
+		return "", fmt.Errorf("lark image key is required")
+	}
+	if maxBytes <= 0 {
+		return "", fmt.Errorf("lark image max bytes must be positive")
+	}
+	if err := telegramutil.EnsureSecureCacheDir(cacheDir); err != nil {
+		return "", err
+	}
+
+	raw, mimeType, err := api.messageResource(ctx, messageID, imageKey, "image", maxBytes)
+	if err != nil {
+		return "", err
+	}
+	mimeType = imageinput.NormalizeMIMEType(mimeType)
+	if !imageinput.SupportedUploadMIME(mimeType) {
+		detected := imageinput.NormalizeMIMEType(http.DetectContentType(raw))
+		if imageinput.SupportedUploadMIME(detected) {
+			mimeType = detected
+		}
+	}
+	if !imageinput.SupportedUploadMIME(mimeType) {
+		return "", fmt.Errorf("lark image format is not supported: %s", mimeType)
+	}
+	ext := imageinput.ExtensionForMIMEType(mimeType)
+	if ext == "" {
+		return "", fmt.Errorf("lark image extension is not supported: %s", mimeType)
+	}
+
+	pattern := "lark_" + sanitizeLarkFileToken(imageKey) + "_*" + ext
+	tmp, err := os.CreateTemp(cacheDir, pattern)
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	return tmpPath, nil
+}
+
+func larkImageCacheDir(fileCacheDir string) string {
+	fileCacheDir = strings.TrimSpace(fileCacheDir)
+	if fileCacheDir == "" {
+		return ""
+	}
+	return filepath.Join(fileCacheDir, "lark")
+}
+
+func larkImageFallbackText(text string, imageRecognitionEnabled bool, imageCount int) string {
+	text = strings.TrimSpace(text)
+	if imageCount <= 0 || imageRecognitionEnabled {
+		if text != "" {
+			return text
+		}
+		return "User sent an image."
+	}
+	if text == "" || text == "User sent an image." {
+		return larkImageRecognitionDisabledPrompt
+	}
+	return text + "\n\n" + larkImageRecognitionDisabledPrompt
+}
+
+func appendLarkImageReadFailure(text string) string {
+	text = strings.TrimSpace(text)
+	note := "Image attachment could not be read."
+	if text == "" || text == "User sent an image." {
+		return note
+	}
+	return text + "\n\n" + note
+}
+
+func sanitizeLarkFileToken(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "img"
+	}
+	var b strings.Builder
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_' || r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "img"
+	}
+	return out
+}
+
+func larkImageDownloadContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, 4*time.Second)
+}

--- a/internal/channelruntime/lark/images_test.go
+++ b/internal/channelruntime/lark/images_test.go
@@ -1,0 +1,80 @@
+package lark
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDownloadLarkImageToCache(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"tenant_access_token":"tenant-token","expire":7200}`))
+		case "/im/v1/messages/om_1001/resources/img_123":
+			if r.URL.Query().Get("type") != "image" {
+				t.Fatalf("type query = %q, want image", r.URL.Query().Get("type"))
+			}
+			if r.Header.Get("Authorization") != "Bearer tenant-token" {
+				t.Fatalf("authorization = %q, want tenant token", r.Header.Get("Authorization"))
+			}
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(raw)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	tokenClient := NewTenantTokenClient(srv.Client(), srv.URL, "app_id", "app_secret")
+	api := newLarkAPI(srv.Client(), srv.URL, tokenClient)
+	path, err := downloadLarkImageToCache(context.Background(), api, t.TempDir(), "om_1001", "img_123", 1024*1024)
+	if err != nil {
+		t.Fatalf("downloadLarkImageToCache() error = %v", err)
+	}
+	if filepath.Ext(path) != ".png" {
+		t.Fatalf("extension = %q, want .png", filepath.Ext(path))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("downloaded content mismatch")
+	}
+}
+
+func TestDownloadLarkImageToCacheRejectsUnknownType(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"tenant_access_token":"tenant-token","expire":7200}`))
+		case "/im/v1/messages/om_1001/resources/img_123":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write([]byte("unknown"))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	tokenClient := NewTenantTokenClient(srv.Client(), srv.URL, "app_id", "app_secret")
+	api := newLarkAPI(srv.Client(), srv.URL, tokenClient)
+	_, err := downloadLarkImageToCache(context.Background(), api, t.TempDir(), "om_1001", "img_123", 1024*1024)
+	if err == nil {
+		t.Fatalf("downloadLarkImageToCache() expected error")
+	}
+}

--- a/internal/channelruntime/lark/images_test.go
+++ b/internal/channelruntime/lark/images_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	larkbus "github.com/quailyquaily/mistermorph/internal/bus/adapters/lark"
 )
 
 func TestDownloadLarkImageToCache(t *testing.T) {
@@ -51,6 +53,46 @@ func TestDownloadLarkImageToCache(t *testing.T) {
 	}
 	if string(got) != string(raw) {
 		t.Fatalf("downloaded content mismatch")
+	}
+}
+
+func TestDownloadLarkInboundImages(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"tenant_access_token":"tenant-token","expire":7200}`))
+		case "/im/v1/messages/om_1001/resources/img_123":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(raw)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	tokenClient := NewTenantTokenClient(srv.Client(), srv.URL, "app_id", "app_secret")
+	api := newLarkAPI(srv.Client(), srv.URL, tokenClient)
+	got := downloadLarkInboundImages(context.Background(), api, t.TempDir(), larkbus.InboundMessage{
+		ChatID:    "oc_group123",
+		MessageID: "om_1001",
+		Text:      "User sent an image.",
+		ImageKeys: []string{"img_123"},
+	}, nil)
+	if len(got.ImagePaths) != 1 {
+		t.Fatalf("image_paths len = %d, want 1", len(got.ImagePaths))
+	}
+	if filepath.Ext(got.ImagePaths[0]) != ".png" {
+		t.Fatalf("extension = %q, want .png", filepath.Ext(got.ImagePaths[0]))
+	}
+	if got.Text != "User sent an image." {
+		t.Fatalf("text = %q, want original text", got.Text)
 	}
 }
 

--- a/internal/channelruntime/lark/lark_api.go
+++ b/internal/channelruntime/lark/lark_api.go
@@ -147,3 +147,53 @@ func (api *larkAPI) postJSON(ctx context.Context, endpoint string, payload any) 
 	}
 	return nil
 }
+
+func (api *larkAPI) messageResource(ctx context.Context, messageID, fileKey, fileType string, maxBytes int64) ([]byte, string, error) {
+	if api == nil {
+		return nil, "", fmt.Errorf("lark api is not initialized")
+	}
+	if api.tokenClient == nil {
+		return nil, "", fmt.Errorf("lark token client is not initialized")
+	}
+	messageID = strings.TrimSpace(messageID)
+	fileKey = strings.TrimSpace(fileKey)
+	fileType = strings.TrimSpace(fileType)
+	if messageID == "" {
+		return nil, "", fmt.Errorf("lark message id is required")
+	}
+	if fileKey == "" {
+		return nil, "", fmt.Errorf("lark file key is required")
+	}
+	if fileType == "" {
+		return nil, "", fmt.Errorf("lark file type is required")
+	}
+	if maxBytes <= 0 {
+		return nil, "", fmt.Errorf("lark max bytes must be positive")
+	}
+	token, err := api.tokenClient.Token(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	endpoint := api.baseURL + "/im/v1/messages/" + url.PathEscape(messageID) + "/resources/" + url.PathEscape(fileKey) + "?type=" + url.QueryEscape(fileType)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := api.http.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if readErr != nil {
+		return nil, "", readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("lark resource download http %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	if int64(len(raw)) > maxBytes {
+		return nil, "", fmt.Errorf("lark resource too large: > %d bytes", maxBytes)
+	}
+	return raw, resp.Header.Get("Content-Type"), nil
+}

--- a/internal/channelruntime/lark/run.go
+++ b/internal/channelruntime/lark/run.go
@@ -27,6 +27,7 @@ type RunOptions struct {
 	AddressingInterjectThreshold  float64
 	TaskTimeout                   time.Duration
 	MaxConcurrency                int
+	FileCacheDir                  string
 	ServerListen                  string
 	ServerAuthToken               string
 	ServerMaxQueue                int
@@ -43,6 +44,7 @@ type RunOptions struct {
 	MemoryShortTermDays           int
 	MemoryInjectionEnabled        bool
 	MemoryInjectionMaxItems       int
+	ImageRecognitionEnabled       bool
 	Hooks                         Hooks
 	InspectPrompt                 bool
 	InspectRequest                bool

--- a/internal/channelruntime/lark/runtime.go
+++ b/internal/channelruntime/lark/runtime.go
@@ -382,6 +382,10 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				"is_lightweight", dec.Addressing.IsLightweight,
 			)
 		}
+		if taskRuntimeOpts.ImageRecognitionEnabled && len(inbound.ImageKeys) > 0 {
+			inbound = downloadLarkInboundImages(ctx, api, larkImageCacheDir(opts.FileCacheDir), inbound, logger)
+			text = strings.TrimSpace(inbound.Text)
+		}
 
 		workspaceDir, err := workspace.LookupWorkspaceDir(workspaceStore, msg.ConversationKey)
 		if err != nil {
@@ -491,8 +495,6 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		EncryptKey:        strings.TrimSpace(opts.EncryptKey),
 		Inbound:           larkInboundAdapter,
 		AllowedChats:      allowedChats,
-		API:               api,
-		FileCacheDir:      larkImageCacheDir(opts.FileCacheDir),
 		ImageRecognition:  opts.ImageRecognitionEnabled,
 		Logger:            logger,
 	}))

--- a/internal/channelruntime/lark/runtime.go
+++ b/internal/channelruntime/lark/runtime.go
@@ -165,6 +165,7 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		MemoryEnabled:           opts.MemoryEnabled,
 		MemoryInjectionEnabled:  opts.MemoryInjectionEnabled,
 		MemoryInjectionMaxItems: opts.MemoryInjectionMaxItems,
+		ImageRecognitionEnabled: opts.ImageRecognitionEnabled,
 		MemoryOrchestrator:      memRuntime.Orchestrator,
 		MemoryProjectionWorker:  memRuntime.ProjectionWorker,
 	}
@@ -397,6 +398,7 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				FromUserID:      inbound.FromUserID,
 				DisplayName:     inbound.DisplayName,
 				Text:            text,
+				ImagePaths:      append([]string(nil), inbound.ImagePaths...),
 				WorkspaceDir:    workspaceDir,
 				SentAt:          inbound.SentAt,
 				Version:         version,
@@ -489,6 +491,9 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		EncryptKey:        strings.TrimSpace(opts.EncryptKey),
 		Inbound:           larkInboundAdapter,
 		AllowedChats:      allowedChats,
+		API:               api,
+		FileCacheDir:      larkImageCacheDir(opts.FileCacheDir),
+		ImageRecognition:  opts.ImageRecognitionEnabled,
 		Logger:            logger,
 	}))
 	webhookServer := &http.Server{

--- a/internal/channelruntime/lark/runtime_options.go
+++ b/internal/channelruntime/lark/runtime_options.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/quailyquaily/mistermorph/agent"
+	"github.com/quailyquaily/mistermorph/internal/pathutil"
 )
 
 type runtimeLoopOptions struct {
@@ -16,6 +17,7 @@ type runtimeLoopOptions struct {
 	AddressingInterjectThreshold  float64
 	TaskTimeout                   time.Duration
 	MaxConcurrency                int
+	FileCacheDir                  string
 	ServerListen                  string
 	ServerAuthToken               string
 	ServerMaxQueue                int
@@ -32,6 +34,7 @@ type runtimeLoopOptions struct {
 	MemoryShortTermDays           int
 	MemoryInjectionEnabled        bool
 	MemoryInjectionMaxItems       int
+	ImageRecognitionEnabled       bool
 	Hooks                         Hooks
 	InspectPrompt                 bool
 	InspectRequest                bool
@@ -47,6 +50,7 @@ func resolveRuntimeLoopOptionsFromRunOptions(opts RunOptions) runtimeLoopOptions
 		AddressingInterjectThreshold:  opts.AddressingInterjectThreshold,
 		TaskTimeout:                   opts.TaskTimeout,
 		MaxConcurrency:                opts.MaxConcurrency,
+		FileCacheDir:                  strings.TrimSpace(opts.FileCacheDir),
 		ServerListen:                  strings.TrimSpace(opts.ServerListen),
 		ServerAuthToken:               strings.TrimSpace(opts.ServerAuthToken),
 		ServerMaxQueue:                opts.ServerMaxQueue,
@@ -63,6 +67,7 @@ func resolveRuntimeLoopOptionsFromRunOptions(opts RunOptions) runtimeLoopOptions
 		MemoryShortTermDays:           opts.MemoryShortTermDays,
 		MemoryInjectionEnabled:        opts.MemoryInjectionEnabled,
 		MemoryInjectionMaxItems:       opts.MemoryInjectionMaxItems,
+		ImageRecognitionEnabled:       opts.ImageRecognitionEnabled,
 		Hooks:                         opts.Hooks,
 		InspectPrompt:                 opts.InspectPrompt,
 		InspectRequest:                opts.InspectRequest,
@@ -75,6 +80,7 @@ func normalizeRuntimeLoopOptions(opts runtimeLoopOptions) runtimeLoopOptions {
 	opts.AppSecret = strings.TrimSpace(opts.AppSecret)
 	opts.AllowedChatIDs = normalizeRunStringSlice(opts.AllowedChatIDs)
 	opts.GroupTriggerMode = strings.ToLower(strings.TrimSpace(opts.GroupTriggerMode))
+	opts.FileCacheDir = strings.TrimSpace(opts.FileCacheDir)
 	opts.ServerListen = strings.TrimSpace(opts.ServerListen)
 	opts.ServerAuthToken = strings.TrimSpace(opts.ServerAuthToken)
 	opts.BaseURL = strings.TrimSpace(opts.BaseURL)
@@ -111,6 +117,10 @@ func normalizeRuntimeLoopOptions(opts runtimeLoopOptions) runtimeLoopOptions {
 	if opts.BaseURL == "" {
 		opts.BaseURL = defaultLarkBaseURL
 	}
+	if opts.FileCacheDir == "" {
+		opts.FileCacheDir = "~/.cache/morph"
+	}
+	opts.FileCacheDir = pathutil.ExpandHomePath(opts.FileCacheDir)
 	if opts.ServerListen == "" {
 		opts.ServerListen = "127.0.0.1:8787"
 	}

--- a/internal/channelruntime/lark/runtime_task.go
+++ b/internal/channelruntime/lark/runtime_task.go
@@ -3,6 +3,7 @@ package lark
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/quailyquaily/mistermorph/agent"
 	busruntime "github.com/quailyquaily/mistermorph/internal/bus"
 	larkbus "github.com/quailyquaily/mistermorph/internal/bus/adapters/lark"
+	"github.com/quailyquaily/mistermorph/internal/channelruntime/imageinput"
 	"github.com/quailyquaily/mistermorph/internal/channelruntime/taskruntime"
 	"github.com/quailyquaily/mistermorph/internal/chathistory"
 	"github.com/quailyquaily/mistermorph/internal/idempotency"
@@ -29,6 +31,7 @@ type runtimeTaskOptions struct {
 	MemoryEnabled           bool
 	MemoryInjectionEnabled  bool
 	MemoryInjectionMaxItems int
+	ImageRecognitionEnabled bool
 	MemoryOrchestrator      *memoryruntime.Orchestrator
 	MemoryProjectionWorker  *memoryruntime.ProjectionWorker
 }
@@ -42,6 +45,7 @@ type larkJob struct {
 	FromUserID      string
 	DisplayName     string
 	Text            string
+	ImagePaths      []string
 	WorkspaceDir    string
 	SentAt          time.Time
 	Version         uint64
@@ -65,11 +69,17 @@ func runLarkTask(
 	ctx = llmstats.WithMetadata(ctx, job.TaskID, job.EventID)
 	ctx = pathroots.WithWorkspaceDir(ctx, job.WorkspaceDir)
 	ctx = builtin.WithContactsSendRuntimeContext(ctx, contactsSendRuntimeContextForLark(job))
+	logger := rt.Logger
 	task := strings.TrimSpace(job.Text)
 	if task == "" {
 		return nil, nil, nil, fmt.Errorf("empty lark task")
 	}
-	historyMsg, currentMsg, err := buildLarkPromptMessages(history, job)
+	mainRoute, err := rt.ResolveMainRouteForRun()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	mainModel := strings.TrimSpace(mainRoute.ClientConfig.Model)
+	historyMsg, currentMsg, err := buildLarkPromptMessages(history, job, mainModel, runtimeOpts.ImageRecognitionEnabled, logger)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -126,6 +136,7 @@ func runLarkTask(
 	}
 	result, err := rt.Run(ctx, taskruntime.RunRequest{
 		Task:           task,
+		Model:          mainModel,
 		Scene:          "lark.loop",
 		History:        llmHistory,
 		Meta:           meta,
@@ -147,7 +158,7 @@ func runLarkTask(
 	return result.Final, result.Context, result.LoadedSkills, nil
 }
 
-func buildLarkPromptMessages(history []chathistory.ChatHistoryItem, job larkJob) (*llm.Message, *llm.Message, error) {
+func buildLarkPromptMessages(history []chathistory.ChatHistoryItem, job larkJob, model string, imageRecognitionEnabled bool, logger *slog.Logger) (*llm.Message, *llm.Message, error) {
 	historyRaw, err := chathistory.RenderHistoryContext(chathistory.ChannelLark, history)
 	if err != nil {
 		return nil, nil, fmt.Errorf("render lark history context: %w", err)
@@ -161,7 +172,19 @@ func buildLarkPromptMessages(history []chathistory.ChatHistoryItem, job larkJob)
 	if err != nil {
 		return nil, nil, fmt.Errorf("render lark current message: %w", err)
 	}
-	current := llm.Message{Role: "user", Content: currentRaw}
+	imagePaths := append([]string(nil), job.ImagePaths...)
+	if !imageRecognitionEnabled {
+		imagePaths = nil
+	}
+	current, err := imageinput.BuildUserMessage(currentRaw, model, imagePaths, imageinput.MessageOptions{
+		MaxImages: larkLLMMaxImages,
+		MaxBytes:  larkLLMMaxImageBytes,
+		Logger:    logger,
+		LogPrefix: "lark",
+	})
+	if err != nil {
+		return nil, nil, err
+	}
 	return historyMsg, &current, nil
 }
 
@@ -216,8 +239,20 @@ func newLarkInboundHistoryItem(job larkJob) chathistory.ChatHistoryItem {
 		ReplyToMessageID: strings.TrimSpace(job.MessageID),
 		SentAt:           job.SentAt.UTC(),
 		Sender:           larkSenderFromJob(job, false),
-		Text:             strings.TrimSpace(job.Text),
+		Text:             larkHistoryText(job.Text, len(job.ImagePaths)),
 	}
+}
+
+func larkHistoryText(text string, imageCount int) string {
+	text = strings.TrimSpace(text)
+	if imageCount <= 0 {
+		return text
+	}
+	marker := fmt.Sprintf("[image attachments: %d]", imageCount)
+	if text == "" {
+		return marker
+	}
+	return text + "\n" + marker
 }
 
 func larkJobFromInbound(inbound larkbus.InboundMessage) larkJob {
@@ -228,6 +263,7 @@ func larkJobFromInbound(inbound larkbus.InboundMessage) larkJob {
 		FromUserID:   strings.TrimSpace(inbound.FromUserID),
 		DisplayName:  strings.TrimSpace(inbound.DisplayName),
 		Text:         strings.TrimSpace(inbound.Text),
+		ImagePaths:   append([]string(nil), inbound.ImagePaths...),
 		SentAt:       inbound.SentAt.UTC(),
 		MentionUsers: append([]string(nil), inbound.MentionUsers...),
 		EventID:      strings.TrimSpace(inbound.EventID),

--- a/internal/channelruntime/lark/runtime_task_test.go
+++ b/internal/channelruntime/lark/runtime_task_test.go
@@ -1,6 +1,8 @@
 package lark
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -25,7 +27,7 @@ func TestBuildLarkPromptMessagesSeparatesHistoryAndCurrent(t *testing.T) {
 		DisplayName: "Alice",
 		Text:        "latest",
 		SentAt:      time.Date(2026, 3, 8, 9, 2, 0, 0, time.UTC),
-	})
+	}, "gpt-5.2", true, nil)
 	if err != nil {
 		t.Fatalf("buildLarkPromptMessages() error = %v", err)
 	}
@@ -76,7 +78,7 @@ func TestBuildLarkPromptMessagesOmitsEmptyHistory(t *testing.T) {
 		DisplayName: "Alice",
 		Text:        "latest",
 		SentAt:      time.Date(2026, 3, 8, 9, 2, 0, 0, time.UTC),
-	})
+	}, "gpt-5.2", false, nil)
 	if err != nil {
 		t.Fatalf("buildLarkPromptMessages() error = %v", err)
 	}
@@ -85,5 +87,41 @@ func TestBuildLarkPromptMessagesOmitsEmptyHistory(t *testing.T) {
 	}
 	if currentMsg == nil || !strings.Contains(currentMsg.Content, "\"text\": \"latest\"") {
 		t.Fatalf("current message should still be present: %#v", currentMsg)
+	}
+}
+
+func TestBuildLarkPromptMessagesWithImageParts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "image.png")
+	if err := os.WriteFile(path, []byte("png-data"), 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	historyMsg, currentMsg, err := buildLarkPromptMessages(nil, larkJob{
+		ChatID:      "oc_123",
+		ChatType:    "group",
+		MessageID:   "102",
+		FromUserID:  "ou_123",
+		DisplayName: "Alice",
+		Text:        "latest",
+		ImagePaths:  []string{path},
+		SentAt:      time.Date(2026, 3, 8, 9, 2, 0, 0, time.UTC),
+	}, "gpt-5.2", true, nil)
+	if err != nil {
+		t.Fatalf("buildLarkPromptMessages() error = %v", err)
+	}
+	if historyMsg != nil {
+		t.Fatalf("historyMsg should be nil")
+	}
+	if currentMsg == nil {
+		t.Fatalf("currentMsg = nil")
+	}
+	if len(currentMsg.Parts) != 2 {
+		t.Fatalf("current parts len = %d, want 2", len(currentMsg.Parts))
+	}
+	if currentMsg.Parts[1].MIMEType != "image/png" {
+		t.Fatalf("image MIME = %q, want image/png", currentMsg.Parts[1].MIMEType)
 	}
 }

--- a/internal/channelruntime/lark/webhook.go
+++ b/internal/channelruntime/lark/webhook.go
@@ -30,8 +30,6 @@ type larkWebhookHandlerOptions struct {
 	EncryptKey        string
 	Inbound           *larkbus.InboundAdapter
 	AllowedChats      map[string]bool
-	API               *larkAPI
-	FileCacheDir      string
 	ImageRecognition  bool
 	Logger            *slog.Logger
 }
@@ -103,11 +101,6 @@ type larkImageContent struct {
 	Text     string `json:"text,omitempty"`
 }
 
-type larkParsedInboundMessage struct {
-	Message   larkbus.InboundMessage
-	ImageKeys []string
-}
-
 func newLarkWebhookHandler(opts larkWebhookHandlerOptions) http.Handler {
 	verificationToken := strings.TrimSpace(opts.VerificationToken)
 	encryptKey := strings.TrimSpace(opts.EncryptKey)
@@ -151,7 +144,7 @@ func newLarkWebhookHandler(opts larkWebhookHandlerOptions) http.Handler {
 			http.Error(w, "invalid json", http.StatusBadRequest)
 			return
 		}
-		parsed, ok, normalizeErr := inboundMessageFromWebhookEvent(payload, allowedChats)
+		inbound, ok, normalizeErr := inboundMessageFromWebhookEvent(payload, allowedChats)
 		if normalizeErr != nil {
 			logLarkWebhookWarn(opts.Logger, "lark_webhook_event_invalid",
 				"event_id", strings.TrimSpace(payload.Header.GetEventID()),
@@ -161,32 +154,10 @@ func newLarkWebhookHandler(opts larkWebhookHandlerOptions) http.Handler {
 			return
 		}
 		if ok {
-			inbound := parsed.Message
-			if len(parsed.ImageKeys) > 0 {
-				inbound.Text = larkImageFallbackText(inbound.Text, opts.ImageRecognition, len(parsed.ImageKeys))
-				if opts.ImageRecognition {
-					for _, imageKey := range parsed.ImageKeys {
-						if len(inbound.ImagePaths) >= larkLLMMaxImages {
-							break
-						}
-						imageCtx, cancelImage := larkImageDownloadContext(r.Context())
-						path, imageErr := downloadLarkImageToCache(imageCtx, opts.API, strings.TrimSpace(opts.FileCacheDir), inbound.MessageID, imageKey, larkLLMMaxImageBytes)
-						cancelImage()
-						if imageErr != nil {
-							logLarkWebhookWarn(opts.Logger, "lark_image_download_failed",
-								"event_id", strings.TrimSpace(payload.Header.GetEventID()),
-								"chat_id", strings.TrimSpace(inbound.ChatID),
-								"message_id", strings.TrimSpace(inbound.MessageID),
-								"image_key", strings.TrimSpace(imageKey),
-								"error", imageErr.Error(),
-							)
-							continue
-						}
-						inbound.ImagePaths = append(inbound.ImagePaths, path)
-					}
-					if len(inbound.ImagePaths) == 0 {
-						inbound.Text = appendLarkImageReadFailure(inbound.Text)
-					}
+			if len(inbound.ImageKeys) > 0 {
+				inbound.Text = larkImageFallbackText(inbound.Text, opts.ImageRecognition, len(inbound.ImageKeys))
+				if !opts.ImageRecognition {
+					inbound.ImageKeys = nil
 				}
 			}
 			accepted, publishErr := opts.Inbound.HandleInboundMessage(r.Context(), inbound)
@@ -295,53 +266,51 @@ func verifyLarkWebhookSignature(headers http.Header, encryptKey string, body []b
 	return nil
 }
 
-func inboundMessageFromWebhookEvent(payload larkWebhookEnvelope, allowedChats map[string]bool) (larkParsedInboundMessage, bool, error) {
+func inboundMessageFromWebhookEvent(payload larkWebhookEnvelope, allowedChats map[string]bool) (larkbus.InboundMessage, bool, error) {
 	if payload.Event == nil {
-		return larkParsedInboundMessage{}, false, nil
+		return larkbus.InboundMessage{}, false, nil
 	}
 	event := payload.Event
 	if !strings.EqualFold(strings.TrimSpace(event.Sender.SenderType), "user") {
-		return larkParsedInboundMessage{}, false, nil
+		return larkbus.InboundMessage{}, false, nil
 	}
 	chatID := strings.TrimSpace(event.Message.ChatID)
 	if chatID == "" {
-		return larkParsedInboundMessage{}, false, fmt.Errorf("chat_id is required")
+		return larkbus.InboundMessage{}, false, fmt.Errorf("chat_id is required")
 	}
 	if len(allowedChats) > 0 && !allowedChats[chatID] {
-		return larkParsedInboundMessage{}, false, nil
+		return larkbus.InboundMessage{}, false, nil
 	}
 	messageID := strings.TrimSpace(event.Message.MessageID)
 	if messageID == "" {
-		return larkParsedInboundMessage{}, false, fmt.Errorf("message_id is required")
+		return larkbus.InboundMessage{}, false, fmt.Errorf("message_id is required")
 	}
 	chatType, err := normalizeLarkInboundChatType(event.Message.ChatType)
 	if err != nil {
-		return larkParsedInboundMessage{}, false, err
+		return larkbus.InboundMessage{}, false, err
 	}
 	fromUserID := strings.TrimSpace(event.Sender.SenderID.OpenID)
 	if fromUserID == "" {
-		return larkParsedInboundMessage{}, false, fmt.Errorf("from_user_id is required")
+		return larkbus.InboundMessage{}, false, fmt.Errorf("from_user_id is required")
 	}
 	text, imageKeys, ok, err := extractLarkMessageContent(event.Message.MessageType, event.Message.Content)
 	if err != nil {
-		return larkParsedInboundMessage{}, false, err
+		return larkbus.InboundMessage{}, false, err
 	}
 	if !ok {
-		return larkParsedInboundMessage{}, false, nil
+		return larkbus.InboundMessage{}, false, nil
 	}
-	return larkParsedInboundMessage{
-		Message: larkbus.InboundMessage{
-			ChatID:       chatID,
-			MessageID:    messageID,
-			SentAt:       parseLarkEventTime(event.Message.CreateTime),
-			ChatType:     chatType,
-			FromUserID:   fromUserID,
-			DisplayName:  "",
-			Text:         text,
-			MentionUsers: collectLarkMentionUsers(event.Message.Mentions),
-			EventID:      strings.TrimSpace(payload.Header.GetEventID()),
-		},
-		ImageKeys: imageKeys,
+	return larkbus.InboundMessage{
+		ChatID:       chatID,
+		MessageID:    messageID,
+		SentAt:       parseLarkEventTime(event.Message.CreateTime),
+		ChatType:     chatType,
+		FromUserID:   fromUserID,
+		DisplayName:  "",
+		Text:         text,
+		MentionUsers: collectLarkMentionUsers(event.Message.Mentions),
+		EventID:      strings.TrimSpace(payload.Header.GetEventID()),
+		ImageKeys:    imageKeys,
 	}, true, nil
 }
 

--- a/internal/channelruntime/lark/webhook.go
+++ b/internal/channelruntime/lark/webhook.go
@@ -30,6 +30,9 @@ type larkWebhookHandlerOptions struct {
 	EncryptKey        string
 	Inbound           *larkbus.InboundAdapter
 	AllowedChats      map[string]bool
+	API               *larkAPI
+	FileCacheDir      string
+	ImageRecognition  bool
 	Logger            *slog.Logger
 }
 
@@ -95,6 +98,16 @@ type larkTextContent struct {
 	Text string `json:"text,omitempty"`
 }
 
+type larkImageContent struct {
+	ImageKey string `json:"image_key,omitempty"`
+	Text     string `json:"text,omitempty"`
+}
+
+type larkParsedInboundMessage struct {
+	Message   larkbus.InboundMessage
+	ImageKeys []string
+}
+
 func newLarkWebhookHandler(opts larkWebhookHandlerOptions) http.Handler {
 	verificationToken := strings.TrimSpace(opts.VerificationToken)
 	encryptKey := strings.TrimSpace(opts.EncryptKey)
@@ -138,7 +151,7 @@ func newLarkWebhookHandler(opts larkWebhookHandlerOptions) http.Handler {
 			http.Error(w, "invalid json", http.StatusBadRequest)
 			return
 		}
-		inbound, ok, normalizeErr := inboundMessageFromWebhookEvent(payload, allowedChats)
+		parsed, ok, normalizeErr := inboundMessageFromWebhookEvent(payload, allowedChats)
 		if normalizeErr != nil {
 			logLarkWebhookWarn(opts.Logger, "lark_webhook_event_invalid",
 				"event_id", strings.TrimSpace(payload.Header.GetEventID()),
@@ -148,6 +161,34 @@ func newLarkWebhookHandler(opts larkWebhookHandlerOptions) http.Handler {
 			return
 		}
 		if ok {
+			inbound := parsed.Message
+			if len(parsed.ImageKeys) > 0 {
+				inbound.Text = larkImageFallbackText(inbound.Text, opts.ImageRecognition, len(parsed.ImageKeys))
+				if opts.ImageRecognition {
+					for _, imageKey := range parsed.ImageKeys {
+						if len(inbound.ImagePaths) >= larkLLMMaxImages {
+							break
+						}
+						imageCtx, cancelImage := larkImageDownloadContext(r.Context())
+						path, imageErr := downloadLarkImageToCache(imageCtx, opts.API, strings.TrimSpace(opts.FileCacheDir), inbound.MessageID, imageKey, larkLLMMaxImageBytes)
+						cancelImage()
+						if imageErr != nil {
+							logLarkWebhookWarn(opts.Logger, "lark_image_download_failed",
+								"event_id", strings.TrimSpace(payload.Header.GetEventID()),
+								"chat_id", strings.TrimSpace(inbound.ChatID),
+								"message_id", strings.TrimSpace(inbound.MessageID),
+								"image_key", strings.TrimSpace(imageKey),
+								"error", imageErr.Error(),
+							)
+							continue
+						}
+						inbound.ImagePaths = append(inbound.ImagePaths, path)
+					}
+					if len(inbound.ImagePaths) == 0 {
+						inbound.Text = appendLarkImageReadFailure(inbound.Text)
+					}
+				}
+			}
 			accepted, publishErr := opts.Inbound.HandleInboundMessage(r.Context(), inbound)
 			if publishErr != nil {
 				logLarkWebhookWarn(opts.Logger, "lark_webhook_publish_error",
@@ -254,50 +295,53 @@ func verifyLarkWebhookSignature(headers http.Header, encryptKey string, body []b
 	return nil
 }
 
-func inboundMessageFromWebhookEvent(payload larkWebhookEnvelope, allowedChats map[string]bool) (larkbus.InboundMessage, bool, error) {
+func inboundMessageFromWebhookEvent(payload larkWebhookEnvelope, allowedChats map[string]bool) (larkParsedInboundMessage, bool, error) {
 	if payload.Event == nil {
-		return larkbus.InboundMessage{}, false, nil
+		return larkParsedInboundMessage{}, false, nil
 	}
 	event := payload.Event
 	if !strings.EqualFold(strings.TrimSpace(event.Sender.SenderType), "user") {
-		return larkbus.InboundMessage{}, false, nil
+		return larkParsedInboundMessage{}, false, nil
 	}
 	chatID := strings.TrimSpace(event.Message.ChatID)
 	if chatID == "" {
-		return larkbus.InboundMessage{}, false, fmt.Errorf("chat_id is required")
+		return larkParsedInboundMessage{}, false, fmt.Errorf("chat_id is required")
 	}
 	if len(allowedChats) > 0 && !allowedChats[chatID] {
-		return larkbus.InboundMessage{}, false, nil
+		return larkParsedInboundMessage{}, false, nil
 	}
 	messageID := strings.TrimSpace(event.Message.MessageID)
 	if messageID == "" {
-		return larkbus.InboundMessage{}, false, fmt.Errorf("message_id is required")
+		return larkParsedInboundMessage{}, false, fmt.Errorf("message_id is required")
 	}
 	chatType, err := normalizeLarkInboundChatType(event.Message.ChatType)
 	if err != nil {
-		return larkbus.InboundMessage{}, false, err
+		return larkParsedInboundMessage{}, false, err
 	}
 	fromUserID := strings.TrimSpace(event.Sender.SenderID.OpenID)
 	if fromUserID == "" {
-		return larkbus.InboundMessage{}, false, fmt.Errorf("from_user_id is required")
+		return larkParsedInboundMessage{}, false, fmt.Errorf("from_user_id is required")
 	}
-	text, ok, err := extractLarkTextContent(event.Message.MessageType, event.Message.Content)
+	text, imageKeys, ok, err := extractLarkMessageContent(event.Message.MessageType, event.Message.Content)
 	if err != nil {
-		return larkbus.InboundMessage{}, false, err
+		return larkParsedInboundMessage{}, false, err
 	}
 	if !ok {
-		return larkbus.InboundMessage{}, false, nil
+		return larkParsedInboundMessage{}, false, nil
 	}
-	return larkbus.InboundMessage{
-		ChatID:       chatID,
-		MessageID:    messageID,
-		SentAt:       parseLarkEventTime(event.Message.CreateTime),
-		ChatType:     chatType,
-		FromUserID:   fromUserID,
-		DisplayName:  "",
-		Text:         text,
-		MentionUsers: collectLarkMentionUsers(event.Message.Mentions),
-		EventID:      strings.TrimSpace(payload.Header.GetEventID()),
+	return larkParsedInboundMessage{
+		Message: larkbus.InboundMessage{
+			ChatID:       chatID,
+			MessageID:    messageID,
+			SentAt:       parseLarkEventTime(event.Message.CreateTime),
+			ChatType:     chatType,
+			FromUserID:   fromUserID,
+			DisplayName:  "",
+			Text:         text,
+			MentionUsers: collectLarkMentionUsers(event.Message.Mentions),
+			EventID:      strings.TrimSpace(payload.Header.GetEventID()),
+		},
+		ImageKeys: imageKeys,
 	}, true, nil
 }
 
@@ -315,23 +359,40 @@ func normalizeLarkInboundChatType(raw string) (string, error) {
 	}
 }
 
-func extractLarkTextContent(messageType, content string) (string, bool, error) {
-	if !strings.EqualFold(strings.TrimSpace(messageType), "text") {
-		return "", false, nil
-	}
+func extractLarkMessageContent(messageType, content string) (string, []string, bool, error) {
+	messageType = strings.ToLower(strings.TrimSpace(messageType))
 	content = strings.TrimSpace(content)
 	if content == "" {
-		return "", false, nil
+		return "", nil, false, nil
 	}
-	var textContent larkTextContent
-	if err := json.Unmarshal([]byte(content), &textContent); err != nil {
-		return "", false, fmt.Errorf("invalid text content")
+	switch messageType {
+	case "text":
+		var textContent larkTextContent
+		if err := json.Unmarshal([]byte(content), &textContent); err != nil {
+			return "", nil, false, fmt.Errorf("invalid text content")
+		}
+		text := strings.TrimSpace(textContent.Text)
+		if text == "" {
+			return "", nil, false, nil
+		}
+		return text, nil, true, nil
+	case "image":
+		var imageContent larkImageContent
+		if err := json.Unmarshal([]byte(content), &imageContent); err != nil {
+			return "", nil, false, fmt.Errorf("invalid image content")
+		}
+		imageKey := strings.TrimSpace(imageContent.ImageKey)
+		if imageKey == "" {
+			return "", nil, false, nil
+		}
+		text := strings.TrimSpace(imageContent.Text)
+		if text == "" {
+			text = "User sent an image."
+		}
+		return text, []string{imageKey}, true, nil
+	default:
+		return "", nil, false, nil
 	}
-	text := strings.TrimSpace(textContent.Text)
-	if text == "" {
-		return "", false, nil
-	}
-	return text, true, nil
 }
 
 func collectLarkMentionUsers(items []larkWebhookMentionEvent) []string {

--- a/internal/channelruntime/lark/webhook_test.go
+++ b/internal/channelruntime/lark/webhook_test.go
@@ -102,13 +102,14 @@ func TestInboundMessageFromWebhookEvent(t *testing.T) {
 		},
 	}
 
-	msg, ok, err := inboundMessageFromWebhookEvent(payload, map[string]bool{})
+	parsed, ok, err := inboundMessageFromWebhookEvent(payload, map[string]bool{})
 	if err != nil {
 		t.Fatalf("inboundMessageFromWebhookEvent() error = %v", err)
 	}
 	if !ok {
 		t.Fatalf("inboundMessageFromWebhookEvent() ok=false, want true")
 	}
+	msg := parsed.Message
 	if msg.ChatID != "oc_group123" {
 		t.Fatalf("chat_id mismatch: got %q want %q", msg.ChatID, "oc_group123")
 	}
@@ -133,6 +134,45 @@ func TestInboundMessageFromWebhookEvent(t *testing.T) {
 	wantSentAt := time.UnixMilli(1760000000123).UTC()
 	if !msg.SentAt.Equal(wantSentAt) {
 		t.Fatalf("sent_at = %s, want %s", msg.SentAt.Format(time.RFC3339Nano), wantSentAt.Format(time.RFC3339Nano))
+	}
+}
+
+func TestInboundMessageFromWebhookEventImage(t *testing.T) {
+	t.Parallel()
+
+	payload := larkWebhookEnvelope{
+		Header: &larkWebhookHeader{
+			EventID:   "ev_img",
+			EventType: "im.message.receive_v1",
+		},
+		Event: &larkWebhookEvent{
+			Sender: larkWebhookSender{
+				SenderType: "user",
+				SenderID:   larkWebhookUserID{OpenID: "ou_123"},
+			},
+			Message: larkWebhookMessage{
+				MessageID:   "om_1001",
+				CreateTime:  "1760000000123",
+				ChatID:      "oc_group123",
+				ChatType:    "group",
+				MessageType: "image",
+				Content:     `{"image_key":"img_123"}`,
+			},
+		},
+	}
+
+	parsed, ok, err := inboundMessageFromWebhookEvent(payload, map[string]bool{})
+	if err != nil {
+		t.Fatalf("inboundMessageFromWebhookEvent() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("inboundMessageFromWebhookEvent() ok=false, want true")
+	}
+	if parsed.Message.Text != "User sent an image." {
+		t.Fatalf("text = %q, want image fallback", parsed.Message.Text)
+	}
+	if len(parsed.ImageKeys) != 1 || parsed.ImageKeys[0] != "img_123" {
+		t.Fatalf("image keys = %#v, want [img_123]", parsed.ImageKeys)
 	}
 }
 

--- a/internal/channelruntime/lark/webhook_test.go
+++ b/internal/channelruntime/lark/webhook_test.go
@@ -102,14 +102,13 @@ func TestInboundMessageFromWebhookEvent(t *testing.T) {
 		},
 	}
 
-	parsed, ok, err := inboundMessageFromWebhookEvent(payload, map[string]bool{})
+	msg, ok, err := inboundMessageFromWebhookEvent(payload, map[string]bool{})
 	if err != nil {
 		t.Fatalf("inboundMessageFromWebhookEvent() error = %v", err)
 	}
 	if !ok {
 		t.Fatalf("inboundMessageFromWebhookEvent() ok=false, want true")
 	}
-	msg := parsed.Message
 	if msg.ChatID != "oc_group123" {
 		t.Fatalf("chat_id mismatch: got %q want %q", msg.ChatID, "oc_group123")
 	}
@@ -161,18 +160,18 @@ func TestInboundMessageFromWebhookEventImage(t *testing.T) {
 		},
 	}
 
-	parsed, ok, err := inboundMessageFromWebhookEvent(payload, map[string]bool{})
+	msg, ok, err := inboundMessageFromWebhookEvent(payload, map[string]bool{})
 	if err != nil {
 		t.Fatalf("inboundMessageFromWebhookEvent() error = %v", err)
 	}
 	if !ok {
 		t.Fatalf("inboundMessageFromWebhookEvent() ok=false, want true")
 	}
-	if parsed.Message.Text != "User sent an image." {
-		t.Fatalf("text = %q, want image fallback", parsed.Message.Text)
+	if msg.Text != "User sent an image." {
+		t.Fatalf("text = %q, want image fallback", msg.Text)
 	}
-	if len(parsed.ImageKeys) != 1 || parsed.ImageKeys[0] != "img_123" {
-		t.Fatalf("image keys = %#v, want [img_123]", parsed.ImageKeys)
+	if len(msg.ImageKeys) != 1 || msg.ImageKeys[0] != "img_123" {
+		t.Fatalf("image keys = %#v, want [img_123]", msg.ImageKeys)
 	}
 }
 

--- a/internal/channelruntime/line/images.go
+++ b/internal/channelruntime/line/images.go
@@ -2,13 +2,13 @@ package line
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/quailyquaily/mistermorph/internal/channelruntime/imageinput"
 	"github.com/quailyquaily/mistermorph/internal/telegramutil"
 	"github.com/quailyquaily/mistermorph/llm"
 )
@@ -18,73 +18,13 @@ const (
 	lineLLMMaxImageBytes = int64(5 * 1024 * 1024)
 )
 
-func buildLineHistoryMessage(content string, model string, imagePaths []string, logger *slog.Logger) (llm.Message, error) {
-	return buildLineCurrentMessage(content, model, imagePaths, logger)
-}
-
 func buildLineCurrentMessage(content string, model string, imagePaths []string, logger *slog.Logger) (llm.Message, error) {
-	msg := llm.Message{Role: "user", Content: content}
-	if !llm.ModelSupportsImageParts(model) || len(imagePaths) == 0 {
-		return msg, nil
-	}
-	parts := make([]llm.Part, 0, 1+min(len(imagePaths), lineLLMMaxImages))
-	if strings.TrimSpace(content) != "" {
-		parts = append(parts, llm.Part{Type: llm.PartTypeText, Text: content})
-	}
-
-	seen := make(map[string]bool, len(imagePaths))
-	imageCount := 0
-	for _, rawPath := range imagePaths {
-		if imageCount >= lineLLMMaxImages {
-			break
-		}
-		path := strings.TrimSpace(rawPath)
-		if path == "" || seen[path] {
-			continue
-		}
-		seen[path] = true
-
-		info, err := os.Stat(path)
-		if err != nil {
-			if logger != nil {
-				logger.Warn("line_image_part_skip", "path", path, "error", err.Error())
-			}
-			continue
-		}
-		if info.Size() <= 0 {
-			continue
-		}
-		if info.Size() > lineLLMMaxImageBytes {
-			return llm.Message{}, fmt.Errorf("图片太大: %s (%d bytes > %d bytes)", filepath.Base(path), info.Size(), lineLLMMaxImageBytes)
-		}
-
-		raw, err := os.ReadFile(path)
-		if err != nil {
-			if logger != nil {
-				logger.Warn("line_image_part_read_error", "path", path, "error", err.Error())
-			}
-			continue
-		}
-		mimeType := lineImageMIMEType(path)
-		if !isLineSupportedUploadImageMIME(mimeType) {
-			if logger != nil {
-				logger.Warn("line_image_part_skip_unsupported_format", "path", path, "mime_type", mimeType)
-			}
-			continue
-		}
-
-		parts = append(parts, llm.Part{
-			Type:       llm.PartTypeImageBase64,
-			MIMEType:   mimeType,
-			DataBase64: base64.StdEncoding.EncodeToString(raw),
-		})
-		imageCount++
-	}
-	if imageCount == 0 {
-		return msg, nil
-	}
-	msg.Parts = parts
-	return msg, nil
+	return imageinput.BuildUserMessage(content, model, imagePaths, imageinput.MessageOptions{
+		MaxImages: lineLLMMaxImages,
+		MaxBytes:  lineLLMMaxImageBytes,
+		Logger:    logger,
+		LogPrefix: "line",
+	})
 }
 
 func downloadLineImageToCache(ctx context.Context, api *lineAPI, cacheDir string, messageID string, maxBytes int64) (string, error) {
@@ -113,11 +53,11 @@ func downloadLineImageToCache(ctx context.Context, api *lineAPI, cacheDir string
 	if err != nil {
 		return "", err
 	}
-	mimeType = lineNormalizeMIMEType(mimeType)
-	if !isLineSupportedUploadImageMIME(mimeType) {
+	mimeType = imageinput.NormalizeMIMEType(mimeType)
+	if !imageinput.SupportedUploadMIME(mimeType) {
 		return "", fmt.Errorf("line image format is not supported: %s", mimeType)
 	}
-	ext := lineImageExtFromMIMEType(mimeType)
+	ext := imageinput.ExtensionForMIMEType(mimeType)
 	if ext == "" {
 		return "", fmt.Errorf("line image extension is not supported: %s", mimeType)
 	}
@@ -162,50 +102,6 @@ func ensureLineSecureChildDir(parentDir, childDir string) error {
 		return fmt.Errorf("child dir is not under parent dir: %s", childAbs)
 	}
 	return telegramutil.EnsureSecureCacheDir(childAbs)
-}
-
-func lineNormalizeMIMEType(mimeType string) string {
-	mimeType = strings.TrimSpace(strings.ToLower(mimeType))
-	if idx := strings.Index(mimeType, ";"); idx >= 0 {
-		mimeType = strings.TrimSpace(mimeType[:idx])
-	}
-	return mimeType
-}
-
-func lineImageExtFromMIMEType(mimeType string) string {
-	switch lineNormalizeMIMEType(mimeType) {
-	case "image/jpeg":
-		return ".jpg"
-	case "image/png":
-		return ".png"
-	case "image/webp":
-		return ".webp"
-	default:
-		return ""
-	}
-}
-
-func lineImageMIMEType(path string) string {
-	ext := strings.ToLower(strings.TrimSpace(filepath.Ext(path)))
-	switch ext {
-	case ".jpg", ".jpeg":
-		return "image/jpeg"
-	case ".png":
-		return "image/png"
-	case ".webp":
-		return "image/webp"
-	default:
-		return ""
-	}
-}
-
-func isLineSupportedUploadImageMIME(mimeType string) bool {
-	switch lineNormalizeMIMEType(mimeType) {
-	case "image/jpeg", "image/png", "image/webp":
-		return true
-	default:
-		return false
-	}
 }
 
 func sanitizeLineFileToken(raw string) string {

--- a/internal/channelruntime/line/images_test.go
+++ b/internal/channelruntime/line/images_test.go
@@ -27,7 +27,7 @@ var tinyPNG = []byte{
 	0x42, 0x60, 0x82,
 }
 
-func TestBuildLineHistoryMessageWithImageParts(t *testing.T) {
+func TestBuildLineCurrentMessageWithImageParts(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -36,9 +36,9 @@ func TestBuildLineHistoryMessageWithImageParts(t *testing.T) {
 		t.Fatalf("write image: %v", err)
 	}
 
-	msg, err := buildLineHistoryMessage("hello", "gpt-5.2", []string{path}, nil)
+	msg, err := buildLineCurrentMessage("hello", "gpt-5.2", []string{path}, nil)
 	if err != nil {
-		t.Fatalf("buildLineHistoryMessage() error = %v", err)
+		t.Fatalf("buildLineCurrentMessage() error = %v", err)
 	}
 	if len(msg.Parts) != 2 {
 		t.Fatalf("parts len = %d, want 2", len(msg.Parts))
@@ -61,12 +61,12 @@ func TestBuildLineHistoryMessageWithImageParts(t *testing.T) {
 	}
 }
 
-func TestBuildLineHistoryMessageUnsupportedModel(t *testing.T) {
+func TestBuildLineCurrentMessageUnsupportedModel(t *testing.T) {
 	t.Parallel()
 
-	msg, err := buildLineHistoryMessage("hello", "text-only-model", []string{"/tmp/x.png"}, nil)
+	msg, err := buildLineCurrentMessage("hello", "text-only-model", []string{"/tmp/x.png"}, nil)
 	if err != nil {
-		t.Fatalf("buildLineHistoryMessage() error = %v", err)
+		t.Fatalf("buildLineCurrentMessage() error = %v", err)
 	}
 	if len(msg.Parts) != 0 {
 		t.Fatalf("parts len = %d, want 0", len(msg.Parts))
@@ -151,7 +151,7 @@ func TestBuildLinePromptMessagesOmitsEmptyHistory(t *testing.T) {
 	}
 }
 
-func TestBuildLineHistoryMessageImageTooLarge(t *testing.T) {
+func TestBuildLineCurrentMessageImageTooLarge(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -161,12 +161,33 @@ func TestBuildLineHistoryMessageImageTooLarge(t *testing.T) {
 		t.Fatalf("write image: %v", err)
 	}
 
-	_, err := buildLineHistoryMessage("hello", "gpt-5.2", []string{path}, nil)
+	_, err := buildLineCurrentMessage("hello", "gpt-5.2", []string{path}, nil)
 	if err == nil {
-		t.Fatalf("buildLineHistoryMessage() expected error")
+		t.Fatalf("buildLineCurrentMessage() expected error")
 	}
 	if !strings.Contains(err.Error(), "图片太大") {
 		t.Fatalf("error = %v, want 图片太大", err)
+	}
+}
+
+func TestBuildLineCurrentMessageSkipsUnknownFileTypes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "image.bin")
+	if err := os.WriteFile(path, []byte("not-an-image"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	msg, err := buildLineCurrentMessage("hello", "gpt-5.2", []string{path}, nil)
+	if err != nil {
+		t.Fatalf("buildLineCurrentMessage() error = %v", err)
+	}
+	if len(msg.Parts) != 0 {
+		t.Fatalf("parts len = %d, want 0", len(msg.Parts))
+	}
+	if msg.Content != "hello" {
+		t.Fatalf("content = %q, want hello", msg.Content)
 	}
 }
 

--- a/internal/channelruntime/line/runtime_task.go
+++ b/internal/channelruntime/line/runtime_task.go
@@ -146,10 +146,7 @@ func buildLinePromptMessages(history []chathistory.ChatHistoryItem, job lineJob,
 	}
 	var historyMsg *llm.Message
 	if strings.TrimSpace(historyRaw) != "" {
-		msg, buildErr := buildLineHistoryMessage(historyRaw, model, nil, logger)
-		if buildErr != nil {
-			return nil, nil, buildErr
-		}
+		msg := llm.Message{Role: "user", Content: historyRaw}
 		historyMsg = &msg
 	}
 

--- a/internal/channelruntime/slack/images.go
+++ b/internal/channelruntime/slack/images.go
@@ -1,0 +1,168 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/quailyquaily/mistermorph/internal/channelruntime/imageinput"
+	"github.com/quailyquaily/mistermorph/internal/telegramutil"
+)
+
+const (
+	slackLLMMaxImages     = 3
+	slackLLMMaxImageBytes = int64(5 * 1024 * 1024)
+)
+
+const slackImageRecognitionDisabledPrompt = "User sent an image, but image recognition is disabled in the current Slack runtime. Reply briefly and ask the user to describe the image in text or enable slack in multimodal.image.sources."
+
+func downloadSlackImageToCache(ctx context.Context, api *slackAPI, cacheDir string, file slackEventFile, maxBytes int64) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if api == nil || api.http == nil {
+		return "", fmt.Errorf("slack api is not initialized")
+	}
+	cacheDir = strings.TrimSpace(cacheDir)
+	if cacheDir == "" {
+		return "", fmt.Errorf("slack image cache dir is required")
+	}
+	if maxBytes <= 0 {
+		return "", fmt.Errorf("slack image max bytes must be positive")
+	}
+	if file.Size > maxBytes {
+		return "", fmt.Errorf("slack image too large: %d bytes > %d bytes", file.Size, maxBytes)
+	}
+	mimeType := imageinput.NormalizeMIMEType(slackFileMIMEType(file))
+	if !imageinput.SupportedUploadMIME(mimeType) {
+		return "", fmt.Errorf("slack image format is not supported: %s", mimeType)
+	}
+	ext := imageinput.ExtensionForMIMEType(mimeType)
+	if ext == "" {
+		return "", fmt.Errorf("slack image extension is not supported: %s", mimeType)
+	}
+	downloadURL := slackFileDownloadURL(file)
+	if downloadURL == "" {
+		return "", fmt.Errorf("slack image download url is required")
+	}
+	if err := telegramutil.EnsureSecureCacheDir(cacheDir); err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(api.botToken))
+	resp, err := api.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		msg := strings.TrimSpace(string(raw))
+		if msg == "" {
+			return "", fmt.Errorf("slack image download http %d", resp.StatusCode)
+		}
+		return "", fmt.Errorf("slack image download http %d: %s", resp.StatusCode, msg)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if int64(len(raw)) > maxBytes {
+		return "", fmt.Errorf("slack image too large: > %d bytes", maxBytes)
+	}
+
+	token := strings.TrimSpace(file.ID)
+	if token == "" {
+		token = strings.TrimSpace(file.Name)
+	}
+	pattern := "slack_" + sanitizeSlackFileToken(token) + "_*" + ext
+	tmp, err := os.CreateTemp(cacheDir, pattern)
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	return tmpPath, nil
+}
+
+func slackImageCacheDir(fileCacheDir string) string {
+	fileCacheDir = strings.TrimSpace(fileCacheDir)
+	if fileCacheDir == "" {
+		return ""
+	}
+	return filepath.Join(fileCacheDir, "slack")
+}
+
+func slackImageFallbackText(text string, imageRecognitionEnabled bool, imageCount int) string {
+	text = strings.TrimSpace(text)
+	if imageCount <= 0 || imageRecognitionEnabled {
+		if text != "" {
+			return text
+		}
+		return "User sent an image."
+	}
+	if text == "" {
+		return slackImageRecognitionDisabledPrompt
+	}
+	return text + "\n\n" + slackImageRecognitionDisabledPrompt
+}
+
+func appendSlackImageReadFailure(text string) string {
+	text = strings.TrimSpace(text)
+	note := "Image attachment could not be read."
+	if text == "" || text == "User sent an image." {
+		return note
+	}
+	return text + "\n\n" + note
+}
+
+func sanitizeSlackFileToken(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "img"
+	}
+	var b strings.Builder
+	for _, r := range raw {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_' || r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "img"
+	}
+	return out
+}
+
+func slackImageDownloadContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, 20*time.Second)
+}

--- a/internal/channelruntime/slack/images.go
+++ b/internal/channelruntime/slack/images.go
@@ -35,6 +35,13 @@ func downloadSlackImageToCache(ctx context.Context, api *slackAPI, cacheDir stri
 	if maxBytes <= 0 {
 		return "", fmt.Errorf("slack image max bytes must be positive")
 	}
+	if slackFileNeedsInfo(file) {
+		resolved, err := api.fileInfo(ctx, file.ID)
+		if err != nil {
+			return "", err
+		}
+		file = resolved
+	}
 	if file.Size > maxBytes {
 		return "", fmt.Errorf("slack image too large: %d bytes > %d bytes", file.Size, maxBytes)
 	}

--- a/internal/channelruntime/slack/images_test.go
+++ b/internal/channelruntime/slack/images_test.go
@@ -2,10 +2,13 @@ package slack
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -44,6 +47,69 @@ func TestDownloadSlackImageToCache(t *testing.T) {
 	}
 }
 
+func TestDownloadSlackImageToCacheUsesFilesInfoForSlackConnectPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("png-data")
+	var filesInfoCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/files.info":
+			filesInfoCalled = true
+			if r.Header.Get("Authorization") != "Bearer xoxb-token" {
+				t.Fatalf("authorization = %q, want bot token", r.Header.Get("Authorization"))
+			}
+			body, _ := io.ReadAll(r.Body)
+			if !strings.Contains(string(body), "file=F333") {
+				t.Fatalf("files.info body = %q, want file=F333", string(body))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"file": map[string]any{
+					"id":                   "F333",
+					"name":                 "photo.png",
+					"mimetype":             "image/png",
+					"url_private_download": srvURL(r) + "/file",
+					"size":                 len(raw),
+				},
+			})
+		case "/file":
+			if r.Header.Get("Authorization") != "Bearer xoxb-token" {
+				t.Fatalf("download authorization = %q, want bot token", r.Header.Get("Authorization"))
+			}
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(raw)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	api := newSlackAPI(srv.Client(), srv.URL, "xoxb-token", "xapp-token")
+	path, err := downloadSlackImageToCache(context.Background(), api, t.TempDir(), slackEventFile{
+		ID:         "F333",
+		Mode:       "file_access",
+		FileAccess: "check_file_info",
+	}, 1024*1024)
+	if err != nil {
+		t.Fatalf("downloadSlackImageToCache() error = %v", err)
+	}
+	if !filesInfoCalled {
+		t.Fatalf("files.info was not called")
+	}
+	if filepath.Ext(path) != ".png" {
+		t.Fatalf("extension = %q, want .png", filepath.Ext(path))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("downloaded content mismatch")
+	}
+}
+
 func TestDownloadSlackImageToCacheRejectsUnknownType(t *testing.T) {
 	t.Parallel()
 
@@ -57,4 +123,12 @@ func TestDownloadSlackImageToCacheRejectsUnknownType(t *testing.T) {
 	if err == nil {
 		t.Fatalf("downloadSlackImageToCache() expected error")
 	}
+}
+
+func srvURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
 }

--- a/internal/channelruntime/slack/images_test.go
+++ b/internal/channelruntime/slack/images_test.go
@@ -1,0 +1,60 @@
+package slack
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDownloadSlackImageToCache(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("png-data")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer xoxb-token" {
+			t.Fatalf("authorization = %q, want bot token", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(raw)
+	}))
+	defer srv.Close()
+
+	api := newSlackAPI(srv.Client(), "", "xoxb-token", "xapp-token")
+	path, err := downloadSlackImageToCache(context.Background(), api, t.TempDir(), slackEventFile{
+		ID:                 "F111",
+		Mimetype:           "image/png",
+		URLPrivateDownload: srv.URL + "/file",
+		Size:               int64(len(raw)),
+	}, 1024*1024)
+	if err != nil {
+		t.Fatalf("downloadSlackImageToCache() error = %v", err)
+	}
+	if filepath.Ext(path) != ".png" {
+		t.Fatalf("extension = %q, want .png", filepath.Ext(path))
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != string(raw) {
+		t.Fatalf("downloaded content mismatch")
+	}
+}
+
+func TestDownloadSlackImageToCacheRejectsUnknownType(t *testing.T) {
+	t.Parallel()
+
+	api := newSlackAPI(http.DefaultClient, "", "xoxb-token", "xapp-token")
+	_, err := downloadSlackImageToCache(context.Background(), api, t.TempDir(), slackEventFile{
+		ID:                 "F111",
+		Mimetype:           "application/octet-stream",
+		URLPrivateDownload: "https://files.slack.test/file",
+		Size:               10,
+	}, 1024*1024)
+	if err == nil {
+		t.Fatalf("downloadSlackImageToCache() expected error")
+	}
+}

--- a/internal/channelruntime/slack/runtime.go
+++ b/internal/channelruntime/slack/runtime.go
@@ -50,6 +50,7 @@ type RunOptions struct {
 	MemoryShortTermDays           int
 	MemoryInjectionEnabled        bool
 	MemoryInjectionMaxItems       int
+	ImageRecognitionEnabled       bool
 	Hooks                         Hooks
 	InspectPrompt                 bool
 	InspectRequest                bool
@@ -75,6 +76,7 @@ type slackJob struct {
 	Username        string
 	DisplayName     string
 	Text            string
+	ImagePaths      []string
 	WorkspaceDir    string
 	SentAt          time.Time
 	Version         uint64
@@ -301,6 +303,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 		MemoryEnabled:           opts.MemoryEnabled,
 		MemoryInjectionEnabled:  opts.MemoryInjectionEnabled,
 		MemoryInjectionMaxItems: opts.MemoryInjectionMaxItems,
+		ImageRecognitionEnabled: opts.ImageRecognitionEnabled,
 		MemoryOrchestrator:      memRuntime.Orchestrator,
 		MemoryProjectionWorker:  memRuntime.ProjectionWorker,
 	}
@@ -651,6 +654,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 				Username:        inbound.Username,
 				DisplayName:     inbound.DisplayName,
 				Text:            text,
+				ImagePaths:      append([]string(nil), inbound.ImagePaths...),
 				WorkspaceDir:    workspaceDir,
 				SentAt:          inbound.SentAt,
 				Version:         version,
@@ -774,6 +778,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 			Text:            event.Text,
 			SentAt:          event.SentAt,
 			MentionUsers:    append([]string(nil), event.MentionUsers...),
+			ImagePaths:      append([]string(nil), event.ImagePaths...),
 		}))
 		history[historyScopeKey] = trimChatHistoryItems(cur, slackHistoryCapForMode(groupTriggerMode))
 		mu.Unlock()
@@ -823,6 +828,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 			}
 			logger.Info("slack_inbound_event",
 				"event_type", event.EventType,
+				"event_subtype", event.EventSubtype,
 				"event_id", event.EventID,
 				"team_id", event.TeamID,
 				"channel_id", event.ChannelID,
@@ -830,6 +836,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 				"user_id", event.UserID,
 				"message_ts", event.MessageTS,
 				"thread_ts", event.ThreadTS,
+				"image_file_count", len(event.ImageFiles),
 				"is_app_mention", event.IsAppMention,
 				"is_thread_message", event.IsThreadMessage,
 			)
@@ -868,6 +875,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 			}
 			event.Username = username
 			event.DisplayName = displayName
+			event.Text = slackImageFallbackText(event.Text, taskRuntimeOpts.ImageRecognitionEnabled, len(event.ImageFiles))
 			handledCommand, cmdErr := maybeHandleSlackCommand(context.Background(), d, inprocBus, workspaceStore, conversationKey, event, botUserID)
 			if cmdErr != nil {
 				logger.Warn("slack_command_error",
@@ -940,12 +948,54 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 					return nil
 				}
 				if !accepted {
+					logger.Info("slack_group_ignored",
+						"team_id", event.TeamID,
+						"channel_id", event.ChannelID,
+						"message_ts", event.MessageTS,
+						"thread_ts", event.ThreadTS,
+						"text_len", len(event.Text),
+						"image_file_count", len(event.ImageFiles),
+						"llm_attempted", dec.AddressingLLMAttempted,
+						"llm_ok", dec.AddressingLLMOK,
+						"llm_addressed", dec.Addressing.Addressed,
+						"confidence", dec.Addressing.Confidence,
+						"wanna_interject", dec.Addressing.WannaInterject,
+						"interject", dec.Addressing.Interject,
+						"impulse", dec.Addressing.Impulse,
+						"is_lightweight", dec.Addressing.IsLightweight,
+						"reason", dec.Reason,
+					)
 					if strings.EqualFold(groupTriggerMode, "talkative") {
 						appendIgnoredInboundHistory(event)
 					}
 					return nil
 				}
 				event.ThreadTS = quoteReplyThreadTSForGroupTrigger(event, dec)
+			}
+			if taskRuntimeOpts.ImageRecognitionEnabled && len(event.ImageFiles) > 0 {
+				imageCacheDir := slackImageCacheDir(fileCacheDir)
+				for _, file := range event.ImageFiles {
+					if len(event.ImagePaths) >= slackLLMMaxImages {
+						break
+					}
+					imageCtx, cancelImage := slackImageDownloadContext(context.Background())
+					path, imageErr := downloadSlackImageToCache(imageCtx, api, imageCacheDir, file, slackLLMMaxImageBytes)
+					cancelImage()
+					if imageErr != nil {
+						logger.Warn("slack_image_download_failed",
+							"team_id", event.TeamID,
+							"channel_id", event.ChannelID,
+							"message_ts", event.MessageTS,
+							"file_id", strings.TrimSpace(file.ID),
+							"error", imageErr.Error(),
+						)
+						continue
+					}
+					event.ImagePaths = append(event.ImagePaths, path)
+				}
+				if len(event.ImagePaths) == 0 {
+					event.Text = appendSlackImageReadFailure(event.Text)
+				}
 			}
 
 			accepted, err := slackInboundAdapter.HandleInboundMessage(context.Background(), slackbus.InboundMessage{
@@ -961,6 +1011,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 				SentAt:       event.SentAt,
 				MentionUsers: append([]string(nil), event.MentionUsers...),
 				EventID:      event.EventID,
+				ImagePaths:   append([]string(nil), event.ImagePaths...),
 			})
 			if err != nil {
 				logger.Warn("slack_bus_publish_error", "channel_id", event.ChannelID, "message_ts", event.MessageTS, "bus_error_code", busErrorCodeString(err), "error", err.Error())

--- a/internal/channelruntime/slack/runtime_options.go
+++ b/internal/channelruntime/slack/runtime_options.go
@@ -31,6 +31,7 @@ type runtimeLoopOptions struct {
 	MemoryShortTermDays           int
 	MemoryInjectionEnabled        bool
 	MemoryInjectionMaxItems       int
+	ImageRecognitionEnabled       bool
 	InspectPrompt                 bool
 	InspectRequest                bool
 	TaskStore                     daemonruntime.TaskView
@@ -64,6 +65,7 @@ func resolveRuntimeLoopOptionsFromRunOptions(opts RunOptions) runtimeLoopOptions
 		MemoryShortTermDays:     opts.MemoryShortTermDays,
 		MemoryInjectionEnabled:  opts.MemoryInjectionEnabled,
 		MemoryInjectionMaxItems: opts.MemoryInjectionMaxItems,
+		ImageRecognitionEnabled: opts.ImageRecognitionEnabled,
 		InspectPrompt:           opts.InspectPrompt,
 		InspectRequest:          opts.InspectRequest,
 		TaskStore:               opts.TaskStore,

--- a/internal/channelruntime/slack/runtime_task.go
+++ b/internal/channelruntime/slack/runtime_task.go
@@ -3,12 +3,14 @@ package slack
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/quailyquaily/mistermorph/agent"
 	busruntime "github.com/quailyquaily/mistermorph/internal/bus"
+	"github.com/quailyquaily/mistermorph/internal/channelruntime/imageinput"
 	"github.com/quailyquaily/mistermorph/internal/channelruntime/taskruntime"
 	"github.com/quailyquaily/mistermorph/internal/chathistory"
 	"github.com/quailyquaily/mistermorph/internal/idempotency"
@@ -30,6 +32,7 @@ type runtimeTaskOptions struct {
 	MemoryEnabled           bool
 	MemoryInjectionEnabled  bool
 	MemoryInjectionMaxItems int
+	ImageRecognitionEnabled bool
 	MemoryOrchestrator      *memoryruntime.Orchestrator
 	MemoryProjectionWorker  *memoryruntime.ProjectionWorker
 }
@@ -59,7 +62,12 @@ func runSlackTask(
 	if task == "" {
 		return nil, nil, nil, nil, fmt.Errorf("empty slack task")
 	}
-	historyMsg, currentMsg, err := buildSlackPromptMessages(history, job)
+	mainRoute, err := rt.ResolveMainRouteForRun()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	mainModel := strings.TrimSpace(mainRoute.ClientConfig.Model)
+	historyMsg, currentMsg, err := buildSlackPromptMessages(history, job, mainModel, runtimeOpts.ImageRecognitionEnabled, logger)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -130,6 +138,7 @@ func runSlackTask(
 	}
 	result, err := rt.Run(ctx, taskruntime.RunRequest{
 		Task:           task,
+		Model:          mainModel,
 		Scene:          "slack.loop",
 		History:        llmHistory,
 		Meta:           meta,
@@ -165,7 +174,7 @@ func runSlackTask(
 	return result.Final, result.Context, result.LoadedSkills, reaction, nil
 }
 
-func buildSlackPromptMessages(history []chathistory.ChatHistoryItem, job slackJob) (*llm.Message, *llm.Message, error) {
+func buildSlackPromptMessages(history []chathistory.ChatHistoryItem, job slackJob, model string, imageRecognitionEnabled bool, logger *slog.Logger) (*llm.Message, *llm.Message, error) {
 	historyRaw, err := chathistory.RenderHistoryContext(chathistory.ChannelSlack, history)
 	if err != nil {
 		return nil, nil, fmt.Errorf("render slack history context: %w", err)
@@ -179,7 +188,19 @@ func buildSlackPromptMessages(history []chathistory.ChatHistoryItem, job slackJo
 	if err != nil {
 		return nil, nil, fmt.Errorf("render slack current message: %w", err)
 	}
-	current := llm.Message{Role: "user", Content: currentRaw}
+	imagePaths := append([]string(nil), job.ImagePaths...)
+	if !imageRecognitionEnabled {
+		imagePaths = nil
+	}
+	current, err := imageinput.BuildUserMessage(currentRaw, model, imagePaths, imageinput.MessageOptions{
+		MaxImages: slackLLMMaxImages,
+		MaxBytes:  slackLLMMaxImageBytes,
+		Logger:    logger,
+		LogPrefix: "slack",
+	})
+	if err != nil {
+		return nil, nil, err
+	}
 	return historyMsg, &current, nil
 }
 
@@ -237,8 +258,20 @@ func newSlackInboundHistoryItem(job slackJob) chathistory.ChatHistoryItem {
 		ReplyToMessageID: strings.TrimSpace(job.ThreadTS),
 		SentAt:           job.SentAt.UTC(),
 		Sender:           slackSenderFromJob(job, false, ""),
-		Text:             strings.TrimSpace(job.Text),
+		Text:             slackHistoryText(job.Text, len(job.ImagePaths)),
 	}
+}
+
+func slackHistoryText(text string, imageCount int) string {
+	text = strings.TrimSpace(text)
+	if imageCount <= 0 {
+		return text
+	}
+	marker := fmt.Sprintf("[image attachments: %d]", imageCount)
+	if text == "" {
+		return marker
+	}
+	return text + "\n" + marker
 }
 
 func newSlackOutboundAgentHistoryItem(job slackJob, output string, sentAt time.Time, botUserID string) chathistory.ChatHistoryItem {

--- a/internal/channelruntime/slack/runtime_task_test.go
+++ b/internal/channelruntime/slack/runtime_task_test.go
@@ -1,6 +1,8 @@
 package slack
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -113,7 +115,7 @@ func TestBuildSlackPromptMessagesSeparatesHistoryAndCurrent(t *testing.T) {
 		DisplayName: "Alice",
 		Text:        "latest",
 		SentAt:      time.Date(2026, 3, 8, 9, 2, 0, 0, time.UTC),
-	})
+	}, "gpt-5.2", true, nil)
 	if err != nil {
 		t.Fatalf("buildSlackPromptMessages() error = %v", err)
 	}
@@ -148,7 +150,7 @@ func TestBuildSlackPromptMessagesOmitsEmptyHistory(t *testing.T) {
 		DisplayName: "Alice",
 		Text:        "latest",
 		SentAt:      time.Date(2026, 3, 8, 9, 2, 0, 0, time.UTC),
-	})
+	}, "gpt-5.2", false, nil)
 	if err != nil {
 		t.Fatalf("buildSlackPromptMessages() error = %v", err)
 	}
@@ -157,6 +159,45 @@ func TestBuildSlackPromptMessagesOmitsEmptyHistory(t *testing.T) {
 	}
 	if currentMsg == nil || !strings.Contains(currentMsg.Content, "\"text\": \"latest\"") {
 		t.Fatalf("current message should still be present: %#v", currentMsg)
+	}
+}
+
+func TestBuildSlackPromptMessagesWithImageParts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "image.png")
+	if err := os.WriteFile(path, []byte("png-data"), 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	historyMsg, currentMsg, err := buildSlackPromptMessages(nil, slackJob{
+		TeamID:      "T1",
+		ChannelID:   "C1",
+		ChatType:    "channel",
+		MessageTS:   "102.0001",
+		ThreadTS:    "102.0001",
+		UserID:      "U1",
+		Username:    "alice",
+		DisplayName: "Alice",
+		Text:        "latest",
+		ImagePaths:  []string{path},
+		SentAt:      time.Date(2026, 3, 8, 9, 2, 0, 0, time.UTC),
+	}, "gpt-5.2", true, nil)
+	if err != nil {
+		t.Fatalf("buildSlackPromptMessages() error = %v", err)
+	}
+	if historyMsg != nil {
+		t.Fatalf("historyMsg should be nil")
+	}
+	if currentMsg == nil {
+		t.Fatalf("currentMsg = nil")
+	}
+	if len(currentMsg.Parts) != 2 {
+		t.Fatalf("current parts len = %d, want 2", len(currentMsg.Parts))
+	}
+	if currentMsg.Parts[1].MIMEType != "image/png" {
+		t.Fatalf("image MIME = %q, want image/png", currentMsg.Parts[1].MIMEType)
 	}
 }
 

--- a/internal/channelruntime/slack/runtime_test.go
+++ b/internal/channelruntime/slack/runtime_test.go
@@ -89,6 +89,100 @@ func TestParseSlackInboundEvent_IgnoresSelfMessage(t *testing.T) {
 	}
 }
 
+func TestParseSlackInboundEventWithImageFile(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(map[string]any{
+		"team_id":  "T111",
+		"event_id": "Ev03",
+		"event": map[string]any{
+			"type":         "message",
+			"subtype":      "file_share",
+			"user":         "U111",
+			"text":         "",
+			"channel":      "D222",
+			"channel_type": "im",
+			"ts":           "1739667600.000100",
+			"files": []map[string]any{
+				{
+					"id":                   "F111",
+					"name":                 "photo.png",
+					"mimetype":             "image/png",
+					"url_private_download": "https://files.slack.test/photo.png",
+					"size":                 123,
+				},
+				{
+					"id":                   "F222",
+					"name":                 "note.txt",
+					"mimetype":             "text/plain",
+					"url_private_download": "https://files.slack.test/note.txt",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	event, ok, err := parseSlackInboundEvent(slackSocketEnvelope{
+		Type:    "events_api",
+		Payload: payload,
+	}, "U999")
+	if err != nil {
+		t.Fatalf("parseSlackInboundEvent() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("parseSlackInboundEvent() ok=false, want true")
+	}
+	if len(event.ImageFiles) != 1 {
+		t.Fatalf("image files len = %d, want 1", len(event.ImageFiles))
+	}
+	if event.EventSubtype != "file_share" {
+		t.Fatalf("event subtype = %q, want file_share", event.EventSubtype)
+	}
+	if event.ImageFiles[0].ID != "F111" {
+		t.Fatalf("image file id = %q, want F111", event.ImageFiles[0].ID)
+	}
+}
+
+func TestParseSlackInboundEventIgnoresNonImageFileShare(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(map[string]any{
+		"team_id":  "T111",
+		"event_id": "Ev04",
+		"event": map[string]any{
+			"type":         "message",
+			"subtype":      "file_share",
+			"user":         "U111",
+			"text":         "",
+			"channel":      "D222",
+			"channel_type": "im",
+			"ts":           "1739667600.000100",
+			"files": []map[string]any{
+				{
+					"id":                   "F222",
+					"name":                 "note.txt",
+					"mimetype":             "text/plain",
+					"url_private_download": "https://files.slack.test/note.txt",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	_, ok, err := parseSlackInboundEvent(slackSocketEnvelope{
+		Type:    "events_api",
+		Payload: payload,
+	}, "U999")
+	if err != nil {
+		t.Fatalf("parseSlackInboundEvent() error = %v", err)
+	}
+	if ok {
+		t.Fatalf("parseSlackInboundEvent() ok=true, want false")
+	}
+}
+
 func TestDecideSlackGroupTrigger_Strict(t *testing.T) {
 	t.Parallel()
 

--- a/internal/channelruntime/slack/runtime_test.go
+++ b/internal/channelruntime/slack/runtime_test.go
@@ -144,6 +144,53 @@ func TestParseSlackInboundEventWithImageFile(t *testing.T) {
 	}
 }
 
+func TestParseSlackInboundEventWithSlackConnectImagePlaceholder(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(map[string]any{
+		"team_id":  "T111",
+		"event_id": "Ev05",
+		"event": map[string]any{
+			"type":         "message",
+			"subtype":      "file_share",
+			"user":         "U111",
+			"text":         "",
+			"channel":      "C222",
+			"channel_type": "channel",
+			"ts":           "1739667600.000100",
+			"files": []map[string]any{
+				{
+					"id":          "F333",
+					"mode":        "file_access",
+					"file_access": "check_file_info",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	event, ok, err := parseSlackInboundEvent(slackSocketEnvelope{
+		Type:    "events_api",
+		Payload: payload,
+	}, "U999")
+	if err != nil {
+		t.Fatalf("parseSlackInboundEvent() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("parseSlackInboundEvent() ok=false, want true")
+	}
+	if len(event.ImageFiles) != 1 {
+		t.Fatalf("image files len = %d, want 1", len(event.ImageFiles))
+	}
+	if event.ImageFiles[0].ID != "F333" {
+		t.Fatalf("image file id = %q, want F333", event.ImageFiles[0].ID)
+	}
+	if !slackFileNeedsInfo(event.ImageFiles[0]) {
+		t.Fatalf("image file should require files.info")
+	}
+}
+
 func TestParseSlackInboundEventIgnoresNonImageFileShare(t *testing.T) {
 	t.Parallel()
 

--- a/internal/channelruntime/slack/slack_api.go
+++ b/internal/channelruntime/slack/slack_api.go
@@ -91,6 +91,12 @@ type slackEmojiListResponse struct {
 	Categories json.RawMessage `json:"categories,omitempty"`
 }
 
+type slackFileInfoResponse struct {
+	OK    bool           `json:"ok"`
+	Error string         `json:"error,omitempty"`
+	File  slackEventFile `json:"file,omitempty"`
+}
+
 var slackEmojiNameRegexp = regexp.MustCompile(`^[A-Za-z0-9_+\-]+$`)
 
 func (api *slackAPI) authTest(ctx context.Context) (slackAuthTestResult, error) {
@@ -231,6 +237,41 @@ func (api *slackAPI) listEmojiNames(ctx context.Context) ([]string, error) {
 	}
 	sort.Strings(names)
 	return names, nil
+}
+
+func (api *slackAPI) fileInfo(ctx context.Context, fileID string) (slackEventFile, error) {
+	if api == nil {
+		return slackEventFile{}, fmt.Errorf("slack api is not initialized")
+	}
+	fileID = strings.TrimSpace(fileID)
+	if fileID == "" {
+		return slackEventFile{}, fmt.Errorf("slack file id is required")
+	}
+	body, status, _, err := api.postAuthForm(ctx, api.botToken, "/files.info", url.Values{
+		"file": []string{fileID},
+	})
+	if err != nil {
+		return slackEventFile{}, err
+	}
+	if status < 200 || status >= 300 {
+		return slackEventFile{}, fmt.Errorf("slack files.info http %d", status)
+	}
+	var out slackFileInfoResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return slackEventFile{}, err
+	}
+	if !out.OK {
+		code := strings.TrimSpace(out.Error)
+		if code == "" {
+			code = "unknown_error"
+		}
+		return slackEventFile{}, fmt.Errorf("slack files.info failed: %s", code)
+	}
+	file := out.File
+	if strings.TrimSpace(file.ID) == "" {
+		file.ID = fileID
+	}
+	return file, nil
 }
 
 func collectSlackEmojiNamesFromCategories(raw json.RawMessage, out map[string]bool) {

--- a/internal/channelruntime/slack/socket_events.go
+++ b/internal/channelruntime/slack/socket_events.go
@@ -50,6 +50,8 @@ type slackEventFile struct {
 	ID                 string `json:"id,omitempty"`
 	Name               string `json:"name,omitempty"`
 	Title              string `json:"title,omitempty"`
+	Mode               string `json:"mode,omitempty"`
+	FileAccess         string `json:"file_access,omitempty"`
 	Mimetype           string `json:"mimetype,omitempty"`
 	Filetype           string `json:"filetype,omitempty"`
 	URLPrivate         string `json:"url_private,omitempty"`
@@ -209,7 +211,7 @@ func slackImageFilesFromEvent(files []slackEventFile) []slackEventFile {
 		id := strings.TrimSpace(file.ID)
 		url := slackFileDownloadURL(file)
 		mimeType := slackFileMIMEType(file)
-		if url == "" || !strings.HasPrefix(mimeType, "image/") {
+		if !slackFileNeedsInfo(file) && (url == "" || !strings.HasPrefix(mimeType, "image/")) {
 			continue
 		}
 		key := id
@@ -223,6 +225,14 @@ func slackImageFilesFromEvent(files []slackEventFile) []slackEventFile {
 		out = append(out, file)
 	}
 	return out
+}
+
+func slackFileNeedsInfo(file slackEventFile) bool {
+	if strings.TrimSpace(file.ID) == "" {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(file.FileAccess), "check_file_info") ||
+		strings.EqualFold(strings.TrimSpace(file.Mode), "file_access")
 }
 
 func slackFileDownloadURL(file slackEventFile) string {

--- a/internal/channelruntime/slack/socket_events.go
+++ b/internal/channelruntime/slack/socket_events.go
@@ -32,21 +32,34 @@ type slackEventsAPIPayload struct {
 }
 
 type slackEvent struct {
-	Type        string `json:"type,omitempty"`
-	Subtype     string `json:"subtype,omitempty"`
-	User        string `json:"user,omitempty"`
-	Text        string `json:"text,omitempty"`
-	Channel     string `json:"channel,omitempty"`
-	ChannelType string `json:"channel_type,omitempty"`
-	TS          string `json:"ts,omitempty"`
-	ThreadTS    string `json:"thread_ts,omitempty"`
-	BotID       string `json:"bot_id,omitempty"`
-	Team        string `json:"team,omitempty"`
-	EventTS     string `json:"event_ts,omitempty"`
+	Type        string           `json:"type,omitempty"`
+	Subtype     string           `json:"subtype,omitempty"`
+	User        string           `json:"user,omitempty"`
+	Text        string           `json:"text,omitempty"`
+	Channel     string           `json:"channel,omitempty"`
+	ChannelType string           `json:"channel_type,omitempty"`
+	TS          string           `json:"ts,omitempty"`
+	ThreadTS    string           `json:"thread_ts,omitempty"`
+	BotID       string           `json:"bot_id,omitempty"`
+	Team        string           `json:"team,omitempty"`
+	EventTS     string           `json:"event_ts,omitempty"`
+	Files       []slackEventFile `json:"files,omitempty"`
+}
+
+type slackEventFile struct {
+	ID                 string `json:"id,omitempty"`
+	Name               string `json:"name,omitempty"`
+	Title              string `json:"title,omitempty"`
+	Mimetype           string `json:"mimetype,omitempty"`
+	Filetype           string `json:"filetype,omitempty"`
+	URLPrivate         string `json:"url_private,omitempty"`
+	URLPrivateDownload string `json:"url_private_download,omitempty"`
+	Size               int64  `json:"size,omitempty"`
 }
 
 type slackInboundEvent struct {
 	EventType       string
+	EventSubtype    string
 	TeamID          string
 	ChannelID       string
 	ChatType        string
@@ -59,6 +72,8 @@ type slackInboundEvent struct {
 	EventID         string
 	SentAt          time.Time
 	MentionUsers    []string
+	ImageFiles      []slackEventFile
+	ImagePaths      []string
 	IsAppMention    bool
 	IsThreadMessage bool
 }
@@ -112,7 +127,9 @@ func parseSlackInboundEvent(envelope slackSocketEnvelope, botUserID string) (sla
 		return slackInboundEvent{}, false, nil
 	}
 	subtype := strings.TrimSpace(event.Subtype)
-	if subtype != "" {
+	text := strings.TrimSpace(event.Text)
+	imageFiles := slackImageFilesFromEvent(event.Files)
+	if !acceptSlackMessageSubtype(subtype, imageFiles) {
 		return slackInboundEvent{}, false, nil
 	}
 	if strings.TrimSpace(event.BotID) != "" {
@@ -133,8 +150,7 @@ func parseSlackInboundEvent(envelope slackSocketEnvelope, botUserID string) (sla
 	if messageTS == "" {
 		return slackInboundEvent{}, false, nil
 	}
-	text := strings.TrimSpace(event.Text)
-	if text == "" {
+	if text == "" && len(imageFiles) == 0 {
 		return slackInboundEvent{}, false, nil
 	}
 	teamID := strings.TrimSpace(payload.TeamID)
@@ -158,6 +174,7 @@ func parseSlackInboundEvent(envelope slackSocketEnvelope, botUserID string) (sla
 
 	return slackInboundEvent{
 		EventType:       eventType,
+		EventSubtype:    subtype,
 		TeamID:          teamID,
 		ChannelID:       channelID,
 		ChatType:        chatType,
@@ -168,9 +185,94 @@ func parseSlackInboundEvent(envelope slackSocketEnvelope, botUserID string) (sla
 		EventID:         strings.TrimSpace(payload.EventID),
 		SentAt:          sentAt,
 		MentionUsers:    collectSlackMentionUsers(text),
+		ImageFiles:      imageFiles,
 		IsAppMention:    isAppMention,
 		IsThreadMessage: strings.TrimSpace(event.ThreadTS) != "",
 	}, true, nil
+}
+
+func acceptSlackMessageSubtype(subtype string, imageFiles []slackEventFile) bool {
+	subtype = strings.TrimSpace(subtype)
+	if subtype == "" {
+		return true
+	}
+	return subtype == "file_share" && len(imageFiles) > 0
+}
+
+func slackImageFilesFromEvent(files []slackEventFile) []slackEventFile {
+	if len(files) == 0 {
+		return nil
+	}
+	out := make([]slackEventFile, 0, len(files))
+	seen := make(map[string]bool, len(files))
+	for _, file := range files {
+		id := strings.TrimSpace(file.ID)
+		url := slackFileDownloadURL(file)
+		mimeType := slackFileMIMEType(file)
+		if url == "" || !strings.HasPrefix(mimeType, "image/") {
+			continue
+		}
+		key := id
+		if key == "" {
+			key = url
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, file)
+	}
+	return out
+}
+
+func slackFileDownloadURL(file slackEventFile) string {
+	if url := strings.TrimSpace(file.URLPrivateDownload); url != "" {
+		return url
+	}
+	return strings.TrimSpace(file.URLPrivate)
+}
+
+func slackFileMIMEType(file slackEventFile) string {
+	mimeType := strings.TrimSpace(strings.ToLower(file.Mimetype))
+	if idx := strings.Index(mimeType, ";"); idx >= 0 {
+		mimeType = strings.TrimSpace(mimeType[:idx])
+	}
+	if mimeType != "" {
+		return mimeType
+	}
+	switch strings.ToLower(strings.TrimSpace(file.Filetype)) {
+	case "jpg", "jpeg":
+		return "image/jpeg"
+	case "png":
+		return "image/png"
+	case "webp":
+		return "image/webp"
+	case "gif":
+		return "image/gif"
+	}
+	for _, name := range []string{file.Name, file.Title, slackFileDownloadURL(file)} {
+		mimeType = slackImageMIMEFromName(name)
+		if mimeType != "" {
+			return mimeType
+		}
+	}
+	return ""
+}
+
+func slackImageMIMEFromName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case strings.HasSuffix(name, ".jpg"), strings.HasSuffix(name, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(name, ".png"):
+		return "image/png"
+	case strings.HasSuffix(name, ".webp"):
+		return "image/webp"
+	case strings.HasSuffix(name, ".gif"):
+		return "image/gif"
+	default:
+		return ""
+	}
 }
 
 func isSlackGroupChat(chatType string) bool {

--- a/internal/channelruntime/telegram/runtime_task.go
+++ b/internal/channelruntime/telegram/runtime_task.go
@@ -3,7 +3,6 @@ package telegram
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"image"
 	_ "image/gif"
@@ -11,14 +10,13 @@ import (
 	_ "image/png"
 	"io"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/nickalie/go-webpbin"
 	"github.com/quailyquaily/mistermorph/agent"
 	busruntime "github.com/quailyquaily/mistermorph/internal/bus"
+	"github.com/quailyquaily/mistermorph/internal/channelruntime/imageinput"
 	"github.com/quailyquaily/mistermorph/internal/channelruntime/taskruntime"
 	"github.com/quailyquaily/mistermorph/internal/chathistory"
 	"github.com/quailyquaily/mistermorph/internal/llmstats"
@@ -208,10 +206,7 @@ func buildTelegramPromptMessages(history []chathistory.ChatHistoryItem, job tele
 	}
 	var historyMsg *llm.Message
 	if strings.TrimSpace(historyRaw) != "" {
-		msg, buildErr := buildTelegramHistoryMessage(historyRaw, model, nil, logger)
-		if buildErr != nil {
-			return nil, nil, buildErr
-		}
+		msg := llm.Message{Role: "user", Content: historyRaw}
 		historyMsg = &msg
 	}
 
@@ -285,116 +280,27 @@ func stepByIndex(plan *agent.Plan, index int) string {
 	return strings.TrimSpace(plan.Steps[index].Step)
 }
 
-func buildTelegramHistoryMessage(content string, model string, imagePaths []string, logger *slog.Logger) (llm.Message, error) {
-	return buildTelegramCurrentMessage(content, model, imagePaths, logger)
-}
-
 func buildTelegramCurrentMessage(content string, model string, imagePaths []string, logger *slog.Logger) (llm.Message, error) {
-	msg := llm.Message{Role: "user", Content: content}
-	if !llm.ModelSupportsImageParts(model) {
-		return msg, nil
-	}
-	if len(imagePaths) == 0 {
-		return msg, nil
-	}
-	parts := make([]llm.Part, 0, 1+min(len(imagePaths), telegramLLMMaxImages))
-	if strings.TrimSpace(content) != "" {
-		parts = append(parts, llm.Part{Type: llm.PartTypeText, Text: content})
-	}
-
-	enableWebPTranscode := llm.ModelSupportsWebPTranscode(model)
-	seen := make(map[string]bool, len(imagePaths))
-	imageCount := 0
-	for _, rawPath := range imagePaths {
-		if imageCount >= telegramLLMMaxImages {
-			break
-		}
-		path := strings.TrimSpace(rawPath)
-		if path == "" || seen[path] {
-			continue
-		}
-		seen[path] = true
-
-		info, err := os.Stat(path)
-		if err != nil {
-			if logger != nil {
-				logger.Warn("telegram_image_part_skip", "path", path, "error", err.Error())
+	var transcode imageinput.TranscodeFunc
+	if llm.ModelSupportsWebPTranscode(model) {
+		transcode = func(raw []byte, mimeType string) ([]byte, string, error) {
+			if shouldTelegramTranscodeToWebP(mimeType) {
+				webpRaw, err := encodeImageToWebP(raw)
+				if err != nil {
+					return nil, "", err
+				}
+				return webpRaw, "image/webp", nil
 			}
-			continue
+			return raw, mimeType, nil
 		}
-		if info.Size() <= 0 {
-			continue
-		}
-		if info.Size() > telegramLLMMaxImageBytes {
-			return llm.Message{}, fmt.Errorf("图片太大: %s (%d bytes > %d bytes)", filepath.Base(path), info.Size(), telegramLLMMaxImageBytes)
-		}
-
-		raw, err := os.ReadFile(path)
-		if err != nil {
-			if logger != nil {
-				logger.Warn("telegram_image_part_read_error", "path", path, "error", err.Error())
-			}
-			continue
-		}
-		mimeType := telegramImageMIMEType(path)
-		if !isTelegramSupportedUploadImageMIME(mimeType) {
-			if logger != nil {
-				logger.Warn("telegram_image_part_skip_unsupported_format", "path", path, "mime_type", mimeType)
-			}
-			continue
-		}
-		if enableWebPTranscode && shouldTelegramTranscodeToWebP(mimeType) {
-			webpRaw, webpErr := encodeImageToWebP(raw)
-			if webpErr != nil {
-				return llm.Message{}, fmt.Errorf("图片转换失败: %s: %w", filepath.Base(path), webpErr)
-			}
-			raw = webpRaw
-			mimeType = "image/webp"
-		}
-
-		parts = append(parts, llm.Part{
-			Type:       llm.PartTypeImageBase64,
-			MIMEType:   mimeType,
-			DataBase64: base64.StdEncoding.EncodeToString(raw),
-		})
-		imageCount++
 	}
-	if imageCount == 0 {
-		return msg, nil
-	}
-	msg.Parts = parts
-	return msg, nil
-}
-
-func telegramImageMIMEType(path string) string {
-	ext := strings.ToLower(strings.TrimSpace(filepath.Ext(path)))
-	switch ext {
-	case ".jpg", ".jpeg":
-		return "image/jpeg"
-	case ".png":
-		return "image/png"
-	case ".webp":
-		return "image/webp"
-	case ".gif":
-		return "image/gif"
-	case ".bmp":
-		return "image/bmp"
-	case ".heic":
-		return "image/heic"
-	case ".heif":
-		return "image/heif"
-	}
-	return "image/png"
-}
-
-func isTelegramSupportedUploadImageMIME(mimeType string) bool {
-	mimeType = strings.ToLower(strings.TrimSpace(mimeType))
-	switch mimeType {
-	case "image/jpeg", "image/png", "image/webp":
-		return true
-	default:
-		return false
-	}
+	return imageinput.BuildUserMessage(content, model, imagePaths, imageinput.MessageOptions{
+		MaxImages: telegramLLMMaxImages,
+		MaxBytes:  telegramLLMMaxImageBytes,
+		Logger:    logger,
+		LogPrefix: "telegram",
+		Transcode: transcode,
+	})
 }
 
 func shouldTelegramTranscodeToWebP(mimeType string) bool {

--- a/internal/channelruntime/telegram/runtime_task_test.go
+++ b/internal/channelruntime/telegram/runtime_task_test.go
@@ -181,7 +181,7 @@ func TestTelegramPlanProgressLineForFinalStepDoesNotAppendDuplicateLine(t *testi
 	}
 }
 
-func TestBuildTelegramHistoryMessageWithImageParts(t *testing.T) {
+func TestBuildTelegramCurrentMessageWithImageParts(t *testing.T) {
 	orig := encodeImageToWebP
 	encodeImageToWebP = func(raw []byte) ([]byte, error) { return []byte("webp-bytes"), nil }
 	t.Cleanup(func() { encodeImageToWebP = orig })
@@ -192,9 +192,9 @@ func TestBuildTelegramHistoryMessageWithImageParts(t *testing.T) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	msg, err := buildTelegramHistoryMessage("history", "gpt-5.2", []string{imgPath}, nil)
+	msg, err := buildTelegramCurrentMessage("history", "gpt-5.2", []string{imgPath}, nil)
 	if err != nil {
-		t.Fatalf("buildTelegramHistoryMessage() error = %v", err)
+		t.Fatalf("buildTelegramCurrentMessage() error = %v", err)
 	}
 	if msg.Role != "user" {
 		t.Fatalf("role = %q, want user", msg.Role)
@@ -295,7 +295,7 @@ func TestBuildTelegramPromptMessagesOmitsEmptyHistory(t *testing.T) {
 	}
 }
 
-func TestBuildTelegramHistoryMessageSkipsMissingAndCapsCount(t *testing.T) {
+func TestBuildTelegramCurrentMessageSkipsMissingAndCapsCount(t *testing.T) {
 	dir := t.TempDir()
 	paths := make([]string, 0, 4)
 	for i := 0; i < 4; i++ {
@@ -306,9 +306,9 @@ func TestBuildTelegramHistoryMessageSkipsMissingAndCapsCount(t *testing.T) {
 		paths = append(paths, path)
 	}
 
-	msg, err := buildTelegramHistoryMessage("history", "grok-4", append([]string{"/missing.png"}, paths...), nil)
+	msg, err := buildTelegramCurrentMessage("history", "grok-4", append([]string{"/missing.png"}, paths...), nil)
 	if err != nil {
-		t.Fatalf("buildTelegramHistoryMessage() error = %v", err)
+		t.Fatalf("buildTelegramCurrentMessage() error = %v", err)
 	}
 	if len(msg.Parts) != 4 {
 		t.Fatalf("parts len = %d, want 4 (1 text + 3 images)", len(msg.Parts))
@@ -323,16 +323,16 @@ func TestBuildTelegramHistoryMessageSkipsMissingAndCapsCount(t *testing.T) {
 	}
 }
 
-func TestBuildTelegramHistoryMessageUnsupportedModelSkipsImageParts(t *testing.T) {
+func TestBuildTelegramCurrentMessageUnsupportedModelSkipsImageParts(t *testing.T) {
 	dir := t.TempDir()
 	imgPath := filepath.Join(dir, "x.jpg")
 	if err := os.WriteFile(imgPath, []byte("abc"), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	msg, err := buildTelegramHistoryMessage("history", "qwen-max", []string{imgPath}, nil)
+	msg, err := buildTelegramCurrentMessage("history", "qwen-max", []string{imgPath}, nil)
 	if err != nil {
-		t.Fatalf("buildTelegramHistoryMessage() error = %v", err)
+		t.Fatalf("buildTelegramCurrentMessage() error = %v", err)
 	}
 	if len(msg.Parts) != 0 {
 		t.Fatalf("parts len = %d, want 0", len(msg.Parts))
@@ -342,7 +342,7 @@ func TestBuildTelegramHistoryMessageUnsupportedModelSkipsImageParts(t *testing.T
 	}
 }
 
-func TestBuildTelegramHistoryMessageReturnsErrorWhenImageTooLarge(t *testing.T) {
+func TestBuildTelegramCurrentMessageReturnsErrorWhenImageTooLarge(t *testing.T) {
 	orig := encodeImageToWebP
 	encodeImageToWebP = func(raw []byte) ([]byte, error) { return raw, nil }
 	t.Cleanup(func() { encodeImageToWebP = orig })
@@ -359,16 +359,16 @@ func TestBuildTelegramHistoryMessageReturnsErrorWhenImageTooLarge(t *testing.T) 
 	}
 	_ = f.Close()
 
-	_, err = buildTelegramHistoryMessage("history", "gpt-5.2", []string{imgPath}, nil)
+	_, err = buildTelegramCurrentMessage("history", "gpt-5.2", []string{imgPath}, nil)
 	if err == nil {
-		t.Fatalf("buildTelegramHistoryMessage() expected error")
+		t.Fatalf("buildTelegramCurrentMessage() expected error")
 	}
 	if !strings.Contains(err.Error(), "图片太大") {
 		t.Fatalf("error = %q, want contains 图片太大", err.Error())
 	}
 }
 
-func TestBuildTelegramHistoryMessageUsesWebPForSupportedModel(t *testing.T) {
+func TestBuildTelegramCurrentMessageUsesWebPForSupportedModel(t *testing.T) {
 	orig := encodeImageToWebP
 	encodeImageToWebP = func(raw []byte) ([]byte, error) { return []byte("webp-bytes"), nil }
 	t.Cleanup(func() { encodeImageToWebP = orig })
@@ -379,9 +379,9 @@ func TestBuildTelegramHistoryMessageUsesWebPForSupportedModel(t *testing.T) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	msg, err := buildTelegramHistoryMessage("history", "gpt-5.2", []string{imgPath}, nil)
+	msg, err := buildTelegramCurrentMessage("history", "gpt-5.2", []string{imgPath}, nil)
 	if err != nil {
-		t.Fatalf("buildTelegramHistoryMessage() error = %v", err)
+		t.Fatalf("buildTelegramCurrentMessage() error = %v", err)
 	}
 	if len(msg.Parts) != 2 {
 		t.Fatalf("parts len = %d, want 2", len(msg.Parts))
@@ -394,7 +394,7 @@ func TestBuildTelegramHistoryMessageUsesWebPForSupportedModel(t *testing.T) {
 	}
 }
 
-func TestBuildTelegramHistoryMessageDoesNotForceWebPForUnsupportedModel(t *testing.T) {
+func TestBuildTelegramCurrentMessageDoesNotForceWebPForUnsupportedModel(t *testing.T) {
 	orig := encodeImageToWebP
 	encodeImageToWebP = func(raw []byte) ([]byte, error) { return []byte("unexpected"), nil }
 	t.Cleanup(func() { encodeImageToWebP = orig })
@@ -405,9 +405,9 @@ func TestBuildTelegramHistoryMessageDoesNotForceWebPForUnsupportedModel(t *testi
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	msg, err := buildTelegramHistoryMessage("history", "grok-4", []string{imgPath}, nil)
+	msg, err := buildTelegramCurrentMessage("history", "grok-4", []string{imgPath}, nil)
 	if err != nil {
-		t.Fatalf("buildTelegramHistoryMessage() error = %v", err)
+		t.Fatalf("buildTelegramCurrentMessage() error = %v", err)
 	}
 	if len(msg.Parts) != 2 {
 		t.Fatalf("parts len = %d, want 2", len(msg.Parts))
@@ -420,7 +420,7 @@ func TestBuildTelegramHistoryMessageDoesNotForceWebPForUnsupportedModel(t *testi
 	}
 }
 
-func TestBuildTelegramHistoryMessageSkipsUnsupportedImageFormats(t *testing.T) {
+func TestBuildTelegramCurrentMessageSkipsUnsupportedImageFormats(t *testing.T) {
 	orig := encodeImageToWebP
 	encodeImageToWebP = func(raw []byte) ([]byte, error) { return []byte("unexpected"), nil }
 	t.Cleanup(func() { encodeImageToWebP = orig })
@@ -430,10 +430,14 @@ func TestBuildTelegramHistoryMessageSkipsUnsupportedImageFormats(t *testing.T) {
 	if err := os.WriteFile(gifPath, []byte("gif-bytes"), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
+	unknownPath := filepath.Join(dir, "x.bin")
+	if err := os.WriteFile(unknownPath, []byte("unknown-bytes"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
 
-	msg, err := buildTelegramHistoryMessage("history", "gpt-5.2", []string{gifPath}, nil)
+	msg, err := buildTelegramCurrentMessage("history", "gpt-5.2", []string{gifPath, unknownPath}, nil)
 	if err != nil {
-		t.Fatalf("buildTelegramHistoryMessage() error = %v", err)
+		t.Fatalf("buildTelegramCurrentMessage() error = %v", err)
 	}
 	if len(msg.Parts) != 0 {
 		t.Fatalf("parts len = %d, want 0", len(msg.Parts))


### PR DESCRIPTION
Summary:
- Add image attachment ingestion for Slack and Lark.
- Share multimodal message building across channel runtimes.
- Update config docs and tests for multimodal image sources.

Tests:
- go test ./...