### PR TITLE
fix(agent): ensure non-empty message content for strict API providers

### DIFF
--- a/agent/engine_loop.go
+++ b/agent/engine_loop.go
@@ -280,9 +280,13 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (*Final, *Con
 				assistantTextAdded = true
 			}
 			if !assistantTextAdded {
+				content := result.Text
+				if strings.TrimSpace(content) == "" {
+					content = " "
+				}
 				st.messages = append(st.messages, llm.Message{
 					Role:      "assistant",
-					Content:   result.Text,
+					Content:   content,
 					ToolCalls: result.ToolCalls,
 				})
 				assistantTextAdded = true
@@ -527,6 +531,9 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (*Final, *Con
 				observationForModel := item.observation
 				if item.err == nil && isUntrustedTool(tc.Name) {
 					observationForModel = wrapUntrustedToolObservation(tc.Name, item.observation)
+				}
+				if strings.TrimSpace(observationForModel) == "" {
+					observationForModel = "(no output)"
 				}
 
 				if strings.TrimSpace(tc.ID) != "" {


### PR DESCRIPTION
Some API providers (e.g., ByteDance ARK) reject LLM requests when `messages.content` is an empty string. This happens when:

1. The assistant returns a tool call without any accompanying text — `result.Text` is empty.
2. A tool execution produces no observable output — `observation` is empty.

**Changes:**

- Assistant messages: fill with a single space `" "` when `result.Text` is empty.
- Tool messages: fill with `\"(no output)\"` when observation is empty.

This is a minimal compatibility fix that doesn't affect behavior for providers that already tolerate empty content (e.g., Anthropic official API, AWS Bedrock).