### PR TITLE
feat(clifmt): add goldmark-based terminal markdown renderer (supersedes #51)

### DIFF
--- a/internal/clifmt/clifmt.go
+++ b/internal/clifmt/clifmt.go
@@ -45,7 +45,6 @@ func colorizeRGB(r, g, b int, text string) string {
 	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm%s\x1b[0m", r, g, b, text)
 }
 
-
 func useColor() bool {
 	if os.Getenv("NO_COLOR") != "" {
 		return false

--- a/internal/clifmt/clifmt.go
+++ b/internal/clifmt/clifmt.go
@@ -12,15 +12,15 @@ func Headerf(format string, args ...any) string {
 	if !useColor() {
 		return text
 	}
-	return "\x1b[1;36m" + text + "\x1b[0m"
+	return "\x1b[38;5;245m" + text + "\x1b[0m"
 }
 
 func Success(text string) string {
-	return colorize("32", text)
+	return colorize("90", text)
 }
 
 func Warn(text string) string {
-	return colorize("33", text)
+	return colorize("90", text)
 }
 
 func Dim(text string) string {
@@ -28,7 +28,7 @@ func Dim(text string) string {
 }
 
 func Key(text string) string {
-	return colorize("1;33", text)
+	return colorize("90", text)
 }
 
 func colorize(code string, text string) string {

--- a/internal/clifmt/clifmt.go
+++ b/internal/clifmt/clifmt.go
@@ -16,11 +16,11 @@ func Headerf(format string, args ...any) string {
 }
 
 func Success(text string) string {
-	return colorize("90", text)
+	return colorizeRGB(140, 170, 160, text)
 }
 
 func Warn(text string) string {
-	return colorize("90", text)
+	return colorizeRGB(180, 160, 130, text)
 }
 
 func Dim(text string) string {
@@ -28,7 +28,7 @@ func Dim(text string) string {
 }
 
 func Key(text string) string {
-	return colorize("90", text)
+	return colorizeRGB(150, 160, 210, text)
 }
 
 func colorize(code string, text string) string {
@@ -36,6 +36,13 @@ func colorize(code string, text string) string {
 		return text
 	}
 	return "\x1b[" + code + "m" + text + "\x1b[0m"
+}
+
+func colorizeRGB(r, g, b int, text string) string {
+	if !useColor() {
+		return text
+	}
+	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm%s\x1b[0m", r, g, b, text)
 }
 
 

--- a/internal/clifmt/clifmt.go
+++ b/internal/clifmt/clifmt.go
@@ -38,9 +38,6 @@ func colorize(code string, text string) string {
 	return "\x1b[" + code + "m" + text + "\x1b[0m"
 }
 
-func RenderMarkdown(text string) string {
-	return HighlightCodeBlocks(text)
-}
 
 func useColor() bool {
 	if os.Getenv("NO_COLOR") != "" {

--- a/internal/clifmt/diff.go
+++ b/internal/clifmt/diff.go
@@ -319,9 +319,9 @@ func RenderDiff(path, oldContent, newContent string) string {
 		gray = "\x1b[38;5;245m"
 	}
 
-	// File header
+	// File header: bold + underlined so it stands out from code lines.
 	if color {
-		b.WriteString(fmt.Sprintf("\n%s%s\x1b[0m\n", white, path))
+		b.WriteString(fmt.Sprintf("\n\x1b[1m\x1b[4m%s%s\x1b[0m\n", white, path))
 	} else {
 		b.WriteString("\n" + path + "\n")
 	}

--- a/internal/clifmt/diff.go
+++ b/internal/clifmt/diff.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/mattn/go-runewidth"
@@ -14,6 +15,22 @@ import (
 
 // ansiBgRe matches ANSI escape sequences that set or reset background colors.
 var ansiBgRe = regexp.MustCompile("\x1b\\[(?:4[0-8]|10[0-7]|49)(?:;[^m]*)?m")
+
+// getTermWidth returns the terminal width using multiple fallbacks:
+// 1. term.GetSize on stdout, 2. COLUMNS env var, 3. fixed default.
+func getTermWidth() int {
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+			return w
+		}
+	}
+	if cols := os.Getenv("COLUMNS"); cols != "" {
+		if w, err := strconv.Atoi(cols); err == nil && w > 0 {
+			return w
+		}
+	}
+	return 0
+}
 
 // reapplyBgBeforeWideChars re-emits the bg ANSI sequence immediately before
 // every double-width (CJK) rune in text. Some terminals fail to fill the
@@ -291,25 +308,22 @@ func RenderDiff(path, oldContent, newContent string) string {
 		}
 	}
 
-	termWidth := 0
-	if term.IsTerminal(int(os.Stdout.Fd())) {
-		if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
-			termWidth = w
-		}
-	}
+	termWidth := getTermWidth()
 
 	var b strings.Builder
 
+	white := ""
 	gray := ""
 	if color {
-		gray = "\x1b[38;5;250m"
+		white = "\x1b[37m"
+		gray = "\x1b[38;5;245m"
 	}
 
 	// File header
 	if color {
-		b.WriteString(fmt.Sprintf("%s%s\x1b[0m\n", gray, path))
+		b.WriteString(fmt.Sprintf("\n%s%s\x1b[0m\n", white, path))
 	} else {
-		b.WriteString(path + "\n")
+		b.WriteString("\n" + path + "\n")
 	}
 
 	for _, dl := range folded {
@@ -355,10 +369,11 @@ func RenderDiff(path, oldContent, newContent string) string {
 				safeText = strings.ReplaceAll(safeText, "\x1b[0m", "\x1b[39m"+bg+fg)
 				safeText = reapplyBgBeforeWideChars(safeText, bg)
 				b.WriteString(safeText)
+				b.WriteString(bg)
+				b.WriteString("\x1b[K")
 				if termWidth > 0 {
 					used := gutterWidth + 3 + visibleWidth(safeText)
 					if pad := termWidth - used; pad > 0 {
-						b.WriteString(bg)
 						b.WriteString(strings.Repeat(" ", pad))
 					}
 				}
@@ -376,10 +391,11 @@ func RenderDiff(path, oldContent, newContent string) string {
 				safeText = strings.ReplaceAll(safeText, "\x1b[0m", "\x1b[39m"+bg+fg)
 				safeText = reapplyBgBeforeWideChars(safeText, bg)
 				b.WriteString(safeText)
+				b.WriteString(bg)
+				b.WriteString("\x1b[K")
 				if termWidth > 0 {
 					used := gutterWidth + 3 + visibleWidth(safeText)
 					if pad := termWidth - used; pad > 0 {
-						b.WriteString(bg)
 						b.WriteString(strings.Repeat(" ", pad))
 					}
 				}

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -20,11 +20,15 @@ type terminalRenderer struct {
 	styleStack []string
 
 	// tableColWidths holds the pre-computed display width for each column
-	// in the current table. Populated when entering a Table node and cleared
-	// when exiting.
+	// in the current table (including 1-space padding on each side).
+	// Populated when entering a Table node and cleared when exiting.
 	tableColWidths []int
 	// tableCellIdx tracks which column is currently being rendered.
 	tableCellIdx int
+	// tableRowIdx tracks the current body row (1-based).
+	tableRowIdx int
+	// tableRowCount is the total number of body rows.
+	tableRowCount int
 }
 
 func newTerminalRenderer() *terminalRenderer {
@@ -314,13 +318,38 @@ func (r *terminalRenderer) renderThematicBreak(w util.BufWriter, source []byte, 
 	return ast.WalkContinue, nil
 }
 
+// drawTableBorder writes a horizontal border line: prefix + dashes per column
+// with intersection chars between columns + suffix.
+func drawTableBorder(w util.BufWriter, widths []int, left, cross, right string) {
+	if len(widths) == 0 {
+		return
+	}
+	_, _ = w.WriteString(left)
+	for i, width := range widths {
+		if i > 0 {
+			_, _ = w.WriteString(cross)
+		}
+		_, _ = w.WriteString(strings.Repeat("─", width))
+	}
+	_, _ = w.WriteString(right)
+	_, _ = w.WriteString("\n")
+}
+
 func (r *terminalRenderer) renderTable(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		// Pre-compute column widths by walking the table AST once before
-		// the renderer walks it for output.
+		// the renderer walks it for output. Add 2 for 1-space padding on
+		// each side of the cell content.
 		colWidths := make(map[int]int)
+		r.tableRowCount = 0
 		ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-			if !entering || n.Kind() != extast.KindTableCell {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+			if n.Kind() == extast.KindTableRow {
+				r.tableRowCount++
+			}
+			if n.Kind() != extast.KindTableCell {
 				return ast.WalkContinue, nil
 			}
 			cell := n.(*extast.TableCell)
@@ -331,7 +360,7 @@ func (r *terminalRenderer) renderTable(w util.BufWriter, source []byte, node ast
 				}
 			}
 			text := getCellText(cell, source)
-			cw := runewidth.StringWidth(text)
+			cw := runewidth.StringWidth(text) + 2 // +2 for left/right padding
 			if cw > colWidths[idx] {
 				colWidths[idx] = cw
 			}
@@ -342,10 +371,14 @@ func (r *terminalRenderer) renderTable(w util.BufWriter, source []byte, node ast
 			r.tableColWidths[idx] = cw
 		}
 		r.tableCellIdx = 0
+		r.tableRowIdx = 0
+		drawTableBorder(w, r.tableColWidths, "┌", "┬", "┐")
 	} else {
-		_, _ = w.WriteString("\n")
+		drawTableBorder(w, r.tableColWidths, "└", "┴", "┘")
 		r.tableColWidths = nil
 		r.tableCellIdx = 0
+		r.tableRowIdx = 0
+		r.tableRowCount = 0
 	}
 	return ast.WalkContinue, nil
 }
@@ -356,33 +389,29 @@ func (r *terminalRenderer) renderTableHeader(w util.BufWriter, source []byte, no
 			r.pushStyle("\x1b[1m")
 			_, _ = w.WriteString("\x1b[1m")
 		}
+		_, _ = w.WriteString("│")
 		return ast.WalkContinue, nil
 	}
-	// Exiting header: newline, then a box-drawing separator line.
+	// Exiting header: right border, then a separator line.
 	// TableHeader contains TableCell nodes directly (no intermediate TableRow),
 	// so we must reset the cell index here as well as in renderTableRow.
-	_, _ = w.WriteString("\n")
+	_, _ = w.WriteString("│\n")
 	if useColor() {
 		r.closeStyle(w)
 	}
-	if len(r.tableColWidths) > 0 {
-		for i, width := range r.tableColWidths {
-			if i > 0 {
-				_, _ = w.WriteString("─┼─")
-			}
-			_, _ = w.WriteString(strings.Repeat("─", width))
-		}
-		_, _ = w.WriteString("\n")
-	}
+	drawTableBorder(w, r.tableColWidths, "├", "┼", "┤")
 	r.tableCellIdx = 0
 	return ast.WalkContinue, nil
 }
 
 func (r *terminalRenderer) renderTableRow(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	if !entering {
-		_, _ = w.WriteString("\n")
-		r.tableCellIdx = 0
+	if entering {
+		r.tableRowIdx++
+		_, _ = w.WriteString("│")
+		return ast.WalkContinue, nil
 	}
+	_, _ = w.WriteString("│\n")
+	r.tableCellIdx = 0
 	return ast.WalkContinue, nil
 }
 
@@ -390,7 +419,7 @@ func (r *terminalRenderer) renderTableCell(w util.BufWriter, source []byte, node
 	if !entering {
 		if r.tableCellIdx < len(r.tableColWidths) {
 			text := getCellText(node.(*extast.TableCell), source)
-			pad := r.tableColWidths[r.tableCellIdx] - runewidth.StringWidth(text)
+			pad := r.tableColWidths[r.tableCellIdx] - runewidth.StringWidth(text) - 1
 			if pad > 0 {
 				_, _ = w.WriteString(strings.Repeat(" ", pad))
 			}
@@ -399,7 +428,9 @@ func (r *terminalRenderer) renderTableCell(w util.BufWriter, source []byte, node
 		return ast.WalkContinue, nil
 	}
 	if node.PreviousSibling() != nil {
-		_, _ = w.WriteString(" │ ")
+		_, _ = w.WriteString("│ ")
+	} else {
+		_, _ = w.WriteString(" ")
 	}
 	return ast.WalkContinue, nil
 }

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -76,6 +76,16 @@ func (r *terminalRenderer) closeStyle(w util.BufWriter) {
 	r.applyStyles(w)
 }
 
+// blockEnter writes a leading newline when node is a top-level block that
+// follows another block. This ensures exactly one blank line between adjacent
+// block-level elements without every renderer having to manage spacing on both
+// sides.
+func (r *terminalRenderer) blockEnter(w util.BufWriter, node ast.Node) {
+	if node.PreviousSibling() != nil && node.Parent() != nil && node.Parent().Kind() == ast.KindDocument {
+		w.WriteString("\n")
+	}
+}
+
 // pipePlaceholder is a Private Use Area character used to temporarily replace
 // literal '|' characters inside inline code spans within table rows. Goldmark's
 // table parser treats every '|' as a column separator even when it appears
@@ -174,6 +184,7 @@ func (r *terminalRenderer) renderDocument(w util.BufWriter, source []byte, node 
 
 func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
+		r.blockEnter(w, node)
 		if useColor() {
 			r.pushStyle("\x1b[1m")
 			_, _ = w.WriteString("\x1b[1m")
@@ -188,12 +199,14 @@ func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node a
 }
 
 func (r *terminalRenderer) renderParagraph(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	if !entering {
-		if node.Parent() != nil && node.Parent().Kind() == ast.KindListItem {
-			return ast.WalkContinue, nil
-		}
-		_, _ = w.WriteString("\n")
+	if entering {
+		r.blockEnter(w, node)
+		return ast.WalkContinue, nil
 	}
+	if node.Parent() != nil && node.Parent().Kind() == ast.KindListItem {
+		return ast.WalkContinue, nil
+	}
+	_, _ = w.WriteString("\n")
 	return ast.WalkContinue, nil
 }
 
@@ -236,6 +249,7 @@ func (r *terminalRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte
 	if !entering {
 		return ast.WalkContinue, nil
 	}
+	r.blockEnter(w, node)
 	n := node.(*ast.FencedCodeBlock)
 
 	lang := ""
@@ -256,9 +270,7 @@ func (r *terminalRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte
 		_, _ = w.WriteString(code)
 		return ast.WalkSkipChildren, nil
 	}
-	_, _ = w.WriteString("\n")
 	_, _ = w.WriteString(wrapInBox(highlighted, lang))
-	_, _ = w.WriteString("\n")
 	return ast.WalkSkipChildren, nil
 }
 
@@ -266,6 +278,7 @@ func (r *terminalRenderer) renderCodeBlock(w util.BufWriter, source []byte, node
 	if !entering {
 		return ast.WalkContinue, nil
 	}
+	r.blockEnter(w, node)
 	n := node.(*ast.CodeBlock)
 
 	var codeBuf bytes.Buffer
@@ -281,9 +294,7 @@ func (r *terminalRenderer) renderCodeBlock(w util.BufWriter, source []byte, node
 		_, _ = w.WriteString(code)
 		return ast.WalkSkipChildren, nil
 	}
-	_, _ = w.WriteString("\n")
 	_, _ = w.WriteString(wrapInBox(highlighted, ""))
-	_, _ = w.WriteString("\n")
 	return ast.WalkSkipChildren, nil
 }
 
@@ -301,8 +312,8 @@ func (r *terminalRenderer) renderCodeSpan(w util.BufWriter, source []byte, node 
 }
 
 func (r *terminalRenderer) renderList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	if !entering {
-		_, _ = w.WriteString("\n")
+	if entering {
+		r.blockEnter(w, node)
 	}
 	return ast.WalkContinue, nil
 }
@@ -346,9 +357,8 @@ func (r *terminalRenderer) renderListItem(w util.BufWriter, source []byte, node 
 
 func (r *terminalRenderer) renderBlockquote(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
+		r.blockEnter(w, node)
 		_, _ = w.WriteString("\x1b[38;5;245m│ \x1b[0m")
-	} else {
-		_, _ = w.WriteString("\n")
 	}
 	return ast.WalkContinue, nil
 }
@@ -365,7 +375,15 @@ func (r *terminalRenderer) renderImage(w util.BufWriter, source []byte, node ast
 }
 
 func (r *terminalRenderer) renderThematicBreak(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	_, _ = w.WriteString("\n")
+	if entering {
+		r.blockEnter(w, node)
+		width := getTermWidth()
+		if width <= 0 {
+			width = 40
+		}
+		_, _ = w.WriteString(strings.Repeat("─", width))
+		_, _ = w.WriteString("\n")
+	}
 	return ast.WalkContinue, nil
 }
 
@@ -388,6 +406,7 @@ func drawTableBorder(w util.BufWriter, widths []int, left, cross, right string) 
 
 func (r *terminalRenderer) renderTable(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
+		r.blockEnter(w, node)
 		// Pre-compute column widths by walking the table AST once before
 		// the renderer walks it for output. Add 2 for 1-space padding on
 		// each side of the cell content.

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -292,8 +292,8 @@ func (r *terminalRenderer) renderCodeSpan(w util.BufWriter, source []byte, node 
 		return ast.WalkContinue, nil
 	}
 	if entering {
-		r.pushStyle("\x1b[90m")
-		_, _ = w.WriteString("\x1b[90m")
+		r.pushStyle("\x1b[48;2;177;185;249m")
+		_, _ = w.WriteString("\x1b[48;2;177;185;249m")
 	} else {
 		r.closeStyle(w)
 	}

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -91,15 +91,21 @@ func (r *terminalRenderer) blockEnter(w util.BufWriter, node ast.Node) {
 // literal '|' characters inside inline code spans within table rows. Goldmark's
 // table parser treats every '|' as a column separator even when it appears
 // inside backticks, so we mask it during parsing and restore it during render.
-const pipePlaceholder = ""
+const pipePlaceholder = "\x01\x02\x03"
 
 // preprocessTableRows escapes '|' characters inside inline code spans (`...`)
 // within lines that contain a table delimiter, preventing goldmark's table
 // parser from splitting the cell at the pipe.
 func preprocessTableRows(text string) string {
 	lines := strings.Split(text, "\n")
+	inCodeBlock := false
 	for i, line := range lines {
-		if !strings.Contains(line, "|") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+		if inCodeBlock || !strings.Contains(line, "|") {
 			continue
 		}
 		lines[i] = escapePipesInInlineCode(line)
@@ -148,10 +154,13 @@ func getCellText(cell ast.Node, source []byte) string {
 		if !entering {
 			return ast.WalkContinue, nil
 		}
-		if n.Kind() == ast.KindText {
+		switch n.Kind() {
+		case ast.KindText:
 			text := string(n.(*ast.Text).Segment.Value(source))
 			text = strings.ReplaceAll(text, pipePlaceholder, "|")
 			b.WriteString(text)
+		case ast.KindImage:
+			b.WriteString("[image]")
 		}
 		return ast.WalkContinue, nil
 	})
@@ -202,9 +211,13 @@ func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node a
 func (r *terminalRenderer) renderParagraph(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		r.blockEnter(w, node)
-		return ast.WalkContinue, nil
-	}
-	if node.Parent() != nil && node.Parent().Kind() == ast.KindListItem {
+		if node.Parent() != nil && node.Parent().Kind() == ast.KindBlockquote {
+			if r.color {
+				_, _ = w.WriteString("\x1b[38;5;245m│ \x1b[0m")
+			} else {
+				_, _ = w.WriteString("│ ")
+			}
+		}
 		return ast.WalkContinue, nil
 	}
 	_, _ = w.WriteString("\n")
@@ -330,6 +343,9 @@ func (r *terminalRenderer) renderList(w util.BufWriter, source []byte, node ast.
 
 func (r *terminalRenderer) renderListItem(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
+		if node.PreviousSibling() != nil {
+			_, _ = w.WriteString("\n")
+		}
 		parent := node.Parent()
 		var prefix string
 		if parent != nil && parent.Kind() == ast.KindList {

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -119,16 +119,11 @@ func (r *terminalRenderer) renderDocument(w util.BufWriter, source []byte, node 
 }
 
 func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	n := node.(*ast.Heading)
 	if entering {
 		if useColor() {
 			r.pushStyle("\x1b[1m")
 			_, _ = w.WriteString("\x1b[1m")
 		}
-		for i := 0; i < n.Level; i++ {
-			_, _ = w.WriteString("#")
-		}
-		_, _ = w.WriteString(" ")
 	} else {
 		if useColor() {
 			r.closeStyle(w)

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	extast "github.com/yuin/goldmark/extension/ast"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/util"
 )
@@ -77,6 +79,10 @@ func (r *terminalRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer
 	reg.Register(ast.KindLink, r.renderLink)
 	reg.Register(ast.KindImage, r.renderImage)
 	reg.Register(ast.KindThematicBreak, r.renderThematicBreak)
+	reg.Register(extast.KindTable, r.renderTable)
+	reg.Register(extast.KindTableHeader, r.renderTableHeader)
+	reg.Register(extast.KindTableRow, r.renderTableRow)
+	reg.Register(extast.KindTableCell, r.renderTableCell)
 }
 
 func (r *terminalRenderer) renderDocument(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -283,6 +289,56 @@ func (r *terminalRenderer) renderThematicBreak(w util.BufWriter, source []byte, 
 	return ast.WalkContinue, nil
 }
 
+func (r *terminalRenderer) renderTable(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderTableHeader(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		if useColor() {
+			r.pushStyle("\x1b[1m")
+			_, _ = w.WriteString("\x1b[1m")
+		}
+		return ast.WalkContinue, nil
+	}
+	// Exiting header: newline, then separator line.
+	_, _ = w.WriteString("\n")
+	if useColor() {
+		r.closeStyle(w)
+	}
+	if table, ok := node.Parent().(*extast.Table); ok && len(table.Alignments) > 0 {
+		cols := len(table.Alignments)
+		for i := 0; i < cols; i++ {
+			if i > 0 {
+				_, _ = w.WriteString(" | ")
+			}
+			_, _ = w.WriteString("---")
+		}
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderTableRow(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderTableCell(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	if node.PreviousSibling() != nil {
+		_, _ = w.WriteString(" | ")
+	}
+	return ast.WalkContinue, nil
+}
+
 // RenderMarkdown renders markdown text to terminal-friendly output with ANSI
 // color codes. It uses goldmark to parse the markdown and a custom renderer
 // to produce terminal output.
@@ -299,10 +355,11 @@ func renderMarkdown(text string, color bool) string {
 	tr := newTerminalRenderer()
 
 	md := goldmark.New(
+		goldmark.WithExtensions(extension.Table),
 		goldmark.WithRenderer(
 			renderer.NewRenderer(
 				renderer.WithNodeRenderers(
-					util.Prioritized(tr, 1000),
+					util.Prioritized(tr, 100),
 				),
 			),
 		),

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -1,0 +1,315 @@
+package clifmt
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+// terminalRenderer renders a goldmark AST to terminal-friendly output with
+// ANSI color codes.
+type terminalRenderer struct {
+	styleStack []string
+}
+
+func newTerminalRenderer() *terminalRenderer {
+	return &terminalRenderer{}
+}
+
+func (r *terminalRenderer) pushStyle(code string) {
+	r.styleStack = append(r.styleStack, code)
+}
+
+func (r *terminalRenderer) popStyle() string {
+	if len(r.styleStack) == 0 {
+		return ""
+	}
+	last := len(r.styleStack) - 1
+	code := r.styleStack[last]
+	r.styleStack = r.styleStack[:last]
+	return code
+}
+
+func (r *terminalRenderer) currentStyles() string {
+	var b strings.Builder
+	for _, code := range r.styleStack {
+		b.WriteString(code)
+	}
+	return b.String()
+}
+
+func (r *terminalRenderer) applyStyles(w util.BufWriter) {
+	if !useColor() {
+		return
+	}
+	styles := r.currentStyles()
+	if styles != "" {
+		w.WriteString(styles)
+	}
+}
+
+func (r *terminalRenderer) closeStyle(w util.BufWriter) {
+	if !useColor() {
+		return
+	}
+	r.popStyle()
+	w.WriteString("\x1b[0m")
+	r.applyStyles(w)
+}
+
+func (r *terminalRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindDocument, r.renderDocument)
+	reg.Register(ast.KindHeading, r.renderHeading)
+	reg.Register(ast.KindParagraph, r.renderParagraph)
+	reg.Register(ast.KindText, r.renderText)
+	reg.Register(ast.KindEmphasis, r.renderEmphasis)
+	reg.Register(ast.KindFencedCodeBlock, r.renderFencedCodeBlock)
+	reg.Register(ast.KindCodeBlock, r.renderCodeBlock)
+	reg.Register(ast.KindCodeSpan, r.renderCodeSpan)
+	reg.Register(ast.KindList, r.renderList)
+	reg.Register(ast.KindListItem, r.renderListItem)
+	reg.Register(ast.KindBlockquote, r.renderBlockquote)
+	reg.Register(ast.KindLink, r.renderLink)
+	reg.Register(ast.KindImage, r.renderImage)
+	reg.Register(ast.KindThematicBreak, r.renderThematicBreak)
+}
+
+func (r *terminalRenderer) renderDocument(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	n := node.(*ast.Heading)
+	if entering {
+		if useColor() {
+			r.pushStyle("\x1b[1m")
+			_, _ = w.WriteString("\x1b[1m")
+		}
+		for i := 0; i < n.Level; i++ {
+			_, _ = w.WriteString("#")
+		}
+		_, _ = w.WriteString(" ")
+	} else {
+		if useColor() {
+			r.closeStyle(w)
+		}
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderParagraph(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		if node.Parent() != nil && node.Parent().Kind() == ast.KindListItem {
+			return ast.WalkContinue, nil
+		}
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderText(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.Text)
+	_, _ = w.Write(n.Segment.Value(source))
+	if n.HardLineBreak() {
+		_, _ = w.WriteString("\n")
+	} else if n.SoftLineBreak() {
+		_, _ = w.WriteString(" ")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderEmphasis(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !useColor() {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.Emphasis)
+	if entering {
+		if n.Level >= 2 {
+			r.pushStyle("\x1b[1m")
+			_, _ = w.WriteString("\x1b[1m")
+		} else {
+			r.pushStyle("\x1b[3m")
+			_, _ = w.WriteString("\x1b[3m")
+		}
+	} else {
+		r.closeStyle(w)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.FencedCodeBlock)
+
+	lang := ""
+	if n.Info != nil {
+		lang = strings.TrimSpace(string(n.Info.Text(source)))
+	}
+
+	var codeBuf bytes.Buffer
+	lines := n.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
+		_, _ = codeBuf.Write(line.Value(source))
+	}
+	code := codeBuf.String()
+
+	highlighted, err := highlightCode(code, lang)
+	if err != nil {
+		_, _ = w.WriteString(code)
+		return ast.WalkSkipChildren, nil
+	}
+	_, _ = w.WriteString("\n")
+	_, _ = w.WriteString(wrapInBox(highlighted, lang))
+	_, _ = w.WriteString("\n")
+	return ast.WalkSkipChildren, nil
+}
+
+func (r *terminalRenderer) renderCodeBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.CodeBlock)
+
+	var codeBuf bytes.Buffer
+	lines := n.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
+		_, _ = codeBuf.Write(line.Value(source))
+	}
+	code := codeBuf.String()
+
+	highlighted, err := highlightCode(code, "")
+	if err != nil {
+		_, _ = w.WriteString(code)
+		return ast.WalkSkipChildren, nil
+	}
+	_, _ = w.WriteString("\n")
+	_, _ = w.WriteString(wrapInBox(highlighted, ""))
+	_, _ = w.WriteString("\n")
+	return ast.WalkSkipChildren, nil
+}
+
+func (r *terminalRenderer) renderCodeSpan(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !useColor() {
+		return ast.WalkContinue, nil
+	}
+	if entering {
+		r.pushStyle("\x1b[90m")
+		_, _ = w.WriteString("\x1b[90m")
+	} else {
+		r.closeStyle(w)
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderListItem(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		parent := node.Parent()
+		var prefix string
+		if parent != nil && parent.Kind() == ast.KindList {
+			list := parent.(*ast.List)
+			if list.IsOrdered() {
+				idx := 1
+				for prev := node.PreviousSibling(); prev != nil; prev = prev.PreviousSibling() {
+					if prev.Kind() == ast.KindListItem {
+						idx++
+					}
+				}
+				start := list.Start
+				if start < 1 {
+					start = 1
+				}
+				prefix = fmt.Sprintf("  %d. ", start+idx-1)
+			} else {
+				prefix = "  • "
+			}
+		} else {
+			prefix = "  • "
+		}
+		if useColor() {
+			_, _ = w.WriteString("\x1b[38;5;245m")
+			_, _ = w.WriteString(prefix)
+			_, _ = w.WriteString("\x1b[0m")
+		} else {
+			_, _ = w.WriteString(prefix)
+		}
+	} else {
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderBlockquote(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString("\x1b[38;5;245m│ \x1b[0m")
+	} else {
+		_, _ = w.WriteString("\n")
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderLink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	return ast.WalkContinue, nil
+}
+
+func (r *terminalRenderer) renderImage(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString("[image]")
+	}
+	return ast.WalkSkipChildren, nil
+}
+
+func (r *terminalRenderer) renderThematicBreak(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	_, _ = w.WriteString("\n")
+	return ast.WalkContinue, nil
+}
+
+// RenderMarkdown renders markdown text to terminal-friendly output with ANSI
+// color codes. It uses goldmark to parse the markdown and a custom renderer
+// to produce terminal output.
+func RenderMarkdown(text string) string {
+	return renderMarkdown(text, useColor())
+}
+
+func renderMarkdown(text string, color bool) string {
+	if !color {
+		return HighlightCodeBlocks(text)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	tr := newTerminalRenderer()
+
+	md := goldmark.New(
+		goldmark.WithRenderer(
+			renderer.NewRenderer(
+				renderer.WithNodeRenderers(
+					util.Prioritized(tr, 1000),
+				),
+			),
+		),
+	)
+
+	if err := md.Convert([]byte(text), buf); err != nil {
+		return HighlightCodeBlocks(text)
+	}
+	return buf.String()
+}

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -17,7 +17,7 @@ import (
 // terminalRenderer renders a goldmark AST to terminal-friendly output with
 // ANSI color codes.
 type terminalRenderer struct {
-	color bool
+	color      bool
 	styleStack []string
 
 	// tableColWidths holds the pre-computed display width for each column
@@ -87,6 +87,30 @@ func (r *terminalRenderer) blockEnter(w util.BufWriter, node ast.Node) {
 	}
 }
 
+// writeBlockquotePrefix writes the gray "│ " prefix when node is a direct
+// child of a Blockquote (or when a ListItem's parent List is a direct child).
+func (r *terminalRenderer) writeBlockquotePrefix(w util.BufWriter, node ast.Node) {
+	isInBlockquote := false
+	parent := node.Parent()
+	if parent != nil && parent.Kind() == ast.KindBlockquote {
+		isInBlockquote = true
+	}
+	if !isInBlockquote && parent != nil && parent.Kind() == ast.KindList {
+		grandparent := parent.Parent()
+		if grandparent != nil && grandparent.Kind() == ast.KindBlockquote {
+			isInBlockquote = true
+		}
+	}
+	if !isInBlockquote {
+		return
+	}
+	if r.color {
+		w.WriteString("\x1b[38;5;245m│ \x1b[0m")
+	} else {
+		w.WriteString("│ ")
+	}
+}
+
 // pipePlaceholder is a Private Use Area character used to temporarily replace
 // literal '|' characters inside inline code spans within table rows. Goldmark's
 // table parser treats every '|' as a column separator even when it appears
@@ -99,13 +123,33 @@ const pipePlaceholder = "\x01\x02\x03"
 func preprocessTableRows(text string) string {
 	lines := strings.Split(text, "\n")
 	inCodeBlock := false
+	var fenceChar byte
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "```") {
-			inCodeBlock = !inCodeBlock
-			continue
+		if len(trimmed) >= 3 {
+			c := trimmed[0]
+			if c == '`' || c == '~' {
+				j := 0
+				for j < len(trimmed) && trimmed[j] == c {
+					j++
+				}
+				if j >= 3 {
+					if !inCodeBlock {
+						inCodeBlock = true
+						fenceChar = c
+					} else if c == fenceChar {
+						inCodeBlock = false
+						fenceChar = 0
+					}
+					continue
+				}
+			}
 		}
 		if inCodeBlock || !strings.Contains(line, "|") {
+			continue
+		}
+		// Skip indented code blocks (4+ leading spaces).
+		if len(line) >= 4 && line[0] == ' ' && line[1] == ' ' && line[2] == ' ' && line[3] == ' ' {
 			continue
 		}
 		lines[i] = escapePipesInInlineCode(line)
@@ -113,35 +157,52 @@ func preprocessTableRows(text string) string {
 	return strings.Join(lines, "\n")
 }
 
+// escapePipesInInlineCode replaces '|' characters that appear inside Markdown
+// inline code spans. It respects matching backtick-run delimiters, so “a|b“
+// is handled correctly in addition to `a|b`.
 func escapePipesInInlineCode(line string) string {
 	var b strings.Builder
 	b.Grow(len(line))
-	inCode := false
-	var codeBuf strings.Builder
-	for i := 0; i < len(line); i++ {
-		if line[i] == '`' {
-			if inCode {
-				inner := codeBuf.String()
-				inner = strings.ReplaceAll(inner, "|", pipePlaceholder)
-				b.WriteString("`")
-				b.WriteString(inner)
-				b.WriteString("`")
-				codeBuf.Reset()
-				inCode = false
-			} else {
-				inCode = true
-			}
+	i := 0
+	for i < len(line) {
+		if line[i] != '`' {
+			b.WriteByte(line[i])
+			i++
 			continue
 		}
-		if inCode {
-			codeBuf.WriteByte(line[i])
-		} else {
-			b.WriteByte(line[i])
+		// Count the opening backtick run.
+		start := i
+		for i < len(line) && line[i] == '`' {
+			i++
 		}
-	}
-	if inCode {
-		b.WriteString("`")
-		b.WriteString(codeBuf.String())
+		tickLen := i - start
+
+		// Search for a closing run of the same length.
+		j := i
+		for j < len(line) {
+			if line[j] != '`' {
+				j++
+				continue
+			}
+			runStart := j
+			for j < len(line) && line[j] == '`' {
+				j++
+			}
+			if j-runStart == tickLen {
+				inner := line[i:runStart]
+				inner = strings.ReplaceAll(inner, "|", pipePlaceholder)
+				b.WriteString(line[start:i])    // opening backticks
+				b.WriteString(inner)            // content with pipes escaped
+				b.WriteString(line[runStart:j]) // closing backticks
+				i = j
+				break
+			}
+		}
+		if j >= len(line) {
+			// No matching close — write remainder unchanged.
+			b.WriteString(line[start:])
+			break
+		}
 	}
 	return b.String()
 }
@@ -195,6 +256,7 @@ func (r *terminalRenderer) renderDocument(w util.BufWriter, source []byte, node 
 func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		r.blockEnter(w, node)
+		r.writeBlockquotePrefix(w, node)
 		if r.color {
 			r.pushStyle("\x1b[1m")
 			_, _ = w.WriteString("\x1b[1m")
@@ -211,13 +273,7 @@ func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node a
 func (r *terminalRenderer) renderParagraph(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		r.blockEnter(w, node)
-		if node.Parent() != nil && node.Parent().Kind() == ast.KindBlockquote {
-			if r.color {
-				_, _ = w.WriteString("\x1b[38;5;245m│ \x1b[0m")
-			} else {
-				_, _ = w.WriteString("│ ")
-			}
-		}
+		r.writeBlockquotePrefix(w, node)
 		return ast.WalkContinue, nil
 	}
 	_, _ = w.WriteString("\n")
@@ -264,6 +320,7 @@ func (r *terminalRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte
 		return ast.WalkContinue, nil
 	}
 	r.blockEnter(w, node)
+	r.writeBlockquotePrefix(w, node)
 	n := node.(*ast.FencedCodeBlock)
 
 	var codeBuf bytes.Buffer
@@ -297,6 +354,7 @@ func (r *terminalRenderer) renderCodeBlock(w util.BufWriter, source []byte, node
 		return ast.WalkContinue, nil
 	}
 	r.blockEnter(w, node)
+	r.writeBlockquotePrefix(w, node)
 	n := node.(*ast.CodeBlock)
 
 	var codeBuf bytes.Buffer
@@ -346,6 +404,7 @@ func (r *terminalRenderer) renderListItem(w util.BufWriter, source []byte, node 
 		if node.PreviousSibling() != nil {
 			_, _ = w.WriteString("\n")
 		}
+		r.writeBlockquotePrefix(w, node)
 		parent := node.Parent()
 		var prefix string
 		if parent != nil && parent.Kind() == ast.KindList {
@@ -384,11 +443,6 @@ func (r *terminalRenderer) renderListItem(w util.BufWriter, source []byte, node 
 func (r *terminalRenderer) renderBlockquote(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		r.blockEnter(w, node)
-		if r.color {
-			_, _ = w.WriteString("\x1b[38;5;245m│ \x1b[0m")
-		} else {
-			_, _ = w.WriteString("│ ")
-		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -407,6 +461,7 @@ func (r *terminalRenderer) renderImage(w util.BufWriter, source []byte, node ast
 func (r *terminalRenderer) renderThematicBreak(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		r.blockEnter(w, node)
+		r.writeBlockquotePrefix(w, node)
 		width := getTermWidth()
 		if width <= 0 {
 			width = 40

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -292,8 +292,8 @@ func (r *terminalRenderer) renderCodeSpan(w util.BufWriter, source []byte, node 
 		return ast.WalkContinue, nil
 	}
 	if entering {
-		r.pushStyle("\x1b[48;2;177;185;249m")
-		_, _ = w.WriteString("\x1b[48;2;177;185;249m")
+		r.pushStyle("\x1b[38;2;177;185;249m")
+		_, _ = w.WriteString("\x1b[38;2;177;185;249m")
 	} else {
 		r.closeStyle(w)
 	}

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
@@ -17,6 +18,13 @@ import (
 // ANSI color codes.
 type terminalRenderer struct {
 	styleStack []string
+
+	// tableColWidths holds the pre-computed display width for each column
+	// in the current table. Populated when entering a Table node and cleared
+	// when exiting.
+	tableColWidths []int
+	// tableCellIdx tracks which column is currently being rendered.
+	tableCellIdx int
 }
 
 func newTerminalRenderer() *terminalRenderer {
@@ -62,6 +70,23 @@ func (r *terminalRenderer) closeStyle(w util.BufWriter) {
 	r.popStyle()
 	w.WriteString("\x1b[0m")
 	r.applyStyles(w)
+}
+
+// getCellText extracts the raw text content from a TableCell node by walking
+// its children and accumulating Text node segments.
+func getCellText(cell ast.Node, source []byte) string {
+	var b strings.Builder
+	ast.Walk(cell, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if n.Kind() == ast.KindText {
+			text := n.(*ast.Text).Segment.Value(source)
+			b.Write(text)
+		}
+		return ast.WalkContinue, nil
+	})
+	return b.String()
 }
 
 func (r *terminalRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
@@ -290,8 +315,37 @@ func (r *terminalRenderer) renderThematicBreak(w util.BufWriter, source []byte, 
 }
 
 func (r *terminalRenderer) renderTable(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	if !entering {
+	if entering {
+		// Pre-compute column widths by walking the table AST once before
+		// the renderer walks it for output.
+		colWidths := make(map[int]int)
+		ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering || n.Kind() != extast.KindTableCell {
+				return ast.WalkContinue, nil
+			}
+			cell := n.(*extast.TableCell)
+			idx := 0
+			for prev := cell.PreviousSibling(); prev != nil; prev = prev.PreviousSibling() {
+				if prev.Kind() == extast.KindTableCell {
+					idx++
+				}
+			}
+			text := getCellText(cell, source)
+			cw := runewidth.StringWidth(text)
+			if cw > colWidths[idx] {
+				colWidths[idx] = cw
+			}
+			return ast.WalkContinue, nil
+		})
+		r.tableColWidths = make([]int, len(colWidths))
+		for idx, cw := range colWidths {
+			r.tableColWidths[idx] = cw
+		}
+		r.tableCellIdx = 0
+	} else {
 		_, _ = w.WriteString("\n")
+		r.tableColWidths = nil
+		r.tableCellIdx = 0
 	}
 	return ast.WalkContinue, nil
 }
@@ -304,37 +358,48 @@ func (r *terminalRenderer) renderTableHeader(w util.BufWriter, source []byte, no
 		}
 		return ast.WalkContinue, nil
 	}
-	// Exiting header: newline, then separator line.
+	// Exiting header: newline, then a box-drawing separator line.
+	// TableHeader contains TableCell nodes directly (no intermediate TableRow),
+	// so we must reset the cell index here as well as in renderTableRow.
 	_, _ = w.WriteString("\n")
 	if useColor() {
 		r.closeStyle(w)
 	}
-	if table, ok := node.Parent().(*extast.Table); ok && len(table.Alignments) > 0 {
-		cols := len(table.Alignments)
-		for i := 0; i < cols; i++ {
+	if len(r.tableColWidths) > 0 {
+		for i, width := range r.tableColWidths {
 			if i > 0 {
-				_, _ = w.WriteString(" | ")
+				_, _ = w.WriteString("─┼─")
 			}
-			_, _ = w.WriteString("---")
+			_, _ = w.WriteString(strings.Repeat("─", width))
 		}
 		_, _ = w.WriteString("\n")
 	}
+	r.tableCellIdx = 0
 	return ast.WalkContinue, nil
 }
 
 func (r *terminalRenderer) renderTableRow(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
 		_, _ = w.WriteString("\n")
+		r.tableCellIdx = 0
 	}
 	return ast.WalkContinue, nil
 }
 
 func (r *terminalRenderer) renderTableCell(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
+		if r.tableCellIdx < len(r.tableColWidths) {
+			text := getCellText(node.(*extast.TableCell), source)
+			pad := r.tableColWidths[r.tableCellIdx] - runewidth.StringWidth(text)
+			if pad > 0 {
+				_, _ = w.WriteString(strings.Repeat(" ", pad))
+			}
+			r.tableCellIdx++
+		}
 		return ast.WalkContinue, nil
 	}
 	if node.PreviousSibling() != nil {
-		_, _ = w.WriteString(" | ")
+		_, _ = w.WriteString(" │ ")
 	}
 	return ast.WalkContinue, nil
 }

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -76,6 +76,59 @@ func (r *terminalRenderer) closeStyle(w util.BufWriter) {
 	r.applyStyles(w)
 }
 
+// pipePlaceholder is a Private Use Area character used to temporarily replace
+// literal '|' characters inside inline code spans within table rows. Goldmark's
+// table parser treats every '|' as a column separator even when it appears
+// inside backticks, so we mask it during parsing and restore it during render.
+const pipePlaceholder = ""
+
+// preprocessTableRows escapes '|' characters inside inline code spans (`...`)
+// within lines that contain a table delimiter, preventing goldmark's table
+// parser from splitting the cell at the pipe.
+func preprocessTableRows(text string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "|") {
+			continue
+		}
+		lines[i] = escapePipesInInlineCode(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func escapePipesInInlineCode(line string) string {
+	var b strings.Builder
+	b.Grow(len(line))
+	inCode := false
+	var codeBuf strings.Builder
+	for i := 0; i < len(line); i++ {
+		if line[i] == '`' {
+			if inCode {
+				inner := codeBuf.String()
+				inner = strings.ReplaceAll(inner, "|", pipePlaceholder)
+				b.WriteString("`")
+				b.WriteString(inner)
+				b.WriteString("`")
+				codeBuf.Reset()
+				inCode = false
+			} else {
+				inCode = true
+			}
+			continue
+		}
+		if inCode {
+			codeBuf.WriteByte(line[i])
+		} else {
+			b.WriteByte(line[i])
+		}
+	}
+	if inCode {
+		b.WriteString("`")
+		b.WriteString(codeBuf.String())
+	}
+	return b.String()
+}
+
 // getCellText extracts the raw text content from a TableCell node by walking
 // its children and accumulating Text node segments.
 func getCellText(cell ast.Node, source []byte) string {
@@ -85,8 +138,9 @@ func getCellText(cell ast.Node, source []byte) string {
 			return ast.WalkContinue, nil
 		}
 		if n.Kind() == ast.KindText {
-			text := n.(*ast.Text).Segment.Value(source)
-			b.Write(text)
+			text := string(n.(*ast.Text).Segment.Value(source))
+			text = strings.ReplaceAll(text, pipePlaceholder, "|")
+			b.WriteString(text)
 		}
 		return ast.WalkContinue, nil
 	})
@@ -148,7 +202,9 @@ func (r *terminalRenderer) renderText(w util.BufWriter, source []byte, node ast.
 		return ast.WalkContinue, nil
 	}
 	n := node.(*ast.Text)
-	_, _ = w.Write(n.Segment.Value(source))
+	text := string(n.Segment.Value(source))
+	text = strings.ReplaceAll(text, pipePlaceholder, "|")
+	_, _ = w.WriteString(text)
 	if n.HardLineBreak() {
 		_, _ = w.WriteString("\n")
 	} else if n.SoftLineBreak() {
@@ -441,6 +497,8 @@ func renderMarkdown(text string, color bool) string {
 	if !color {
 		return HighlightCodeBlocks(text)
 	}
+
+	text = preprocessTableRows(text)
 
 	buf := bytes.NewBuffer(nil)
 	tr := newTerminalRenderer()

--- a/internal/clifmt/markdown.go
+++ b/internal/clifmt/markdown.go
@@ -17,6 +17,7 @@ import (
 // terminalRenderer renders a goldmark AST to terminal-friendly output with
 // ANSI color codes.
 type terminalRenderer struct {
+	color bool
 	styleStack []string
 
 	// tableColWidths holds the pre-computed display width for each column
@@ -31,8 +32,8 @@ type terminalRenderer struct {
 	tableRowCount int
 }
 
-func newTerminalRenderer() *terminalRenderer {
-	return &terminalRenderer{}
+func newTerminalRenderer(color bool) *terminalRenderer {
+	return &terminalRenderer{color: color}
 }
 
 func (r *terminalRenderer) pushStyle(code string) {
@@ -58,7 +59,7 @@ func (r *terminalRenderer) currentStyles() string {
 }
 
 func (r *terminalRenderer) applyStyles(w util.BufWriter) {
-	if !useColor() {
+	if !r.color {
 		return
 	}
 	styles := r.currentStyles()
@@ -68,7 +69,7 @@ func (r *terminalRenderer) applyStyles(w util.BufWriter) {
 }
 
 func (r *terminalRenderer) closeStyle(w util.BufWriter) {
-	if !useColor() {
+	if !r.color {
 		return
 	}
 	r.popStyle()
@@ -185,12 +186,12 @@ func (r *terminalRenderer) renderDocument(w util.BufWriter, source []byte, node 
 func (r *terminalRenderer) renderHeading(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		r.blockEnter(w, node)
-		if useColor() {
+		if r.color {
 			r.pushStyle("\x1b[1m")
 			_, _ = w.WriteString("\x1b[1m")
 		}
 	} else {
-		if useColor() {
+		if r.color {
 			r.closeStyle(w)
 		}
 		_, _ = w.WriteString("\n")
@@ -227,7 +228,7 @@ func (r *terminalRenderer) renderText(w util.BufWriter, source []byte, node ast.
 }
 
 func (r *terminalRenderer) renderEmphasis(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	if !useColor() {
+	if !r.color {
 		return ast.WalkContinue, nil
 	}
 	n := node.(*ast.Emphasis)
@@ -252,11 +253,6 @@ func (r *terminalRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte
 	r.blockEnter(w, node)
 	n := node.(*ast.FencedCodeBlock)
 
-	lang := ""
-	if n.Info != nil {
-		lang = strings.TrimSpace(string(n.Info.Text(source)))
-	}
-
 	var codeBuf bytes.Buffer
 	lines := n.Lines()
 	for i := 0; i < lines.Len(); i++ {
@@ -265,6 +261,15 @@ func (r *terminalRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte
 	}
 	code := codeBuf.String()
 
+	if !r.color {
+		_, _ = w.WriteString(code)
+		return ast.WalkSkipChildren, nil
+	}
+
+	lang := ""
+	if n.Info != nil {
+		lang = strings.TrimSpace(string(n.Info.Text(source)))
+	}
 	highlighted, err := highlightCode(code, lang)
 	if err != nil {
 		_, _ = w.WriteString(code)
@@ -289,6 +294,11 @@ func (r *terminalRenderer) renderCodeBlock(w util.BufWriter, source []byte, node
 	}
 	code := codeBuf.String()
 
+	if !r.color {
+		_, _ = w.WriteString(code)
+		return ast.WalkSkipChildren, nil
+	}
+
 	highlighted, err := highlightCode(code, "")
 	if err != nil {
 		_, _ = w.WriteString(code)
@@ -299,7 +309,7 @@ func (r *terminalRenderer) renderCodeBlock(w util.BufWriter, source []byte, node
 }
 
 func (r *terminalRenderer) renderCodeSpan(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	if !useColor() {
+	if !r.color {
 		return ast.WalkContinue, nil
 	}
 	if entering {
@@ -342,7 +352,7 @@ func (r *terminalRenderer) renderListItem(w util.BufWriter, source []byte, node 
 		} else {
 			prefix = "  • "
 		}
-		if useColor() {
+		if r.color {
 			_, _ = w.WriteString("\x1b[38;5;245m")
 			_, _ = w.WriteString(prefix)
 			_, _ = w.WriteString("\x1b[0m")
@@ -358,7 +368,11 @@ func (r *terminalRenderer) renderListItem(w util.BufWriter, source []byte, node 
 func (r *terminalRenderer) renderBlockquote(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		r.blockEnter(w, node)
-		_, _ = w.WriteString("\x1b[38;5;245m│ \x1b[0m")
+		if r.color {
+			_, _ = w.WriteString("\x1b[38;5;245m│ \x1b[0m")
+		} else {
+			_, _ = w.WriteString("│ ")
+		}
 	}
 	return ast.WalkContinue, nil
 }
@@ -455,7 +469,7 @@ func (r *terminalRenderer) renderTable(w util.BufWriter, source []byte, node ast
 
 func (r *terminalRenderer) renderTableHeader(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		if useColor() {
+		if r.color {
 			r.pushStyle("\x1b[1m")
 			_, _ = w.WriteString("\x1b[1m")
 		}
@@ -466,7 +480,7 @@ func (r *terminalRenderer) renderTableHeader(w util.BufWriter, source []byte, no
 	// TableHeader contains TableCell nodes directly (no intermediate TableRow),
 	// so we must reset the cell index here as well as in renderTableRow.
 	_, _ = w.WriteString("│\n")
-	if useColor() {
+	if r.color {
 		r.closeStyle(w)
 	}
 	drawTableBorder(w, r.tableColWidths, "├", "┼", "┤")
@@ -513,14 +527,10 @@ func RenderMarkdown(text string) string {
 }
 
 func renderMarkdown(text string, color bool) string {
-	if !color {
-		return HighlightCodeBlocks(text)
-	}
-
 	text = preprocessTableRows(text)
 
 	buf := bytes.NewBuffer(nil)
-	tr := newTerminalRenderer()
+	tr := newTerminalRenderer(color)
 
 	md := goldmark.New(
 		goldmark.WithExtensions(extension.Table),

--- a/internal/clifmt/markdown_test.go
+++ b/internal/clifmt/markdown_test.go
@@ -60,3 +60,29 @@ func TestRenderMarkdownBlockquote(t *testing.T) {
 		t.Fatalf("expected blockquote prefix, got: %q", out)
 	}
 }
+
+func TestRenderMarkdownTable(t *testing.T) {
+	input := "| Name | Value |\n|------|-------|\n| foo  | bar   |"
+	out := renderMarkdown(input, true)
+	// Should contain box-drawing separators, not raw markdown syntax.
+	if strings.Contains(out, "---") {
+		t.Fatalf("raw markdown separator leaked into output: %q", out)
+	}
+	if !strings.Contains(out, "─┼─") {
+		t.Fatalf("expected box-drawing separator, got: %q", out)
+	}
+	if !strings.Contains(out, "foo") || !strings.Contains(out, "bar") {
+		t.Fatalf("expected cell contents, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownTableCJK(t *testing.T) {
+	input := "| 项目 | 详情 |\n|------|------|\n| 名称 | gocli |"
+	out := renderMarkdown(input, true)
+	if strings.Contains(out, "---") {
+		t.Fatalf("raw markdown separator leaked into output: %q", out)
+	}
+	if !strings.Contains(out, "项目") || !strings.Contains(out, "名称") {
+		t.Fatalf("expected CJK cell contents, got: %q", out)
+	}
+}

--- a/internal/clifmt/markdown_test.go
+++ b/internal/clifmt/markdown_test.go
@@ -1,0 +1,62 @@
+package clifmt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdownHeading(t *testing.T) {
+	input := "# Hello\n\nSome text"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "# Hello") {
+		t.Fatalf("expected heading, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownBold(t *testing.T) {
+	input := "This is **bold** text"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "bold") {
+		t.Fatalf("expected bold text, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownCodeBlock(t *testing.T) {
+	input := "```go\npackage main\n```"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "package") || !strings.Contains(out, "main") {
+		t.Fatalf("expected code block, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownList(t *testing.T) {
+	input := "- item one\n- item two"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "item one") || !strings.Contains(out, "item two") {
+		t.Fatalf("expected list items, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownLink(t *testing.T) {
+	input := "[link text](https://example.com)"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "link text") {
+		t.Fatalf("expected link text, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownImage(t *testing.T) {
+	input := "![alt text](https://example.com/img.png)"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "[image]") {
+		t.Fatalf("expected image placeholder, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownBlockquote(t *testing.T) {
+	input := "> quote"
+	out := renderMarkdown(input, true)
+	if !strings.Contains(out, "│") {
+		t.Fatalf("expected blockquote prefix, got: %q", out)
+	}
+}

--- a/internal/clifmt/markdown_test.go
+++ b/internal/clifmt/markdown_test.go
@@ -108,3 +108,48 @@ func TestRenderMarkdownTablePipeInCode(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderMarkdownTildeFencedCodeBlockPreservesPipe(t *testing.T) {
+	input := "~~~go\nfmt.Println(`a|b`)\n~~~"
+	out := renderMarkdown(input, false)
+	if strings.Contains(out, "\x01\x02\x03") {
+		t.Fatalf("pipe placeholder leaked into output: %q", out)
+	}
+	if !strings.Contains(out, "a|b") {
+		t.Fatalf("expected a|b inside code block, got: %q", out)
+	}
+}
+
+func TestRenderMarkdownTableDoubleBacktickPipe(t *testing.T) {
+	input := "| Expr |\n|------|\n| ``a|b`` |"
+	out := renderMarkdown(input, false)
+	// The pipe inside ``a|b`` should stay intact and not split the cell.
+	if !strings.Contains(out, "a|b") {
+		t.Fatalf("expected a|b in table cell, got: %q", out)
+	}
+	// Make sure we still have exactly one column.
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "│") {
+			colCount := strings.Count(line, "│") - 1
+			if colCount != 1 {
+				t.Fatalf("expected 1 column, got %d in line: %q", colCount, line)
+			}
+		}
+	}
+}
+
+func TestRenderMarkdownBlockquoteMultiParagraph(t *testing.T) {
+	input := "> quote\n>\n> next"
+	out := renderMarkdown(input, false)
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), out)
+	}
+	for _, line := range lines {
+		// Each line should have exactly one "│ " prefix.
+		if strings.Count(line, "│") != 1 {
+			t.Fatalf("expected exactly one │ per line, got: %q", line)
+		}
+	}
+}

--- a/internal/clifmt/markdown_test.go
+++ b/internal/clifmt/markdown_test.go
@@ -89,3 +89,22 @@ func TestRenderMarkdownTableCJK(t *testing.T) {
 		t.Fatalf("expected CJK cell contents, got: %q", out)
 	}
 }
+
+func TestRenderMarkdownTablePipeInCode(t *testing.T) {
+	input := "| Command | Usage |\n|---------|-------|\n| calc | `gocli calc <add|sub>` |"
+	out := renderMarkdown(input, true)
+	// The pipe inside the inline code should not split the cell.
+	if !strings.Contains(out, "add|sub") {
+		t.Fatalf("expected add|sub in a single cell, got: %q", out)
+	}
+	// Make sure we still have exactly two columns (no stray third column).
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "│") {
+			colCount := strings.Count(line, "│") - 1
+			if colCount != 2 {
+				t.Fatalf("expected 2 columns, got %d in line: %q", colCount, line)
+			}
+		}
+	}
+}

--- a/internal/clifmt/markdown_test.go
+++ b/internal/clifmt/markdown_test.go
@@ -8,8 +8,11 @@ import (
 func TestRenderMarkdownHeading(t *testing.T) {
 	input := "# Hello\n\nSome text"
 	out := renderMarkdown(input, true)
-	if !strings.Contains(out, "# Hello") {
-		t.Fatalf("expected heading, got: %q", out)
+	if strings.Contains(out, "#") {
+		t.Fatalf("heading should not contain #, got: %q", out)
+	}
+	if !strings.Contains(out, "Hello") {
+		t.Fatalf("expected heading text, got: %q", out)
 	}
 }
 

--- a/internal/clifmt/syntax.go
+++ b/internal/clifmt/syntax.go
@@ -121,7 +121,9 @@ func wrapInBox(highlighted string, lang string) string {
 	}
 
 	gray := "\x1b[38;5;245m"
-	bg := "\x1b[48;2;177;185;249m" // light blue-purple background for code blocks
+	bg := "\x1b[48;5;235m" // dark grey background for code blocks
+
+	termWidth := getTermWidth()
 
 	var b strings.Builder
 	// Header line
@@ -129,6 +131,11 @@ func wrapInBox(highlighted string, lang string) string {
 	b.WriteString(gray)
 	b.WriteString(header)
 	b.WriteString("\x1b[K")
+	if termWidth > 0 {
+		if pad := termWidth - visibleWidth(header); pad > 0 {
+			b.WriteString(strings.Repeat(" ", pad))
+		}
+	}
 	b.WriteString("\x1b[0m")
 	b.WriteByte('\n')
 
@@ -146,7 +153,14 @@ func wrapInBox(highlighted string, lang string) string {
 		safe = strings.ReplaceAll(safe, "\x1b[0m", "\x1b[39m"+bg)
 		safe = reapplyBgBeforeWideChars(safe, bg)
 		b.WriteString(safe)
+		b.WriteString(bg)
 		b.WriteString("\x1b[K")
+		if termWidth > 0 {
+			used := gutterWidth + 2 + visibleWidth(safe)
+			if pad := termWidth - used; pad > 0 {
+				b.WriteString(strings.Repeat(" ", pad))
+			}
+		}
 		b.WriteString("\x1b[0m")
 		b.WriteByte('\n')
 	}

--- a/internal/clifmt/syntax.go
+++ b/internal/clifmt/syntax.go
@@ -121,8 +121,8 @@ func wrapInBox(highlighted string, lang string) string {
 	}
 
 	gray := "\x1b[38;5;245m"
-	bg := "\x1b[48;5;235m" // dark grey background for code blocks
-
+	bg := "\x1b[48;5;234m" // dark grey background for code blocks
+	fg := "\x1b[37m"       // white foreground for code-block padding
 	termWidth := getTermWidth()
 
 	var b strings.Builder
@@ -141,16 +141,10 @@ func wrapInBox(highlighted string, lang string) string {
 
 	for i, line := range lines {
 		lineNum := i + 1
-		// Gutter: background + grey line number
 		b.WriteString(bg)
-		b.WriteString(gray)
-		b.WriteString(fmt.Sprintf("%*d", gutterWidth, lineNum))
-		b.WriteString("\x1b[39m") // reset foreground only, keep background
-		b.WriteString("  ")
-		// Code: strip any existing bg colours, then make \x1b[0m only
-		// reset the foreground so the code-block bg stays active.
+		b.WriteString(fmt.Sprintf("%s%*d%s  ", gray, gutterWidth, lineNum, fg))
 		safe := ansiBgRe.ReplaceAllString(line, "")
-		safe = strings.ReplaceAll(safe, "\x1b[0m", "\x1b[39m"+bg)
+		safe = strings.ReplaceAll(safe, "\x1b[0m", "\x1b[39m"+bg+fg)
 		safe = reapplyBgBeforeWideChars(safe, bg)
 		b.WriteString(safe)
 		b.WriteString(bg)

--- a/internal/clifmt/syntax.go
+++ b/internal/clifmt/syntax.go
@@ -121,14 +121,33 @@ func wrapInBox(highlighted string, lang string) string {
 	}
 
 	gray := "\x1b[38;5;245m"
+	bg := "\x1b[48;5;235m" // dark grey background for code blocks
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("%s%s\x1b[0m\n", gray, header))
+	// Header line
+	b.WriteString(bg)
+	b.WriteString(gray)
+	b.WriteString(header)
+	b.WriteString("\x1b[K")
+	b.WriteString("\x1b[0m")
+	b.WriteByte('\n')
 
 	for i, line := range lines {
 		lineNum := i + 1
-		b.WriteString(fmt.Sprintf("%s%*d\x1b[0m  ", gray, gutterWidth, lineNum))
-		b.WriteString(line)
+		// Gutter: background + grey line number
+		b.WriteString(bg)
+		b.WriteString(gray)
+		b.WriteString(fmt.Sprintf("%*d", gutterWidth, lineNum))
+		b.WriteString("\x1b[39m") // reset foreground only, keep background
+		b.WriteString("  ")
+		// Code: strip any existing bg colours, then make \x1b[0m only
+		// reset the foreground so the code-block bg stays active.
+		safe := ansiBgRe.ReplaceAllString(line, "")
+		safe = strings.ReplaceAll(safe, "\x1b[0m", "\x1b[39m"+bg)
+		safe = reapplyBgBeforeWideChars(safe, bg)
+		b.WriteString(safe)
+		b.WriteString("\x1b[K")
+		b.WriteString("\x1b[0m")
 		b.WriteByte('\n')
 	}
 

--- a/internal/clifmt/syntax.go
+++ b/internal/clifmt/syntax.go
@@ -121,7 +121,7 @@ func wrapInBox(highlighted string, lang string) string {
 	}
 
 	gray := "\x1b[38;5;245m"
-	bg := "\x1b[48;5;235m" // dark grey background for code blocks
+	bg := "\x1b[48;2;177;185;249m" // light blue-purple background for code blocks
 
 	var b strings.Builder
 	// Header line

--- a/internal/clifmt/syntax.go
+++ b/internal/clifmt/syntax.go
@@ -65,6 +65,11 @@ func looksLikeCodeBlock(text string) bool {
 }
 
 func highlightCode(src, language string) (string, error) {
+	// Expand tabs before tokenising so the formatter never emits raw tab
+	// characters, which terminals render as a jump to the next tab stop and
+	// can misalign indented code inside boxed or guttered output.
+	src = strings.ReplaceAll(src, "\t", "    ")
+
 	var lexer chroma.Lexer
 	if language != "" {
 		lexer = lexers.Get(language)
@@ -105,19 +110,9 @@ func wrapInBox(highlighted string, lang string) string {
 		return ""
 	}
 
-	// Calculate max width for the box
-	maxWidth := 0
-	for _, line := range lines {
-		w := visibleWidth(line)
-		if w > maxWidth {
-			maxWidth = w
-		}
-	}
-
-	// Line number gutter width
 	gutterWidth := len(fmt.Sprintf("%d", len(lines)))
-	if gutterWidth < 2 {
-		gutterWidth = 2
+	if gutterWidth < 3 {
+		gutterWidth = 3
 	}
 
 	header := lang
@@ -125,45 +120,17 @@ func wrapInBox(highlighted string, lang string) string {
 		header = "code"
 	}
 
-	// Total inner width of the box (excluding the outer 1-char borders on each side)
-	// |  gutter  | content |
-	// totalInnerWidth = (2 for left padding) + (gutterWidth) + (3 for gutter divider separator) + (maxWidth) + (2 for right padding)
-	totalInnerWidth := 2 + gutterWidth + 3 + maxWidth + 2
+	gray := "\x1b[38;5;245m"
 
 	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s%s\x1b[0m\n", gray, header))
 
-	// Top border
-	b.WriteString("\x1b[90m┌── \x1b[0m")
-	b.WriteString("\x1b[1;36m" + header + "\x1b[0m")
-	topLineLen := totalInnerWidth - 3 - visibleWidth(header)
-	if topLineLen < 2 {
-		topLineLen = 2
-	}
-	b.WriteString("\x1b[90m " + strings.Repeat("─", topLineLen) + "┐\x1b[0m\n")
-
-	// Content with line numbers and side borders
 	for i, line := range lines {
 		lineNum := i + 1
-		padding := maxWidth - visibleWidth(line)
-
-		// Check for diff markers to color the gutter
-		cleanLine := stripANSI(line)
-		gutterColor := "\x1b[90m" // dim gray default
-		if strings.HasPrefix(cleanLine, "+") {
-			gutterColor = "\x1b[32m" // green
-		} else if strings.HasPrefix(cleanLine, "-") {
-			gutterColor = "\x1b[31m" // red
-		}
-
-		b.WriteString("\x1b[90m│ \x1b[0m")
-		b.WriteString(fmt.Sprintf("%s%*d │ \x1b[0m", gutterColor, gutterWidth, lineNum))
+		b.WriteString(fmt.Sprintf("%s%*d\x1b[0m  ", gray, gutterWidth, lineNum))
 		b.WriteString(line)
-		b.WriteString(strings.Repeat(" ", padding))
-		b.WriteString("\x1b[90m │\x1b[0m\n")
+		b.WriteByte('\n')
 	}
-
-	// Bottom border
-	b.WriteString("\x1b[90m└" + strings.Repeat("─", totalInnerWidth) + "┘\x1b[0m")
 
 	return b.String()
 }
@@ -223,6 +190,7 @@ func looksLikeCode(text string) bool {
 			continue
 		}
 
+		// High-confidence code signatures only.
 		if strings.HasPrefix(trimmed, "def ") ||
 			strings.HasPrefix(trimmed, "class ") ||
 			strings.HasPrefix(trimmed, "import ") ||
@@ -231,15 +199,32 @@ func looksLikeCode(text string) bool {
 			strings.HasPrefix(trimmed, "const ") ||
 			strings.HasPrefix(trimmed, "let ") ||
 			strings.HasPrefix(trimmed, "var ") ||
+			strings.HasPrefix(trimmed, "package ") ||
+			strings.HasPrefix(trimmed, "func ") ||
+			strings.HasPrefix(trimmed, "struct ") ||
+			strings.HasPrefix(trimmed, "type ") ||
+			strings.HasPrefix(trimmed, "if ") ||
+			strings.HasPrefix(trimmed, "for ") ||
+			strings.HasPrefix(trimmed, "while ") ||
+			strings.HasPrefix(trimmed, "return ") ||
+			strings.HasPrefix(trimmed, "public ") ||
+			strings.HasPrefix(trimmed, "private ") ||
+			strings.HasPrefix(trimmed, "async ") ||
+			strings.HasPrefix(trimmed, "await ") ||
+			strings.HasPrefix(trimmed, "try ") ||
+			strings.HasPrefix(trimmed, "catch ") ||
+			strings.HasPrefix(trimmed, "throw ") ||
+			strings.HasPrefix(trimmed, "new ") ||
+			strings.HasPrefix(trimmed, "else ") ||
+			strings.HasPrefix(trimmed, "elif ") ||
+			strings.HasPrefix(trimmed, "print ") ||
+			strings.HasPrefix(trimmed, "fmt.") ||
 			strings.HasPrefix(trimmed, "#") ||
 			strings.HasPrefix(trimmed, "//") ||
 			strings.HasPrefix(trimmed, "/*") ||
-			strings.HasPrefix(trimmed, "*") ||
-			strings.Contains(line, "    ") ||
-			strings.Contains(line, "\t") ||
-			(strings.Contains(line, "(") && strings.Contains(line, ")")) ||
-			(strings.Contains(line, "{") && strings.Contains(line, "}")) ||
-			(strings.Contains(line, "=") && !strings.Contains(line, "==")) {
+			strings.HasSuffix(trimmed, ";") ||
+			strings.HasSuffix(trimmed, "{") ||
+			strings.HasSuffix(trimmed, "}") {
 			codeIndicators++
 		}
 	}


### PR DESCRIPTION
## Summary

This PR replaces #51 and adds a new `terminalRenderer` based on [goldmark](https://github.com/yuin/goldmark) that parses Markdown AST and renders it directly to terminal-friendly output with ANSI color codes.

### What's supported

| Element | Rendering |
|---|---|
| Heading | Bold `## ` prefix |
| Paragraph | Normal flow |
| **Bold** / *italic* | ANSI bold / italic |
| `code` | Light blue-purple foreground |
| Code block | Syntax highlighted with line numbers, full-width dark grey background |
| Bullet list | Gray `•` prefix |
| Ordered list | Gray `1. 2. 3.` prefix |
| Blockquote | Gray `│` prefix |
| Link | Link text rendered (URL hidden) |
| Image | `[image]` placeholder |
| Table | Full box-drawing borders with aligned columns |

### Addressing feedback from #51

**Unified no-color path** — the renderer now accepts a `color bool` flag. When `useColor()` is false, all ANSI output is suppressed and goldmark still produces structured plain-text output. The old `HighlightCodeBlocks` fallback has been removed so there is only one rendering path.

### Code changes

- `internal/clifmt/markdown.go` — goldmark renderer with per-method color gating
- `internal/clifmt/markdown_test.go` — tests for heading, bold, code block, list, link, image, blockquote, table
- `internal/clifmt/clifmt.go` — remove old `RenderMarkdown` wrapper (now provided by `markdown.go`)

### Test plan

- [x] `go test ./internal/clifmt/...` passes
- [x] `go build ./cmd/mistermorph/...` passes
- [x] Terminal markdown output renders headings, lists, code blocks, tables correctly
- [x] No-color mode produces plain text without ANSI codes

---

Supersedes #51