### PR TITLE
feat(clifmt): add goldmark-based terminal markdown renderer

### DIFF
--- a/internal/clifmt/clifmt.go
+++ b/internal/clifmt/clifmt.go
@@ -38,9 +38,6 @@ func colorize(code string, text string) string {
 	return "\x1b[" + code + "m" + text + "\x1b[0m"
 }
 
-func RenderMarkdown(text string) string {
-	return HighlightCodeBlocks(text)
-}
 
 func useColor() bool {
 	if os.Getenv("NO_COLOR") != "" {

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -1,0 +1,315 @@
+package clifmt
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+// terminalRenderer renders a goldmark AST to terminal-friendly output with
+// ANSI color codes.
+type terminalRenderer struct {
+	styleStack []string
+}
+
+func newTerminalRenderer() *terminalRenderer {
+	return &terminalRenderer{}
+}
+
+func (r *terminalRenderer) pushStyle(code string) {
+	r.styleStack = append(r.styleStack, code)
+}
+
+func (r *terminalRenderer) popStyle() string {
+	if len(r.styleStack) == 0 {
+		return ""
+	}
+	last := len(r.styleStack) - 1
+	code := r.styleStack[last]
+	r.styleStack = r.styleStack[:last]
+	return code
+}
+
+func (r *terminalRenderer) currentStyles() string {
+	var b strings.Builder
+	for _, code := range r.styleStack {
+		b.WriteString(code)
+	}
+	return b.String()
+}
+
+func (r *terminalRenderer) applyStyles(w util.BufWriter) {
+	if !useColor() {
+		return
+	}
+	styles := r.currentStyles()
+	if styles != "" {
+		w.WriteString(styles)
+	}
+}
+
+func (r *terminalRenderer) closeStyle(w util.BufWriter) {
+	if !useColor() {
+		return
+	}
+	r.popStyle()
+	w.WriteString("\x1b[0m")
+	r.applyStyles(w)
+}
+
+func (r *terminalRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindDocument, r.renderDocument)
+	reg.Register(ast.KindHeading, r.renderHeading)
+	reg.Register(ast.KindParagraph, r.renderParagraph)
+	reg.Register(ast.KindText, r.renderText)
+	reg.Register(ast.KindEmphasis, r.renderEmphasis)
+	reg.Register(ast.KindFencedCodeBlock, r.renderFencedCodeBlock)
+	reg.Register(ast.KindCodeBlock, r.renderCodeBlock)
+	reg.Register(ast.KindCodeSpan, r.renderCodeSpan)
+	reg.Register(ast.KindList, r.renderList)
+	reg.Register(ast.KindListItem, r.renderListItem)
+	reg.Register(ast.KindBlockquote, r.renderBlockquote)
+	reg.Register(ast.KindLink, r.renderLink)
+	reg.Register(ast.KindImage, r.renderImage)
+	reg.Register(ast.KindThematicBreak, r.renderThematicBreak)
+}
+
+func (r *terminalRenderer) renderDocument(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	n := node.(*ast.Heading)
+	if entering {
+		if useColor() {
+			r.pushStyle("\x1b[1m")
+			_, _ = w.WriteString("\x1b[1m")
+		}
+		for i := 0; i < n.Level; i++ {
+			_, _ = w.WriteString("#")
+		}
+		_, _ = w.WriteString(" ")
+	} else {
+		if useColor() {
+			r.closeStyle(w)
+		}
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderParagraph(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		if node.Parent() != nil && node.Parent().Kind() == ast.KindListItem {
+			return ast.WalkContinue, nil
+		}
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderText(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.Text)
+	_, _ = w.Write(n.Segment.Value(source))
+	if n.HardLineBreak() {
+		_, _ = w.WriteString("\n")
+	} else if n.SoftLineBreak() {
+		_, _ = w.WriteString(" ")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderEmphasis(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !useColor() {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.Emphasis)
+	if entering {
+		if n.Level >= 2 {
+			r.pushStyle("\x1b[1m")
+			_, _ = w.WriteString("\x1b[1m")
+		} else {
+			r.pushStyle("\x1b[3m")
+			_, _ = w.WriteString("\x1b[3m")
+		}
+	} else {
+		r.closeStyle(w)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.FencedCodeBlock)
+
+	lang := ""
+	if n.Info != nil {
+		lang = strings.TrimSpace(string(n.Info.Text(source)))
+	}
+
+	var codeBuf bytes.Buffer
+	lines := n.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
+		_, _ = codeBuf.Write(line.Value(source))
+	}
+	code := codeBuf.String()
+
+	highlighted, err := highlightCode(code, lang)
+	if err != nil {
+		_, _ = w.WriteString(code)
+		return ast.WalkSkipChildren, nil
+	}
+	_, _ = w.WriteString("\n")
+	_, _ = w.WriteString(wrapInBox(highlighted, lang))
+	_, _ = w.WriteString("\n")
+	return ast.WalkSkipChildren, nil
+}
+
+func (r *terminalRenderer) renderCodeBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.CodeBlock)
+
+	var codeBuf bytes.Buffer
+	lines := n.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
+		_, _ = codeBuf.Write(line.Value(source))
+	}
+	code := codeBuf.String()
+
+	highlighted, err := highlightCode(code, "")
+	if err != nil {
+		_, _ = w.WriteString(code)
+		return ast.WalkSkipChildren, nil
+	}
+	_, _ = w.WriteString("\n")
+	_, _ = w.WriteString(wrapInBox(highlighted, ""))
+	_, _ = w.WriteString("\n")
+	return ast.WalkSkipChildren, nil
+}
+
+func (r *terminalRenderer) renderCodeSpan(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !useColor() {
+		return ast.WalkContinue, nil
+	}
+	if entering {
+		r.pushStyle("\x1b[90m")
+		_, _ = w.WriteString("\x1b[90m")
+	} else {
+		r.closeStyle(w)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderListItem(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		parent := node.Parent()
+		var prefix string
+		if parent != nil && parent.Kind() == ast.KindList {
+			list := parent.(*ast.List)
+			if list.IsOrdered() {
+				idx := 1
+				for prev := node.PreviousSibling(); prev != nil; prev = prev.PreviousSibling() {
+					if prev.Kind() == ast.KindListItem {
+						idx++
+					}
+				}
+				start := list.Start
+				if start < 1 {
+					start = 1
+				}
+				prefix = fmt.Sprintf("  %d. ", start+idx-1)
+			} else {
+				prefix = "  • "
+			}
+		} else {
+			prefix = "  • "
+		}
+		if useColor() {
+			_, _ = w.WriteString("\x1b[38;5;245m")
+			_, _ = w.WriteString(prefix)
+			_, _ = w.WriteString("\x1b[0m")
+		} else {
+			_, _ = w.WriteString(prefix)
+		}
+	} else {
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderBlockquote(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString("\x1b[38;5;245m│ \x1b[0m")
+	} else {
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderLink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderImage(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString("[image]")
+	}
+	return ast.WalkSkipChildren, nil
+}
+
+func (r *terminalRenderer) renderThematicBreak(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	_, _ = w.WriteString("\n")
+	return ast.WalkContinue, nil
+}
+
+// RenderMarkdown renders markdown text to terminal-friendly output with ANSI
+// color codes. It uses goldmark to parse the markdown and a custom renderer
+// to produce terminal output.
+func RenderMarkdown(text string) string {
+	return renderMarkdown(text, useColor())
+}
+
+func renderMarkdown(text string, color bool) string {
+	if !color {
+		return HighlightCodeBlocks(text)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	tr := newTerminalRenderer()
+
+	md := goldmark.New(
+		goldmark.WithRenderer(
+			renderer.NewRenderer(
+				renderer.WithNodeRenderers(
+					util.Prioritized(tr, 1000),
+				),
+			),
+		),
+	)
+
+	if err := md.Convert([]byte(text), buf); err != nil {
+		return HighlightCodeBlocks(text)
+	}
+	return buf.String()
+}

--- a/internal/clifmt/markdown_test.go
+++ b/internal/clifmt/markdown_test.go
@@ -1,0 +1,62 @@
+package clifmt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdownHeading(t *testing.T) {
+	input := "# Hello\n\nSome text"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "# Hello") {
+		t.Fatalf("expected heading, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownBold(t *testing.T) {
+	input := "This is **bold** text"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "bold") {
+		t.Fatalf("expected bold text, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownCodeBlock(t *testing.T) {
+	input := "```go\npackage main\n```"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "package") || !strings.Contains(out, "main") {
+		t.Fatalf("expected code block, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownList(t *testing.T) {
+	input := "- item one\n- item two"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "item one") || !strings.Contains(out, "item two") {
+		t.Fatalf("expected list items, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownLink(t *testing.T) {
+	input := "[link text](https://example.com)"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "link text") {
+		t.Fatalf("expected link text, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownImage(t *testing.T) {
+	input := "![alt text](https://example.com/img.png)"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "[image]") {
+		t.Fatalf("expected image placeholder, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownBlockquote(t *testing.T) {
+	input := "> quote"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "│") {
+		t.Fatalf("expected blockquote prefix, got: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `terminalRenderer` based on [goldmark](https://github.com/yuin/goldmark) that parses Markdown AST and renders it directly to terminal-friendly output with ANSI color codes.

## Motivation

The existing `RenderMarkdown` was just a thin wrapper around `HighlightCodeBlocks`. It did not handle any inline formatting (bold, italic, links, lists, blockquotes, etc.), causing raw Markdown syntax to leak into the TUI chat output.

## What's supported

| Element | Rendering |
|---|---|
| Heading | Bold `## ` prefix |
| Paragraph | Normal flow |
| **Bold** / *italic* | ANSI bold / italic |
| `code` | Dark gray text (`\x1b[90m`) — no reverse-video background |
| Code block | Syntax highlighted with line numbers |
| Bullet list | Gray `•` prefix |
| Ordered list | Gray `1. 2. 3.` prefix |
| Blockquote | Gray `│` prefix |
| Link | Link text rendered (URL hidden) |
| Image | `[image]` placeholder |

## Code changes

- `internal/clifmt/markdown.go` — new goldmark renderer (~290 lines)
- `internal/clifmt/markdown_test.go` — tests for heading, bold, code block, list, link, image, blockquote
- `internal/clifmt/clifmt.go` — remove old `RenderMarkdown` wrapper (now provided by `markdown.go`)

## Notes

- Inline code spans switched from reverse-video (`\x1b[7m`, black-on-white) to dark gray foreground (`\x1b[90m`) for better terminal readability.
- This PR is intentionally scoped to a minimal viable renderer; table rendering, nested list indentation, and link URL display can be improved in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)