### PR TITLE
fix(uniai): preserve /vN version suffix in normalizeOpenAIBase

### DIFF
--- a/providers/uniai/client.go
+++ b/providers/uniai/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1342,6 +1343,11 @@ func normalizeOpenAIBase(endpoint string) string {
 	endpoint = strings.TrimRight(endpoint, "/")
 	if strings.Contains(endpoint, "/backend-api/codex") {
 		endpoint = strings.TrimSuffix(endpoint, "/v1")
+		return endpoint
+	}
+	// If the endpoint already ends with a version segment like /v1, /v2, /v4,
+	// trust it and do not append an extra /v1.
+	if matched, _ := regexp.MatchString(`/v\d+$`, endpoint); matched {
 		return endpoint
 	}
 	if strings.HasSuffix(endpoint, "/v1") || strings.Contains(endpoint, "/v1/") {

--- a/providers/uniai/client_test.go
+++ b/providers/uniai/client_test.go
@@ -1036,3 +1036,25 @@ func TestShouldEnsureGeminiThoughtSignature(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeOpenAIBase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"https://api.openai.com", "https://api.openai.com/v1"},
+		{"https://api.openai.com/", "https://api.openai.com/v1"},
+		{"https://token-plan-cn.xiaomimimo.com/v1", "https://token-plan-cn.xiaomimimo.com/v1"},
+		{"https://api.kimi.com/coding/v1", "https://api.kimi.com/coding/v1"},
+		{"https://open.bigmodel.cn/api/paas/v4", "https://open.bigmodel.cn/api/paas/v4"},
+		{"https://open.bigmodel.cn/api/paas/v4/", "https://open.bigmodel.cn/api/paas/v4"},
+		{"https://example.com/api/v5", "https://example.com/api/v5"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := normalizeOpenAIBase(tc.input)
+		if got != tc.expected {
+			t.Errorf("normalizeOpenAIBase(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`normalizeOpenAIBase` unconditionally appends `/v1` to any endpoint that does not already contain it. This breaks providers like **zhipuai (智谱 BigModel)** whose OpenAI-compatible base URL ends with a version segment (e.g. `https://open.bigmodel.cn/api/paas/v4`) and does **not** use an additional `/v1` path.

## Example

- Configured endpoint: `https://open.bigmodel.cn/api/paas/v4`
- Actual request URL: `.../v4/v1/chat/completions` → **404 Not Found**
- Expected URL: `.../v4/chat/completions`

## Fix

Add a regex check for `/v\\d+$` so that any endpoint ending with a version segment is preserved as-is, while bare domains still get the automatic `/v1` appended.

| Endpoint | Before | After |
|---|---|---|
| `api.openai.com` | `.../v1` | `.../v1` |
| `...bigmodel.cn/api/paas/v4` | `.../v4/v1` ❌ | `.../v4` ✅ |
| future `...xxx.com/api/v5` | `.../v5/v1` ❌ | `.../v5` ✅ |

## Test

Added `TestNormalizeOpenAIBase` covering bare domains, existing `/v1` paths, and `/v4` style endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)