### PR TITLE
feat(llm): support llm.default_profile to inherit config from a named profile

### DIFF
--- a/internal/llmutil/llmutil.go
+++ b/internal/llmutil/llmutil.go
@@ -26,6 +26,7 @@ type RuntimeValues struct {
 	Endpoint           string `config:"llm.endpoint"`
 	APIKey             string `config:"llm.api_key"`
 	Model              string `config:"llm.model"`
+	DefaultProfile     string `config:"llm.default_profile"`
 	Headers            map[string]string
 	CacheTTL           string `config:"llm.cache_ttl"`
 	CacheKeyPrefix     string `config:"llm.cache_key_prefix"`
@@ -55,11 +56,12 @@ func RuntimeValuesFromReader(r ConfigReader) RuntimeValues {
 	if r == nil {
 		return RuntimeValues{}
 	}
-	return RuntimeValues{
+	values := RuntimeValues{
 		Provider:               strings.TrimSpace(r.GetString("llm.provider")),
 		Endpoint:               strings.TrimSpace(r.GetString("llm.endpoint")),
 		APIKey:                 strings.TrimSpace(r.GetString("llm.api_key")),
 		Model:                  strings.TrimSpace(r.GetString("llm.model")),
+		DefaultProfile:         strings.TrimSpace(r.GetString("llm.default_profile")),
 		Headers:                loadStringMapKeyFromReader(r, "llm.headers"),
 		CacheTTL:               strings.TrimSpace(r.GetString("llm.cache_ttl")),
 		CacheKeyPrefix:         strings.TrimSpace(r.GetString("llm.cache_key_prefix")),
@@ -87,6 +89,7 @@ func RuntimeValuesFromReader(r ConfigReader) RuntimeValues {
 			r.GetString("llm.cloudflare.api_token"),
 		),
 	}
+	return applyDefaultProfileFallback(values)
 }
 
 func RuntimeValuesFromViper() RuntimeValues {
@@ -384,6 +387,41 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func applyDefaultProfileFallback(values RuntimeValues) RuntimeValues {
+	name := strings.TrimSpace(values.DefaultProfile)
+	if name == "" {
+		return values
+	}
+	profile, ok := values.Profiles[name]
+	if !ok {
+		return values
+	}
+	values.Provider = firstNonEmpty(values.Provider, profile.Provider)
+	values.Endpoint = firstNonEmpty(values.Endpoint, profile.Endpoint)
+	values.APIKey = firstNonEmpty(values.APIKey, profile.APIKey)
+	values.Model = firstNonEmpty(values.Model, profile.Model)
+	if values.Headers == nil && len(profile.Headers) > 0 {
+		values.Headers = cloneStringMap(profile.Headers)
+	}
+	values.CacheTTL = firstNonEmpty(values.CacheTTL, profile.CacheTTL)
+	values.CacheKeyPrefix = firstNonEmpty(values.CacheKeyPrefix, profile.CacheKeyPrefix)
+	values.RequestTimeoutRaw = firstNonEmpty(values.RequestTimeoutRaw, profile.RequestTimeoutRaw)
+	values.ToolsEmulationMode = firstNonEmpty(values.ToolsEmulationMode, profile.ToolsEmulationMode)
+	values.TemperatureRaw = firstNonEmpty(values.TemperatureRaw, profile.TemperatureRaw)
+	values.ReasoningEffortRaw = firstNonEmpty(values.ReasoningEffortRaw, profile.ReasoningEffortRaw)
+	values.ReasoningBudgetRaw = firstNonEmpty(values.ReasoningBudgetRaw, profile.ReasoningBudgetRaw)
+	values.AzureDeployment = firstNonEmpty(values.AzureDeployment, profile.Azure.Deployment)
+	values.BedrockAWSKey = firstNonEmpty(values.BedrockAWSKey, profile.Bedrock.AWSKey)
+	values.BedrockAWSSecret = firstNonEmpty(values.BedrockAWSSecret, profile.Bedrock.AWSSecret)
+	values.BedrockAWSSessionToken = firstNonEmpty(values.BedrockAWSSessionToken, profile.Bedrock.AWSSessionToken)
+	values.BedrockAWSProfile = firstNonEmpty(values.BedrockAWSProfile, profile.Bedrock.AWSProfile)
+	values.BedrockAWSRegion = firstNonEmpty(values.BedrockAWSRegion, profile.Bedrock.Region)
+	values.BedrockModelARN = firstNonEmpty(values.BedrockModelARN, profile.Bedrock.ModelARN)
+	values.CloudflareAccountID = firstNonEmpty(values.CloudflareAccountID, profile.Cloudflare.AccountID)
+	values.CloudflareAPIToken = firstNonEmpty(values.CloudflareAPIToken, profile.Cloudflare.APIToken)
+	return values
 }
 
 func loadStringSliceKeyFromReader(r ConfigReader, key string) []string {

--- a/internal/llmutil/llmutil_test.go
+++ b/internal/llmutil/llmutil_test.go
@@ -705,3 +705,78 @@ func TestSystemPromptCacheControlRejectsInvalidTTL(t *testing.T) {
 		t.Fatalf("error = %v, want cache ttl validation message", err)
 	}
 }
+
+func TestRuntimeValuesFromReader_DefaultProfileFillsEmptyFields(t *testing.T) {
+	v := viper.New()
+	v.Set("llm.default_profile", "xiaomimimo")
+	v.Set("llm.profiles", map[string]any{
+		"xiaomimimo": map[string]any{
+			"provider":       "openai",
+			"model":          "mimo-v2.5-pro",
+			"api_key":        "tp-test-key",
+			"endpoint":       "https://token-plan-cn.xiaomimimo.com/v1",
+			"request_timeout": "120s",
+		},
+	})
+
+	values := RuntimeValuesFromReader(v)
+	if values.Provider != "openai" {
+		t.Fatalf("provider = %q, want openai", values.Provider)
+	}
+	if values.Model != "mimo-v2.5-pro" {
+		t.Fatalf("model = %q, want mimo-v2.5-pro", values.Model)
+	}
+	if values.APIKey != "tp-test-key" {
+		t.Fatalf("api_key = %q, want tp-test-key", values.APIKey)
+	}
+	if values.Endpoint != "https://token-plan-cn.xiaomimimo.com/v1" {
+		t.Fatalf("endpoint = %q, want https://token-plan-cn.xiaomimimo.com/v1", values.Endpoint)
+	}
+	if values.RequestTimeoutRaw != "120s" {
+		t.Fatalf("request_timeout = %q, want 120s", values.RequestTimeoutRaw)
+	}
+}
+
+func TestRuntimeValuesFromReader_DefaultProfileDoesNotOverrideExplicitValues(t *testing.T) {
+	v := viper.New()
+	v.Set("llm.default_profile", "xiaomimimo")
+	v.Set("llm.model", "mimo-v2.5")
+	v.Set("llm.profiles", map[string]any{
+		"xiaomimimo": map[string]any{
+			"provider": "openai",
+			"model":    "mimo-v2.5-pro",
+			"api_key":  "tp-test-key",
+			"endpoint": "https://token-plan-cn.xiaomimimo.com/v1",
+		},
+	})
+
+	values := RuntimeValuesFromReader(v)
+	if values.Model != "mimo-v2.5" {
+		t.Fatalf("model = %q, want mimo-v2.5 (explicit value should not be overridden)", values.Model)
+	}
+	if values.Provider != "openai" {
+		t.Fatalf("provider = %q, want openai", values.Provider)
+	}
+	if values.APIKey != "tp-test-key" {
+		t.Fatalf("api_key = %q, want tp-test-key", values.APIKey)
+	}
+}
+
+func TestRuntimeValuesFromReader_DefaultProfileMissingProfileIsNoop(t *testing.T) {
+	v := viper.New()
+	v.Set("llm.default_profile", "nonexistent")
+	v.Set("llm.provider", "openai")
+	v.Set("llm.model", "gpt-4")
+	v.Set("llm.api_key", "test-key")
+
+	values := RuntimeValuesFromReader(v)
+	if values.Provider != "openai" {
+		t.Fatalf("provider = %q, want openai", values.Provider)
+	}
+	if values.Model != "gpt-4" {
+		t.Fatalf("model = %q, want gpt-4", values.Model)
+	}
+	if values.APIKey != "test-key" {
+		t.Fatalf("api_key = %q, want test-key", values.APIKey)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `llm.default_profile` config field that references a profile defined under `llm.profiles`
- Top-level `llm` section values take precedence; the profile only fills in empty fields
- Eliminates duplication when the default model config matches a named profile

## Motivation

Currently users must duplicate provider/model/api_key/endpoint both in the top-level `llm:` section and in `llm.profiles.<name>` if they want the same config as default. This change allows:

```yaml
llm:
  default_profile: xiaomimimo

  profiles:
    xiaomimimo:
      provider: openai
      model: mimo-v2.5-pro
      api_key: "..."
      endpoint: "..."
```

To switch the default model, just change `default_profile` to another profile name. Mixed usage is also supported — set `default_profile` and override specific fields at the top level.

## Test plan

- [x] Unit test: empty top-level fields are filled from the referenced profile
- [x] Unit test: explicit top-level values are not overridden by the profile
- [x] Unit test: referencing a non-existent profile is a no-op
- [x] All existing tests pass (`go test ./internal/llmutil/ ./internal/llmselect/ ./integration/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)