### PR TITLE
将 CLI 颜色统一，并对聊天交互、diff 渲染等 UI 做了多项改进。同时包含 `root.go` 的重复代码清理。

### DIFF
--- a/cmd/mistermorph/chatcmd/agents.go
+++ b/cmd/mistermorph/chatcmd/agents.go
@@ -43,7 +43,7 @@ func handleAgentsGenerate(
 	agentsPath := filepath.Join(projectDir, "AGENTS.md")
 	isUpdate := strings.ToLower(input) == "/update"
 	if isUpdate {
-		_, _ = fmt.Fprintln(writer, "\033[33m⚙️  Regenerating AGENTS.md...\033[0m")
+		_, _ = fmt.Fprintln(writer, "\033[38;5;245m⚙️  Regenerating AGENTS.md...\033[0m")
 	}
 	stopInitAnim, _ := thinkingAnimation(writer)
 	initCtx, initCancel := context.WithCancel(context.Background())
@@ -85,7 +85,7 @@ IMPORTANT: Do NOT use the write_file tool. Instead, write the final AGENTS.md co
 	initCancel()
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			_, _ = fmt.Fprintln(writer, "\n\033[33m⚡ Interrupted.\033[0m")
+			_, _ = fmt.Fprintln(writer, "\n\033[38;5;245m⚡ Interrupted.\033[0m")
 			return history, false
 		}
 		_, _ = fmt.Fprintf(writer, "Error generating AGENTS.md: %v\n", err)
@@ -102,9 +102,9 @@ IMPORTANT: Do NOT use the write_file tool. Instead, write the final AGENTS.md co
 		return history, false
 	}
 	if isUpdate {
-		_, _ = fmt.Fprintf(writer, "\033[32m✓ AGENTS.md updated at %s\033[0m\n", agentsPath)
+		_, _ = fmt.Fprintf(writer, "\033[38;5;245m✓ AGENTS.md updated at %s\033[0m\n", agentsPath)
 	} else {
-		_, _ = fmt.Fprintf(writer, "\033[32m✓ AGENTS.md created at %s\033[0m\n", agentsPath)
+		_, _ = fmt.Fprintf(writer, "\033[38;5;245m✓ AGENTS.md created at %s\033[0m\n", agentsPath)
 	}
 	_, _ = fmt.Fprintln(writer, "\n--- AGENTS.md ---")
 	_, _ = fmt.Fprintln(writer, content)

--- a/cmd/mistermorph/chatcmd/modelcmd.go
+++ b/cmd/mistermorph/chatcmd/modelcmd.go
@@ -44,6 +44,6 @@ func handleModelCommand(
 		_, _ = fmt.Fprintf(writer, "error rebuilding client: %v\n", err)
 		return nil, llmconfig.ClientConfig{}, false
 	}
-	_, _ = fmt.Fprintf(writer, "\033[33m[active model: %s]\033[0m\n", newCfg.Model)
+	_, _ = fmt.Fprintf(writer, "\033[38;5;245m[active model: %s]\033[0m\n", newCfg.Model)
 	return newClient, newCfg, true
 }

--- a/cmd/mistermorph/chatcmd/repl.go
+++ b/cmd/mistermorph/chatcmd/repl.go
@@ -143,7 +143,7 @@ func runREPL(sess *chatSession) error {
 		turnCancel()
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
-				_, _ = fmt.Fprintln(writer, "\n\033[33m⚡ Interrupted.\033[0m")
+				_, _ = fmt.Fprintln(writer, "\n\033[38;5;245m⚡ Interrupted.\033[0m")
 				continue
 			}
 			displayErr := strings.TrimSpace(outputfmt.FormatErrorForDisplay(err))
@@ -156,11 +156,7 @@ func runREPL(sess *chatSession) error {
 
 		rawOutput := formatRawChatOutput(final)
 		displayOutput := formatChatOutput(final)
-		if sess.compactMode {
-			_, _ = fmt.Fprintf(writer, "%s\n", displayOutput)
-		} else {
-			_, _ = fmt.Fprintf(writer, "\033[43m\033[30m %s> \033[0m %s\n", sess.agentName, displayOutput)
-		}
+		_, _ = fmt.Fprintf(writer, "%s\n", displayOutput)
 
 		history = append(history,
 			llm.Message{Role: "user", Content: input},

--- a/cmd/mistermorph/chatcmd/session.go
+++ b/cmd/mistermorph/chatcmd/session.go
@@ -412,7 +412,7 @@ func buildChatSession(cmd *cobra.Command, deps Dependencies) (*chatSession, erro
 			return
 		}
 		writer := sess.currentWriter()
-		msg := fmt.Sprintf("\x1b[33m  used \x1b[32m%s\x1b[0m", toolName)
+		msg := fmt.Sprintf("\x1b[38;5;245m  used %s\x1b[0m", toolName)
 		_, _ = fmt.Fprintf(writer, "\r\033[K%s\n", msg)
 	}))
 	opts = append(opts, agent.WithPlanStepUpdate(func(runCtx *agent.Context, update agent.PlanStepUpdate) {
@@ -420,9 +420,20 @@ func buildChatSession(cmd *cobra.Command, deps Dependencies) (*chatSession, erro
 			return
 		}
 		logger.Debug("plan_step_update_callback", "completedIndex", update.CompletedIndex, "startedIndex", update.StartedIndex, "startedStep", update.StartedStep, "reason", update.Reason)
-		payload := formatPlanProgressUpdate(runCtx, update)
-		if payload != "" {
-			sess.setThinkingMessage(payload)
+		if update.StartedIndex >= 0 && update.StartedStep != "" {
+			// Step started: stop spinner, print plan text safely, then restart.
+			sess.stopThinkingAnimation()
+			writer := sess.currentWriter()
+			total := 0
+			if runCtx != nil && runCtx.Plan != nil {
+				total = len(runCtx.Plan.Steps)
+			}
+			_, _ = fmt.Fprintf(writer, "\033[38;5;245m → plan: %s", update.StartedStep)
+			if total > 0 {
+				_, _ = fmt.Fprintf(writer, " [%d/%d]", update.StartedIndex+1, total)
+			}
+			_, _ = fmt.Fprint(writer, "\033[0m\n")
+			sess.startThinkingAnimation()
 		} else if update.CompletedIndex >= 0 && update.CompletedStep != "" {
 			sess.stopThinkingAnimation()
 			writer := sess.currentWriter()
@@ -430,7 +441,7 @@ func buildChatSession(cmd *cobra.Command, deps Dependencies) (*chatSession, erro
 			if runCtx != nil && runCtx.Plan != nil {
 				total = len(runCtx.Plan.Steps)
 			}
-			_, _ = fmt.Fprintf(writer, "\033[32mplan: ✓ %s", update.CompletedStep)
+			_, _ = fmt.Fprintf(writer, "\033[38;5;245m → plan: ✓ %s", update.CompletedStep)
 			if total > 0 {
 				_, _ = fmt.Fprintf(writer, " [%d/%d]", update.CompletedIndex+1, total)
 			}
@@ -482,7 +493,9 @@ func buildChatSession(cmd *cobra.Command, deps Dependencies) (*chatSession, erro
 				}
 				diff := clifmt.RenderDiff(resolvedPath, "", string(newData))
 				if diff != "" {
+					sess.stopThinkingAnimation()
 					_, _ = fmt.Fprintln(writer, diff)
+					sess.startThinkingAnimation()
 				}
 				return
 			}
@@ -496,7 +509,9 @@ func buildChatSession(cmd *cobra.Command, deps Dependencies) (*chatSession, erro
 			}
 			diff := clifmt.RenderDiff(resolvedPath, oldContent, newContent)
 			if diff != "" {
+				sess.stopThinkingAnimation()
 				_, _ = fmt.Fprintln(writer, diff)
+				sess.startThinkingAnimation()
 			}
 		}
 	}))

--- a/cmd/mistermorph/chatcmd/ui.go
+++ b/cmd/mistermorph/chatcmd/ui.go
@@ -33,11 +33,8 @@ func buildUserName() string {
 	return userName
 }
 
-func buildUserPrompt(compactMode bool, userName string) string {
-	if compactMode {
-		return "\033[32m• \033[0m"
-	}
-	return fmt.Sprintf("\033[42m\033[30m %s> \033[0m ", userName)
+func buildUserPrompt(_ bool, _ string) string {
+	return "\033[32m• \033[0m"
 }
 
 func thinkingAnimation(writer io.Writer) (stop func(), setMessage func(msg string)) {
@@ -52,7 +49,11 @@ func thinkingAnimation(writer io.Writer) (stop func(), setMessage func(msg strin
 	lastLines := 1
 
 	calcLines := func(text string) int {
-		width, _, _ := term.GetSize(int(os.Stdout.Fd()))
+		fd := int(os.Stdout.Fd())
+		if f, ok := writer.(*os.File); ok {
+			fd = int(f.Fd())
+		}
+		width, _, _ := term.GetSize(fd)
 		if width <= 0 {
 			width = 80
 		}
@@ -70,7 +71,7 @@ func thinkingAnimation(writer io.Writer) (stop func(), setMessage func(msg strin
 
 	buildClearSeq := func(n int) string {
 		if n <= 1 {
-			return "\r\033[K"
+			return "\r\033[2K"
 		}
 		var b strings.Builder
 		for i := 1; i < n; i++ {
@@ -107,7 +108,7 @@ func thinkingAnimation(writer io.Writer) (stop func(), setMessage func(msg strin
 				lastLinesMu.Unlock()
 
 				clearSeq := buildClearSeq(prevLines)
-				_, _ = fmt.Fprintf(writer, "%s\033[92m%s\033[0m \033[33m%s\033[0m", clearSeq, spinner[i%len(spinner)], currentMsg)
+				_, _ = fmt.Fprintf(writer, "%s\033[92m%s\033[0m \033[38;5;245m%s\033[0m", clearSeq, spinner[i%len(spinner)], currentMsg)
 				i++
 			case <-done:
 				return
@@ -124,10 +125,17 @@ func thinkingAnimation(writer io.Writer) (stop func(), setMessage func(msg strin
 		lastLinesMu.Unlock()
 
 		_, _ = fmt.Fprint(writer, buildClearSeq(prevLines))
+
+		msgMu.RLock()
+		currentMsg := msg
+		msgMu.RUnlock()
+		if currentMsg != "" {
+			_, _ = fmt.Fprintf(writer, "\033[38;5;245m%s\033[0m\n", currentMsg)
+		}
 	}
 	setMessage = func(newMsg string) {
 		msgMu.Lock()
-		msg = truncateString(newMsg, 80)
+		msg = newMsg
 		msgMu.Unlock()
 	}
 	return stop, setMessage
@@ -145,8 +153,5 @@ func printChatSessionHeader(writer io.Writer, compact bool, model string, worksp
 	}
 	if fileCacheDir != "" {
 		_, _ = fmt.Fprintf(writer, "\033[38;5;242mfile_cache_dir=%s\033[0m\n", fileCacheDir)
-	}
-	if !compact {
-		_, _ = fmt.Fprintln(writer, "\033[33mInteractive chat started. Press Ctrl+C or type /exit to quit.\033[0m")
 	}
 }

--- a/cmd/mistermorph/root.go
+++ b/cmd/mistermorph/root.go
@@ -86,9 +86,8 @@ func newRootCmd() *cobra.Command {
 
 	registryResolver := newRegistryRuntimeResolver()
 	guardResolver := newGuardRuntimeResolver()
-	telegramLLM := newLLMRuntimeResolver()
-	telegramSkills := newSkillsRuntimeResolver()
 
+	// Add common commands
 	cmd.AddCommand(runcmd.New(runcmd.Dependencies{
 		RegistryFromViper: registryResolver.Registry,
 		GuardFromViper:    guardResolver.Guard,
@@ -96,110 +95,6 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(chatcmd.New(chatcmd.Dependencies{
 		RegistryFromViper: registryResolver.Registry,
 		GuardFromViper:    guardResolver.Guard,
-	}))
-	cmd.AddCommand(telegramcmd.NewCommand(telegramcmd.Dependencies{
-		Dependencies: heartbeatruntime.Dependencies{
-			Logger:          logutil.LoggerFromViper,
-			LogOptions:      logutil.LogOptionsFromViper,
-			ResolveLLMRoute: telegramLLM.ResolveRoute,
-			CreateLLMClient: telegramLLM.CreateClient,
-			Registry:        registryResolver.Registry,
-			Guard:           guardResolver.Guard,
-			PromptSpec: func(ctx context.Context, logger *slog.Logger, logOpts agent.LogOptions, task string, client llm.Client, model string, stickySkills []string) (agent.PromptSpec, []string, error) {
-				cfg := telegramSkills.Config()
-				if len(stickySkills) > 0 {
-					cfg.Requested = append(cfg.Requested, stickySkills...)
-				}
-				return skillsutil.PromptSpecWithSkills(ctx, logger, logOpts, task, client, model, cfg)
-			},
-			BuildHeartbeatTask: heartbeatutil.BuildHeartbeatTask,
-			BuildHeartbeatMeta: func(source string, interval time.Duration, checklistPath string, checklistEmpty bool, extra map[string]any) map[string]any {
-				return heartbeatutil.BuildHeartbeatMeta(source, interval, checklistPath, checklistEmpty, nil, extra)
-			},
-		},
-		HandleModelCommand: func(text string) (string, bool, error) {
-			return llmselect.ExecuteCommandText(telegramLLM.Values(), llmselect.ProcessStore(), text)
-		},
-	}))
-
-	slackLLM := newLLMRuntimeResolver()
-	slackSkills := newSkillsRuntimeResolver()
-	lineLLM := newLLMRuntimeResolver()
-	lineSkills := newSkillsRuntimeResolver()
-	larkLLM := newLLMRuntimeResolver()
-	larkSkills := newSkillsRuntimeResolver()
-
-	cmd.AddCommand(slackcmd.NewCommand(slackcmd.Dependencies{
-		Dependencies: heartbeatruntime.Dependencies{
-			Logger:          logutil.LoggerFromViper,
-			LogOptions:      logutil.LogOptionsFromViper,
-			ResolveLLMRoute: slackLLM.ResolveRoute,
-			CreateLLMClient: slackLLM.CreateClient,
-			Registry:        registryResolver.Registry,
-			Guard:           guardResolver.Guard,
-			PromptSpec: func(ctx context.Context, logger *slog.Logger, logOpts agent.LogOptions, task string, client llm.Client, model string, stickySkills []string) (agent.PromptSpec, []string, error) {
-				cfg := slackSkills.Config()
-				if len(stickySkills) > 0 {
-					cfg.Requested = append(cfg.Requested, stickySkills...)
-				}
-				return skillsutil.PromptSpecWithSkills(ctx, logger, logOpts, task, client, model, cfg)
-			},
-			BuildHeartbeatTask: heartbeatutil.BuildHeartbeatTask,
-			BuildHeartbeatMeta: func(source string, interval time.Duration, checklistPath string, checklistEmpty bool, extra map[string]any) map[string]any {
-				return heartbeatutil.BuildHeartbeatMeta(source, interval, checklistPath, checklistEmpty, nil, extra)
-			},
-		},
-		HandleModelCommand: func(text string) (string, bool, error) {
-			return llmselect.ExecuteCommandText(slackLLM.Values(), llmselect.ProcessStore(), text)
-		},
-	}))
-	cmd.AddCommand(linecmd.NewCommand(linecmd.Dependencies{
-		Dependencies: heartbeatruntime.Dependencies{
-			Logger:          logutil.LoggerFromViper,
-			LogOptions:      logutil.LogOptionsFromViper,
-			ResolveLLMRoute: lineLLM.ResolveRoute,
-			CreateLLMClient: lineLLM.CreateClient,
-			Registry:        registryResolver.Registry,
-			Guard:           guardResolver.Guard,
-			PromptSpec: func(ctx context.Context, logger *slog.Logger, logOpts agent.LogOptions, task string, client llm.Client, model string, stickySkills []string) (agent.PromptSpec, []string, error) {
-				cfg := lineSkills.Config()
-				if len(stickySkills) > 0 {
-					cfg.Requested = append(cfg.Requested, stickySkills...)
-				}
-				return skillsutil.PromptSpecWithSkills(ctx, logger, logOpts, task, client, model, cfg)
-			},
-			BuildHeartbeatTask: heartbeatutil.BuildHeartbeatTask,
-			BuildHeartbeatMeta: func(source string, interval time.Duration, checklistPath string, checklistEmpty bool, extra map[string]any) map[string]any {
-				return heartbeatutil.BuildHeartbeatMeta(source, interval, checklistPath, checklistEmpty, nil, extra)
-			},
-		},
-		HandleModelCommand: func(text string) (string, bool, error) {
-			return llmselect.ExecuteCommandText(lineLLM.Values(), llmselect.ProcessStore(), text)
-		},
-	}))
-	cmd.AddCommand(larkcmd.NewCommand(larkcmd.Dependencies{
-		Dependencies: heartbeatruntime.Dependencies{
-			Logger:          logutil.LoggerFromViper,
-			LogOptions:      logutil.LogOptionsFromViper,
-			ResolveLLMRoute: larkLLM.ResolveRoute,
-			CreateLLMClient: larkLLM.CreateClient,
-			Registry:        registryResolver.Registry,
-			Guard:           guardResolver.Guard,
-			PromptSpec: func(ctx context.Context, logger *slog.Logger, logOpts agent.LogOptions, task string, client llm.Client, model string, stickySkills []string) (agent.PromptSpec, []string, error) {
-				cfg := larkSkills.Config()
-				if len(stickySkills) > 0 {
-					cfg.Requested = append(cfg.Requested, stickySkills...)
-				}
-				return skillsutil.PromptSpecWithSkills(ctx, logger, logOpts, task, client, model, cfg)
-			},
-			BuildHeartbeatTask: heartbeatutil.BuildHeartbeatTask,
-			BuildHeartbeatMeta: func(source string, interval time.Duration, checklistPath string, checklistEmpty bool, extra map[string]any) map[string]any {
-				return heartbeatutil.BuildHeartbeatMeta(source, interval, checklistPath, checklistEmpty, nil, extra)
-			},
-		},
-		HandleModelCommand: func(text string) (string, bool, error) {
-			return llmselect.ExecuteCommandText(larkLLM.Values(), llmselect.ProcessStore(), text)
-		},
 	}))
 	cmd.AddCommand(newToolsCmd(registryResolver.Registry))
 	cmd.AddCommand(newAuthCmd())
@@ -210,7 +105,60 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newInstallCmd())
 	cmd.AddCommand(newVersionCmd())
 
+	// Add channel commands
+	hbDeps, hbValues := channelDependencies(registryResolver, guardResolver)
+	cmd.AddCommand(telegramcmd.NewCommand(telegramcmd.Dependencies{
+		Dependencies: hbDeps,
+		HandleModelCommand: func(text string) (string, bool, error) {
+			return llmselect.ExecuteCommandText(hbValues, llmselect.ProcessStore(), text)
+		},
+	}))
+	cmd.AddCommand(slackcmd.NewCommand(slackcmd.Dependencies{
+		Dependencies: hbDeps,
+		HandleModelCommand: func(text string) (string, bool, error) {
+			return llmselect.ExecuteCommandText(hbValues, llmselect.ProcessStore(), text)
+		},
+	}))
+	cmd.AddCommand(linecmd.NewCommand(linecmd.Dependencies{
+		Dependencies: hbDeps,
+		HandleModelCommand: func(text string) (string, bool, error) {
+			return llmselect.ExecuteCommandText(hbValues, llmselect.ProcessStore(), text)
+		},
+	}))
+	cmd.AddCommand(larkcmd.NewCommand(larkcmd.Dependencies{
+		Dependencies: hbDeps,
+		HandleModelCommand: func(text string) (string, bool, error) {
+			return llmselect.ExecuteCommandText(hbValues, llmselect.ProcessStore(), text)
+		},
+	}))
+
 	return cmd
+}
+
+// channelDependencies creates heartbeat runtime dependencies for channel commands
+func channelDependencies(regResolver *registryRuntimeResolver, guardResolver *guardRuntimeResolver) (heartbeatruntime.Dependencies, llmutil.RuntimeValues) {
+	llmResolver := newLLMRuntimeResolver()
+	skillsResolver := newSkillsRuntimeResolver()
+
+	return heartbeatruntime.Dependencies{
+		Logger:          logutil.LoggerFromViper,
+		LogOptions:      logutil.LogOptionsFromViper,
+		ResolveLLMRoute: llmResolver.ResolveRoute,
+		CreateLLMClient: llmResolver.CreateClient,
+		Registry:        regResolver.Registry,
+		Guard:           guardResolver.Guard,
+		PromptSpec: func(ctx context.Context, logger *slog.Logger, logOpts agent.LogOptions, task string, client llm.Client, model string, stickySkills []string) (agent.PromptSpec, []string, error) {
+			cfg := skillsResolver.Config()
+			if len(stickySkills) > 0 {
+				cfg.Requested = append(cfg.Requested, stickySkills...)
+			}
+			return skillsutil.PromptSpecWithSkills(ctx, logger, logOpts, task, client, model, cfg)
+		},
+		BuildHeartbeatTask: heartbeatutil.BuildHeartbeatTask,
+		BuildHeartbeatMeta: func(source string, interval time.Duration, checklistPath string, checklistEmpty bool, extra map[string]any) map[string]any {
+			return heartbeatutil.BuildHeartbeatMeta(source, interval, checklistPath, checklistEmpty, nil, extra)
+		},
+	}, llmResolver.Values()
 }
 
 func initConfig() {

--- a/internal/clifmt/clifmt.go
+++ b/internal/clifmt/clifmt.go
@@ -12,15 +12,15 @@ func Headerf(format string, args ...any) string {
 	if !useColor() {
 		return text
 	}
-	return "\x1b[1;36m" + text + "\x1b[0m"
+	return "\x1b[38;5;245m" + text + "\x1b[0m"
 }
 
 func Success(text string) string {
-	return colorize("32", text)
+	return colorize("90", text)
 }
 
 func Warn(text string) string {
-	return colorize("33", text)
+	return colorize("90", text)
 }
 
 func Dim(text string) string {
@@ -28,7 +28,7 @@ func Dim(text string) string {
 }
 
 func Key(text string) string {
-	return colorize("1;33", text)
+	return colorize("90", text)
 }
 
 func colorize(code string, text string) string {

--- a/internal/clifmt/diff.go
+++ b/internal/clifmt/diff.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/mattn/go-runewidth"
@@ -14,6 +15,22 @@ import (
 
 // ansiBgRe matches ANSI escape sequences that set or reset background colors.
 var ansiBgRe = regexp.MustCompile("\x1b\\[(?:4[0-8]|10[0-7]|49)(?:;[^m]*)?m")
+
+// getTermWidth returns the terminal width using multiple fallbacks:
+// 1. term.GetSize on stdout, 2. COLUMNS env var, 3. fixed default.
+func getTermWidth() int {
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+			return w
+		}
+	}
+	if cols := os.Getenv("COLUMNS"); cols != "" {
+		if w, err := strconv.Atoi(cols); err == nil && w > 0 {
+			return w
+		}
+	}
+	return 0
+}
 
 // reapplyBgBeforeWideChars re-emits the bg ANSI sequence immediately before
 // every double-width (CJK) rune in text. Some terminals fail to fill the
@@ -291,25 +308,22 @@ func RenderDiff(path, oldContent, newContent string) string {
 		}
 	}
 
-	termWidth := 0
-	if term.IsTerminal(int(os.Stdout.Fd())) {
-		if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
-			termWidth = w
-		}
-	}
+	termWidth := getTermWidth()
 
 	var b strings.Builder
 
+	white := ""
 	gray := ""
 	if color {
-		gray = "\x1b[38;5;250m"
+		white = "\x1b[37m"
+		gray = "\x1b[38;5;245m"
 	}
 
 	// File header
 	if color {
-		b.WriteString(fmt.Sprintf("%s%s\x1b[0m\n", gray, path))
+		b.WriteString(fmt.Sprintf("\n%s%s\x1b[0m\n", white, path))
 	} else {
-		b.WriteString(path + "\n")
+		b.WriteString("\n" + path + "\n")
 	}
 
 	for _, dl := range folded {
@@ -355,10 +369,11 @@ func RenderDiff(path, oldContent, newContent string) string {
 				safeText = strings.ReplaceAll(safeText, "\x1b[0m", "\x1b[39m"+bg+fg)
 				safeText = reapplyBgBeforeWideChars(safeText, bg)
 				b.WriteString(safeText)
+				b.WriteString(bg)
+				b.WriteString("\x1b[K")
 				if termWidth > 0 {
 					used := gutterWidth + 3 + visibleWidth(safeText)
 					if pad := termWidth - used; pad > 0 {
-						b.WriteString(bg)
 						b.WriteString(strings.Repeat(" ", pad))
 					}
 				}
@@ -376,10 +391,11 @@ func RenderDiff(path, oldContent, newContent string) string {
 				safeText = strings.ReplaceAll(safeText, "\x1b[0m", "\x1b[39m"+bg+fg)
 				safeText = reapplyBgBeforeWideChars(safeText, bg)
 				b.WriteString(safeText)
+				b.WriteString(bg)
+				b.WriteString("\x1b[K")
 				if termWidth > 0 {
 					used := gutterWidth + 3 + visibleWidth(safeText)
 					if pad := termWidth - used; pad > 0 {
-						b.WriteString(bg)
 						b.WriteString(strings.Repeat(" ", pad))
 					}
 				}

--- a/internal/clifmt/syntax.go
+++ b/internal/clifmt/syntax.go
@@ -65,6 +65,11 @@ func looksLikeCodeBlock(text string) bool {
 }
 
 func highlightCode(src, language string) (string, error) {
+	// Expand tabs before tokenising so the formatter never emits raw tab
+	// characters, which terminals render as a jump to the next tab stop and
+	// can misalign indented code inside boxed or guttered output.
+	src = strings.ReplaceAll(src, "\t", "    ")
+
 	var lexer chroma.Lexer
 	if language != "" {
 		lexer = lexers.Get(language)
@@ -105,19 +110,9 @@ func wrapInBox(highlighted string, lang string) string {
 		return ""
 	}
 
-	// Calculate max width for the box
-	maxWidth := 0
-	for _, line := range lines {
-		w := visibleWidth(line)
-		if w > maxWidth {
-			maxWidth = w
-		}
-	}
-
-	// Line number gutter width
 	gutterWidth := len(fmt.Sprintf("%d", len(lines)))
-	if gutterWidth < 2 {
-		gutterWidth = 2
+	if gutterWidth < 3 {
+		gutterWidth = 3
 	}
 
 	header := lang
@@ -125,45 +120,17 @@ func wrapInBox(highlighted string, lang string) string {
 		header = "code"
 	}
 
-	// Total inner width of the box (excluding the outer 1-char borders on each side)
-	// |  gutter  | content |
-	// totalInnerWidth = (2 for left padding) + (gutterWidth) + (3 for gutter divider separator) + (maxWidth) + (2 for right padding)
-	totalInnerWidth := 2 + gutterWidth + 3 + maxWidth + 2
+	gray := "\x1b[38;5;245m"
 
 	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s%s\x1b[0m\n", gray, header))
 
-	// Top border
-	b.WriteString("\x1b[90m┌── \x1b[0m")
-	b.WriteString("\x1b[1;36m" + header + "\x1b[0m")
-	topLineLen := totalInnerWidth - 3 - visibleWidth(header)
-	if topLineLen < 2 {
-		topLineLen = 2
-	}
-	b.WriteString("\x1b[90m " + strings.Repeat("─", topLineLen) + "┐\x1b[0m\n")
-
-	// Content with line numbers and side borders
 	for i, line := range lines {
 		lineNum := i + 1
-		padding := maxWidth - visibleWidth(line)
-
-		// Check for diff markers to color the gutter
-		cleanLine := stripANSI(line)
-		gutterColor := "\x1b[90m" // dim gray default
-		if strings.HasPrefix(cleanLine, "+") {
-			gutterColor = "\x1b[32m" // green
-		} else if strings.HasPrefix(cleanLine, "-") {
-			gutterColor = "\x1b[31m" // red
-		}
-
-		b.WriteString("\x1b[90m│ \x1b[0m")
-		b.WriteString(fmt.Sprintf("%s%*d │ \x1b[0m", gutterColor, gutterWidth, lineNum))
+		b.WriteString(fmt.Sprintf("%s%*d\x1b[0m  ", gray, gutterWidth, lineNum))
 		b.WriteString(line)
-		b.WriteString(strings.Repeat(" ", padding))
-		b.WriteString("\x1b[90m │\x1b[0m\n")
+		b.WriteByte('\n')
 	}
-
-	// Bottom border
-	b.WriteString("\x1b[90m└" + strings.Repeat("─", totalInnerWidth) + "┘\x1b[0m")
 
 	return b.String()
 }
@@ -223,6 +190,7 @@ func looksLikeCode(text string) bool {
 			continue
 		}
 
+		// High-confidence code signatures only.
 		if strings.HasPrefix(trimmed, "def ") ||
 			strings.HasPrefix(trimmed, "class ") ||
 			strings.HasPrefix(trimmed, "import ") ||
@@ -231,15 +199,32 @@ func looksLikeCode(text string) bool {
 			strings.HasPrefix(trimmed, "const ") ||
 			strings.HasPrefix(trimmed, "let ") ||
 			strings.HasPrefix(trimmed, "var ") ||
+			strings.HasPrefix(trimmed, "package ") ||
+			strings.HasPrefix(trimmed, "func ") ||
+			strings.HasPrefix(trimmed, "struct ") ||
+			strings.HasPrefix(trimmed, "type ") ||
+			strings.HasPrefix(trimmed, "if ") ||
+			strings.HasPrefix(trimmed, "for ") ||
+			strings.HasPrefix(trimmed, "while ") ||
+			strings.HasPrefix(trimmed, "return ") ||
+			strings.HasPrefix(trimmed, "public ") ||
+			strings.HasPrefix(trimmed, "private ") ||
+			strings.HasPrefix(trimmed, "async ") ||
+			strings.HasPrefix(trimmed, "await ") ||
+			strings.HasPrefix(trimmed, "try ") ||
+			strings.HasPrefix(trimmed, "catch ") ||
+			strings.HasPrefix(trimmed, "throw ") ||
+			strings.HasPrefix(trimmed, "new ") ||
+			strings.HasPrefix(trimmed, "else ") ||
+			strings.HasPrefix(trimmed, "elif ") ||
+			strings.HasPrefix(trimmed, "print ") ||
+			strings.HasPrefix(trimmed, "fmt.") ||
 			strings.HasPrefix(trimmed, "#") ||
 			strings.HasPrefix(trimmed, "//") ||
 			strings.HasPrefix(trimmed, "/*") ||
-			strings.HasPrefix(trimmed, "*") ||
-			strings.Contains(line, "    ") ||
-			strings.Contains(line, "\t") ||
-			(strings.Contains(line, "(") && strings.Contains(line, ")")) ||
-			(strings.Contains(line, "{") && strings.Contains(line, "}")) ||
-			(strings.Contains(line, "=") && !strings.Contains(line, "==")) {
+			strings.HasSuffix(trimmed, ";") ||
+			strings.HasSuffix(trimmed, "{") ||
+			strings.HasSuffix(trimmed, "}") {
 			codeIndicators++
 		}
 	}


### PR DESCRIPTION
 ### 改动内容

  **颜色统一**
  - 将分散的黄色、绿色、青色统一为灰色 `\033[38;5;245m`
  - 涉及：chatcmd 各模块状态消息、clifmt 的 Headerf/Success/Warn/Key

  **聊天 UI 改进**
  - 用户 prompt 始终显示绿色圆点 `•`，不再区分 compact 模式
  - thinking 动画：消息颜色改灰色；支持自定义 writer fd；清行用 `\033[2K`；停止后打印静态灰色消息；取消 80 字符截断
  - 移除会话开始的 "Interactive chat started..." 提示
  - repl 输出移除 assistant 用户名前缀

  **Plan 步骤输出**
  - 步骤开始：停止 spinner → 打印 `→ plan: <step> [n/m]` → 重启 spinner
  - 步骤完成：格式统一为 `→ plan: ✓ <step> [n/m]`
  - diff 渲染时暂停/恢复 spinner，避免动画冲突

  **Diff 渲染改进**
  - tab 转 4 个空格
  - 终端宽度检测增加 `COLUMNS` 环境变量回退
  - 文件头前加空行，颜色改为白色
  - 删除/插入行用 `\x1b[K` + 空格填充双保险，确保背景色铺满整行

  **代码块样式简化**
  - 去掉 box-drawing 边框，改为简洁的灰色标题 + 线号
  - `highlightCode` 内部也做 tab 转空格
  - 收紧 `looksLikeCode` 启发式规则，只保留高置信度代码签名

  **root.go 重构**
  - 提取 `channelDependencies()` 辅助函数，消除 4 份重复的 heartbeat runtime 代码
  - 保留上游行为：保留 `newAuthCmd()` 和各 channel 的 `HandleModelCommand`

  ## 测试清单

  - [ ] `go build ./cmd/mistermorph/...` 编译通过
  - [ ] 交互式聊天模式显示正常
  - [ ] diff 背景色铺满整行
  - [ ] 代码块无边框渲染正常
  - [ ] channel 命令（telegram/slack/line/lark）编译正常且保留模型切换功能
