### PR TITLE
Feat/desktop config fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,8 @@ jobs:
             goarch: arm64
             desktop_asset: mistermorph-desktop-darwin-arm64.dmg
             update_asset: mistermorph-desktop-darwin-arm64.tar.gz
-            raw_desktop_binary: dist/mistermorph-desktop
-            bundled_backend_binary: dist/mistermorph
+            raw_desktop_binary: dist/MisterMorph
+            bundled_backend_binary: dist/mistermorphc
             package_kind: dmg
             go_build_tags: "wailsdesktop production"
           - label: windows-amd64
@@ -111,8 +111,8 @@ jobs:
             goarch: amd64
             desktop_asset: mistermorph-desktop-windows-amd64.zip
             update_asset: ""
-            raw_desktop_binary: dist/mistermorph-desktop.exe
-            bundled_backend_binary: dist/mistermorph.exe
+            raw_desktop_binary: dist/MisterMorph.exe
+            bundled_backend_binary: dist/mistermorphc.exe
             package_kind: zip
             go_build_tags: "wailsdesktop production"
 
@@ -248,6 +248,7 @@ jobs:
           DESKTOP_BIN="${{ matrix.raw_desktop_binary }}" \
           BACKEND_BIN="${{ matrix.bundled_backend_binary }}" \
           OUT_DIR="dist" \
+          BUNDLED_BACKEND_NAME="mistermorphc" \
           TARBALL_PATH="dist/${{ matrix.update_asset }}" \
           CODESIGN_IDENTITY="${CODESIGN_IDENTITY}" \
           APPLE_ID="${APPLE_ID}" \
@@ -299,14 +300,14 @@ jobs:
             Remove-Item -Recurse -Force $bundle
           }
           New-Item -ItemType Directory -Path $bundle | Out-Null
-          Copy-Item "${{ matrix.raw_desktop_binary }}" "$bundle/mistermorph-desktop.exe"
-          Copy-Item "${{ matrix.bundled_backend_binary }}" "$bundle/mistermorph.exe"
+          Copy-Item "${{ matrix.raw_desktop_binary }}" "$bundle/MisterMorph.exe"
+          Copy-Item "${{ matrix.bundled_backend_binary }}" "$bundle/mistermorphc.exe"
           Copy-Item "LICENSE" "$bundle/LICENSE"
           @"
           MisterMorph Desktop for Windows.
 
-          Keep mistermorph-desktop.exe and mistermorph.exe in the same directory.
-          Launch the app with mistermorph-desktop.exe.
+          Keep MisterMorph.exe and mistermorphc.exe in the same directory.
+          Launch the app with MisterMorph.exe.
           "@ | Set-Content "$bundle/README-desktop.txt"
           if (Test-Path "dist/${{ matrix.desktop_asset }}") {
             Remove-Item -Force "dist/${{ matrix.desktop_asset }}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ go.work
 go.work.sum
 dump
 
+# OS metadata
+.DS_Store
+
 # Admin SPA dependencies
 web/console/node_modules/
 web/console/dist/

--- a/cmd/mistermorph/consolecmd/agent_settings.go
+++ b/cmd/mistermorph/consolecmd/agent_settings.go
@@ -363,13 +363,11 @@ func resolveConsoleConfigPath() (string, error) {
 	if explicit != "" {
 		return pathutil.ExpandHomePath(explicit), nil
 	}
-	for _, candidate := range []string{"config.yaml", "~/.morph/config.yaml"} {
-		resolved := pathutil.ExpandHomePath(candidate)
-		if _, err := os.Stat(resolved); err == nil {
-			return resolved, nil
-		}
+	defaultPath := pathutil.DefaultConfigPath()
+	if _, err := os.Stat(defaultPath); err == nil {
+		return defaultPath, nil
 	}
-	return filepath.Clean(pathutil.ExpandHomePath("config.yaml")), nil
+	return defaultPath, nil
 }
 
 func readAgentSettings(configPath string) (agentSettingsPayload, error) {

--- a/cmd/mistermorph/consolecmd/config_path_test.go
+++ b/cmd/mistermorph/consolecmd/config_path_test.go
@@ -1,0 +1,73 @@
+package consolecmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestResolveConsoleConfigPath_ExplicitFlagWins(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	restoreConsoleConfigKey(t)
+	viper.Set("config", "~/custom.yaml")
+
+	got, err := resolveConsoleConfigPath()
+	if err != nil {
+		t.Fatalf("resolveConsoleConfigPath() error = %v", err)
+	}
+	want := filepath.Join(home, "custom.yaml")
+	if got != filepath.Clean(want) {
+		t.Fatalf("resolveConsoleConfigPath() path = %q, want %q", got, filepath.Clean(want))
+	}
+}
+
+func TestResolveConsoleConfigPath_DefaultIgnoresCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	restoreConsoleConfigKey(t)
+	viper.Set("config", "")
+
+	wd := t.TempDir()
+	restoreConsoleWD(t, wd)
+	if err := os.WriteFile("config.yaml", []byte("llm:\n  provider: openai\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(config.yaml) error = %v", err)
+	}
+
+	got, err := resolveConsoleConfigPath()
+	if err != nil {
+		t.Fatalf("resolveConsoleConfigPath() error = %v", err)
+	}
+	want := filepath.Join(home, ".morph", "config.yaml")
+	if got != filepath.Clean(want) {
+		t.Fatalf("resolveConsoleConfigPath() path = %q, want %q", got, filepath.Clean(want))
+	}
+}
+
+func restoreConsoleConfigKey(t *testing.T) {
+	t.Helper()
+	prev, had := viper.Get("config"), viper.IsSet("config")
+	t.Cleanup(func() {
+		if had {
+			viper.Set("config", prev)
+			return
+		}
+		viper.Set("config", nil)
+	})
+}
+
+func restoreConsoleWD(t *testing.T, wd string) {
+	t.Helper()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(wd); err != nil {
+		t.Fatalf("Chdir(%q) error = %v", wd, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+}

--- a/cmd/mistermorph/install_config_wizard.go
+++ b/cmd/mistermorph/install_config_wizard.go
@@ -67,7 +67,7 @@ func findReadableInstallConfig(cmd *cobra.Command, installDir string) (string, b
 		candidates = append(candidates, pathutil.ExpandHomePath(cfgFlagPath))
 	}
 	candidates = append(candidates, filepath.Join(installDir, "config.yaml"))
-	candidates = append(candidates, filepath.Join(pathutil.ExpandHomePath("~/.morph"), "config.yaml"))
+	candidates = append(candidates, pathutil.DefaultConfigPath())
 
 	seen := map[string]bool{}
 	for _, p := range candidates {

--- a/cmd/mistermorph/root.go
+++ b/cmd/mistermorph/root.go
@@ -250,11 +250,9 @@ func resolveConfigFile() (string, bool) {
 		return pathutil.ExpandHomePath(explicit), true
 	}
 
-	for _, candidate := range []string{"config.yaml", "~/.morph/config.yaml"} {
-		resolved := pathutil.ExpandHomePath(candidate)
-		if _, err := os.Stat(resolved); err == nil {
-			return resolved, false
-		}
+	defaultPath := pathutil.DefaultConfigPath()
+	if _, err := os.Stat(defaultPath); err == nil {
+		return defaultPath, false
 	}
 	return "", false
 }

--- a/cmd/mistermorph/root_config_test.go
+++ b/cmd/mistermorph/root_config_test.go
@@ -24,7 +24,7 @@ func TestResolveConfigFile_ExplicitFlagWins(t *testing.T) {
 	}
 }
 
-func TestResolveConfigFile_DefaultOrderPrefersCWD(t *testing.T) {
+func TestResolveConfigFile_DefaultOrderIgnoresCWD(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	restoreConfigKey(t)
@@ -45,8 +45,9 @@ func TestResolveConfigFile_DefaultOrderPrefersCWD(t *testing.T) {
 	}
 
 	got, explicit := resolveConfigFile()
-	if got != filepath.Clean("config.yaml") {
-		t.Fatalf("resolveConfigFile() path = %q, want %q", got, filepath.Clean("config.yaml"))
+	want := filepath.Join(morphDir, "config.yaml")
+	if got != filepath.Clean(want) {
+		t.Fatalf("resolveConfigFile() path = %q, want %q", got, filepath.Clean(want))
 	}
 	if explicit {
 		t.Fatalf("resolveConfigFile() explicit = true, want false")

--- a/desktop/wails/README.md
+++ b/desktop/wails/README.md
@@ -4,9 +4,9 @@ This directory contains the Wails desktop host for `mistermorph`.
 
 ## Current MVP wiring
 
-- Runs a local `mistermorph console serve` subprocess on a random loopback port.
-- Prefers a sibling or configured `mistermorph` backend binary and can auto-download one as fallback.
-- If no `mistermorph` backend binary is found, desktop host tries to download a matching release binary first.
+- Runs a local backend `console serve` subprocess on a random loopback port.
+- Prefers a sibling or configured backend binary and can auto-download one as fallback.
+- If no bundled backend binary is found, desktop host tries to download a matching CLI release binary first.
 - Proxies the Wails WebView traffic to the local console server at root path `/`.
 - Exposes a Go binding `App.RestartApp()` for setup-complete restart.
 
@@ -62,8 +62,7 @@ go build -tags 'wailsdesktop production' -o ./bin/mistermorph-desktop ./desktop/
 ```
 
 For local Linux builds with DevTools enabled, use `scripts/build-desktop.sh`. It automatically switches Linux debug builds to `wailsdesktop dev devtools`, because Wails v3 alpha does not currently support `linux + production + devtools`.
-With default outputs, that script writes `./bin/mistermorph-desktop` and `./bin/mistermorph`
-(Windows: `mistermorph-desktop.exe` and `mistermorph.exe`).
+With default outputs, that script writes `./bin/MisterMorph` and `./bin/mistermorphc` on macOS, `./bin/MisterMorph.exe` and `./bin/mistermorphc.exe` on Windows, and `./bin/mistermorph-desktop` and `./bin/mistermorph` on Linux.
 
 ## Config file forwarding
 
@@ -74,8 +73,8 @@ If you start desktop app with `--config <path>`, that path is forwarded to the c
 Backend binary candidate order:
 
 1. `MISTERMORPH_DESKTOP_BACKEND_BIN`
-2. `./bin/mistermorph` (or `.exe` on Windows)
-3. sibling paths near desktop executable (`mistermorph`; legacy `mistermorph-backend` still accepted)
+2. `./bin/mistermorphc` on macOS/Windows, or `./bin/mistermorph` on Linux
+3. sibling paths near desktop executable (`mistermorphc` before `mistermorph` on macOS/Windows; `mistermorph` on Linux; legacy `mistermorph-backend` still accepted)
 4. `PATH` lookup (`mistermorph`)
 5. download from GitHub releases (enabled by default)
 
@@ -103,10 +102,10 @@ That gives the Wails v3 updater a stable latest-release URL:
 https://github.com/quailyquaily/mistermorph/releases/latest/download/update.json
 ```
 
-The desktop release packages bundle a sibling `mistermorph` backend binary so the packaged app can launch `console serve` without a first-run download.
+The macOS and Windows desktop release packages bundle a sibling `mistermorphc` backend binary; the Linux package keeps the sibling backend as `mistermorph`.
 The Linux updater tarball is not an `.AppImage` wrapped in another archive; it contains the unpacked AppDir bundle so the updater asset is a real Linux app payload.
 That bundled backend is built with `CGO_ENABLED=0` on purpose; keep it that way unless the CLI/backend grows an unavoidable native dependency.
-The Windows release bundle now includes both `mistermorph-desktop.exe` and `mistermorph.exe`; keep them in the same directory after unzip.
+The Windows release bundle includes both `MisterMorph.exe` and `mistermorphc.exe`; keep them in the same directory after unzip.
 The Windows release workflow also generates a `.ico` and Windows `.syso` resource on the runner so the published desktop executable carries the app icon.
 The macOS packaging script signs the `.app` bundle in two modes:
 

--- a/desktop/wails/backend_binary.go
+++ b/desktop/wails/backend_binary.go
@@ -162,6 +162,16 @@ func desktopBackendBinaryBaseName() string {
 	return "mistermorph"
 }
 
+func desktopBundledBackendBinaryBaseName() string {
+	if goRuntime.GOOS == "windows" {
+		return "mistermorphc.exe"
+	}
+	if goRuntime.GOOS == "linux" {
+		return desktopBackendBinaryBaseName()
+	}
+	return "mistermorphc"
+}
+
 func desktopLegacyBundledBackendBinaryBaseName() string {
 	if goRuntime.GOOS == "windows" {
 		return "mistermorph-backend.exe"
@@ -170,12 +180,19 @@ func desktopLegacyBundledBackendBinaryBaseName() string {
 }
 
 func desktopBackendCandidateBaseNames() []string {
+	bundled := desktopBundledBackendBinaryBaseName()
 	base := desktopBackendBinaryBaseName()
 	legacy := desktopLegacyBundledBackendBinaryBaseName()
-	if legacy == base {
-		return []string{base}
+	out := make([]string, 0, 3)
+	seen := map[string]struct{}{}
+	for _, name := range []string{bundled, base, legacy} {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
 	}
-	return []string{base, legacy}
+	return out
 }
 
 func desktopBackendAutoDownloadEnabled() bool {

--- a/desktop/wails/backend_binary_test.go
+++ b/desktop/wails/backend_binary_test.go
@@ -91,18 +91,23 @@ func TestResolveDesktopBackendCandidates_AppDirPreferredOverWorkingDir(t *testin
 	if len(candidates) < 3 {
 		t.Fatalf("expected multiple candidates, got %#v", candidates)
 	}
-	if got, want := candidates[0], filepath.Join(appDir, "usr", "bin", desktopBackendBinaryBaseName()); !sameCleanPath(got, want) {
+	if got, want := candidates[0], filepath.Join(appDir, "usr", "bin", desktopBundledBackendBinaryBaseName()); !sameCleanPath(got, want) {
 		t.Fatalf("first candidate = %q, want %q", got, want)
 	}
-	appDirCandidate := filepath.Join(appDir, "usr", "bin", desktopBackendBinaryBaseName())
+	appDirCandidate := filepath.Join(appDir, "usr", "bin", desktopBundledBackendBinaryBaseName())
+	cliCandidate := filepath.Join(appDir, "usr", "bin", desktopBackendBinaryBaseName())
 	legacyCandidate := filepath.Join(appDir, "usr", "bin", desktopLegacyBundledBackendBinaryBaseName())
-	wdCandidate := filepath.Join(wd, "bin", desktopBackendBinaryBaseName())
+	wdCandidate := filepath.Join(wd, "bin", desktopBundledBackendBinaryBaseName())
 	appIdx := -1
+	cliIdx := -1
 	legacyIdx := -1
 	wdIdx := -1
 	for i, c := range candidates {
 		if sameCleanPath(c, appDirCandidate) {
 			appIdx = i
+		}
+		if sameCleanPath(c, cliCandidate) {
+			cliIdx = i
 		}
 		if sameCleanPath(c, legacyCandidate) {
 			legacyIdx = i
@@ -111,13 +116,17 @@ func TestResolveDesktopBackendCandidates_AppDirPreferredOverWorkingDir(t *testin
 			wdIdx = i
 		}
 	}
-	if appIdx == -1 || legacyIdx == -1 || wdIdx == -1 {
-		t.Fatalf("expected appdir, legacy and wd candidates in %#v", candidates)
+	if appIdx == -1 || cliIdx == -1 || legacyIdx == -1 || wdIdx == -1 {
+		t.Fatalf("expected appdir bundled, cli, legacy and wd candidates in %#v", candidates)
 	}
-	if appIdx >= legacyIdx || legacyIdx >= wdIdx {
-		t.Fatalf("candidate order appdir=%d legacy=%d wd=%d, want appdir < legacy < wd in %#v", appIdx, legacyIdx, wdIdx, candidates)
+	if desktopBundledBackendBinaryBaseName() == desktopBackendBinaryBaseName() {
+		if appIdx >= legacyIdx || legacyIdx >= wdIdx {
+			t.Fatalf("candidate order appdir=%d legacy=%d wd=%d, want appdir < legacy < wd in %#v", appIdx, legacyIdx, wdIdx, candidates)
+		}
+	} else if appIdx >= cliIdx || cliIdx >= legacyIdx || legacyIdx >= wdIdx {
+		t.Fatalf("candidate order appdir=%d cli=%d legacy=%d wd=%d, want appdir < cli < legacy < wd in %#v", appIdx, cliIdx, legacyIdx, wdIdx, candidates)
 	}
-	unexpected := filepath.Join(appDir, "usr", "bin", "bin", desktopBackendBinaryBaseName())
+	unexpected := filepath.Join(appDir, "usr", "bin", "bin", desktopBundledBackendBinaryBaseName())
 	for _, c := range candidates {
 		if sameCleanPath(c, unexpected) {
 			t.Fatalf("unexpected nested bin candidate %q in %#v", c, candidates)
@@ -125,29 +134,38 @@ func TestResolveDesktopBackendCandidates_AppDirPreferredOverWorkingDir(t *testin
 	}
 }
 
-func TestResolveDesktopBackendCandidates_SiblingBackendBeforeLegacyName(t *testing.T) {
+func TestResolveDesktopBackendCandidates_SiblingBundledBackendBeforeCLIAndLegacyNames(t *testing.T) {
 	root := t.TempDir()
-	exePath := filepath.Join(root, "mistermorph-desktop.app", "Contents", "MacOS", "mistermorph-desktop")
+	exePath := filepath.Join(root, "MisterMorph.app", "Contents", "MacOS", "MisterMorph")
 	t.Setenv(desktopBackendBinEnv, "")
 
 	candidates := resolveDesktopBackendCandidates(exePath, "")
-	defaultCandidate := filepath.Join(filepath.Dir(exePath), desktopBackendBinaryBaseName())
+	bundledCandidate := filepath.Join(filepath.Dir(exePath), desktopBundledBackendBinaryBaseName())
+	cliCandidate := filepath.Join(filepath.Dir(exePath), desktopBackendBinaryBaseName())
 	legacyCandidate := filepath.Join(filepath.Dir(exePath), desktopLegacyBundledBackendBinaryBaseName())
-	defaultIdx := -1
+	bundledIdx := -1
+	cliIdx := -1
 	legacyIdx := -1
 	for i, c := range candidates {
-		if sameCleanPath(c, defaultCandidate) {
-			defaultIdx = i
+		if sameCleanPath(c, bundledCandidate) {
+			bundledIdx = i
+		}
+		if sameCleanPath(c, cliCandidate) {
+			cliIdx = i
 		}
 		if sameCleanPath(c, legacyCandidate) {
 			legacyIdx = i
 		}
 	}
-	if defaultIdx == -1 || legacyIdx == -1 {
-		t.Fatalf("expected sibling default and legacy candidates in %#v", candidates)
+	if bundledIdx == -1 || cliIdx == -1 || legacyIdx == -1 {
+		t.Fatalf("expected sibling bundled, cli and legacy candidates in %#v", candidates)
 	}
-	if defaultIdx >= legacyIdx {
-		t.Fatalf("default candidate index = %d, legacy candidate index = %d, want default before legacy in %#v", defaultIdx, legacyIdx, candidates)
+	if desktopBundledBackendBinaryBaseName() == desktopBackendBinaryBaseName() {
+		if bundledIdx >= legacyIdx {
+			t.Fatalf("candidate order bundled=%d legacy=%d, want bundled before legacy in %#v", bundledIdx, legacyIdx, candidates)
+		}
+	} else if bundledIdx >= cliIdx || cliIdx >= legacyIdx {
+		t.Fatalf("candidate order bundled=%d cli=%d legacy=%d, want bundled before cli before legacy in %#v", bundledIdx, cliIdx, legacyIdx, candidates)
 	}
 }
 

--- a/desktop/wails/config.go
+++ b/desktop/wails/config.go
@@ -16,11 +16,9 @@ func resolveDesktopConfigPath(args []string) (string, bool) {
 		return filepath.Clean(pathutil.ExpandHomePath(explicit)), true
 	}
 
-	for _, candidate := range []string{"config.yaml", "~/.morph/config.yaml"} {
-		resolved := filepath.Clean(pathutil.ExpandHomePath(candidate))
-		if _, err := os.Stat(resolved); err == nil {
-			return resolved, false
-		}
+	defaultPath := pathutil.DefaultConfigPath()
+	if _, err := os.Stat(defaultPath); err == nil {
+		return defaultPath, false
 	}
 	return "", false
 }

--- a/desktop/wails/config_test.go
+++ b/desktop/wails/config_test.go
@@ -1,0 +1,56 @@
+//go:build wailsdesktop
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDesktopConfigPath_ExplicitFlagWins(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, explicit := resolveDesktopConfigPath([]string{"--config", "~/custom.yaml"})
+	want := filepath.Join(home, "custom.yaml")
+	if got != filepath.Clean(want) {
+		t.Fatalf("resolveDesktopConfigPath() path = %q, want %q", got, filepath.Clean(want))
+	}
+	if !explicit {
+		t.Fatalf("resolveDesktopConfigPath() explicit = false, want true")
+	}
+}
+
+func TestResolveDesktopConfigPath_DefaultIgnoresCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	wd := t.TempDir()
+	restoreDesktopWD(t, wd)
+	if err := os.WriteFile("config.yaml", []byte("llm:\n  provider: openai\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(config.yaml) error = %v", err)
+	}
+
+	got, explicit := resolveDesktopConfigPath(nil)
+	if got != "" {
+		t.Fatalf("resolveDesktopConfigPath() path = %q, want empty", got)
+	}
+	if explicit {
+		t.Fatalf("resolveDesktopConfigPath() explicit = true, want false")
+	}
+}
+
+func restoreDesktopWD(t *testing.T, wd string) {
+	t.Helper()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(wd); err != nil {
+		t.Fatalf("Chdir(%q) error = %v", wd, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+}

--- a/desktop/wails/packaging/package-darwin.sh
+++ b/desktop/wails/packaging/package-darwin.sh
@@ -3,15 +3,15 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-APP_BUNDLE_NAME="${APP_BUNDLE_NAME:-mistermorph-desktop}"
+APP_BUNDLE_NAME="${APP_BUNDLE_NAME:-MisterMorph}"
 APP_DISPLAY_NAME="${APP_DISPLAY_NAME:-MisterMorph}"
-APP_EXECUTABLE_NAME="${APP_EXECUTABLE_NAME:-mistermorph-desktop}"
+APP_EXECUTABLE_NAME="${APP_EXECUTABLE_NAME:-MisterMorph}"
 BUNDLE_ID="${BUNDLE_ID:-io.quaily.mistermorph}"
 VERSION="${VERSION:-0.0.0}"
 ARCH="${ARCH:-arm64}"
-DESKTOP_BIN="${DESKTOP_BIN:-${ROOT_DIR}/dist/mistermorph-desktop}"
-BACKEND_BIN="${BACKEND_BIN:-${ROOT_DIR}/dist/mistermorph}"
-BUNDLED_BACKEND_NAME="${BUNDLED_BACKEND_NAME:-mistermorph}"
+DESKTOP_BIN="${DESKTOP_BIN:-${ROOT_DIR}/dist/MisterMorph}"
+BACKEND_BIN="${BACKEND_BIN:-${ROOT_DIR}/dist/mistermorphc}"
+BUNDLED_BACKEND_NAME="${BUNDLED_BACKEND_NAME:-mistermorphc}"
 ICON_PNG="${ICON_PNG:-${ROOT_DIR}/desktop/wails/packaging/appicon.png}"
 OUT_DIR="${OUT_DIR:-${ROOT_DIR}/dist}"
 APP_DIR="${OUT_DIR}/${APP_BUNDLE_NAME}.app"
@@ -70,7 +70,6 @@ iconutil -c icns "${ICONSET_DIR}" -o "${ICNS_PATH}"
 
 cp "${ICNS_PATH}" "${APP_DIR}/Contents/Resources/mistermorph.icns"
 cp "${DESKTOP_BIN}" "${APP_DIR}/Contents/MacOS/${APP_EXECUTABLE_NAME}"
-# Keep desktop and backend executable names lowercase and distinct.
 cp "${BACKEND_BIN}" "${APP_DIR}/Contents/MacOS/${BUNDLED_BACKEND_NAME}"
 chmod +x "${APP_DIR}/Contents/MacOS/${APP_EXECUTABLE_NAME}" "${APP_DIR}/Contents/MacOS/${BUNDLED_BACKEND_NAME}"
 

--- a/docs/app.md
+++ b/docs/app.md
@@ -23,7 +23,7 @@ You do not need to run `mistermorph console serve`.
 The desktop code lives in `desktop/wails` and builds with `wailsdesktop production`.
 
 - the Wails process owns the native window and Go bindings
-- a child process runs `mistermorph console serve`
+- a child process runs the bundled backend with `console serve`
 - the App routes WebView traffic to that child process
 
 The wrapper only handles lifecycle, process management, restart, and proxying.
@@ -49,7 +49,7 @@ The wrapper only handles lifecycle, process management, restart, and proxying.
                                                | spawn
                                                v
                            +----------------------------------+
-                           | Child: `mistermorph console serve` |
+                           | Child: bundled backend `console serve` |
                            | listen: 127.0.0.1:<random>       |
                            | base path: /console              |
                            | allow-empty-password: enabled    |
@@ -64,7 +64,7 @@ Startup sequence:
 desktop main
   -> resolve backend binary path
   -> reserve random loopback port
-  -> spawn child: mistermorph console serve
+  -> spawn child: bundled backend console serve
   -> poll GET /health until ready
   -> open native window
   -> proxy requests to the child process
@@ -84,7 +84,7 @@ incomplete config
 
 ## Paths and Configuration
 
-- Console assets are embedded in the bundled `mistermorph` backend by default.
+- Console assets are embedded in the bundled backend by default.
 - You can override static assets with:
   - `console.static_dir`
   - `--console-static-dir /abs/path/to/dist`
@@ -136,7 +136,7 @@ Tagged releases currently publish:
 - Linux `amd64`: `mistermorph-desktop-linux-amd64.AppImage`
 - Windows `amd64`: `mistermorph-desktop-windows-amd64.zip`
 
-The package includes a sibling `mistermorph` backend binary, so the wrapper can start `console serve` locally without a first-run download.
+The package includes a sibling backend binary, so the wrapper can start `console serve` locally without a first-run download. macOS and Windows name that backend `mistermorphc`; Linux keeps it as `mistermorph`.
 
 That backend is built with `CGO_ENABLED=0` on purpose. Keep it that way unless you have a packaging plan to change it.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ The canonical config template is [../assets/config/config.example.yaml](../asset
 
 Precedence:
 
-`CLI flag > MISTER_MORPH_* env > config.yaml > default`
+`CLI flag > MISTER_MORPH_* env > ~/.morph/config.yaml > default`
 
 Supported config file formats:
 
@@ -56,8 +56,8 @@ run with that config until process exit
 Resolved console config path:
 
 - `--config`, if explicitly set
-- otherwise the first existing file in `config.yaml`, `~/.morph/config.yaml`
-- if neither exists, the default write target is local `config.yaml`
+- otherwise `~/.morph/config.yaml`
+- if it does not exist yet, `~/.morph/config.yaml` is still the default write target
 
 Snapshot build flow:
 

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -67,6 +67,10 @@ func ResolveStateFile(stateDir string, filename string) string {
 	return filepath.Clean(filepath.Join(base, filename))
 }
 
+func DefaultConfigPath() string {
+	return ResolveStateFile("", "config.yaml")
+}
+
 func IsWithinDir(baseAbs string, candAbs string) bool {
 	baseAbs = filepath.Clean(baseAbs)
 	candAbs = filepath.Clean(candAbs)

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -128,7 +128,10 @@ fi
 
 mkdir -p "$(dirname "${OUTPUT}")"
 
-build_tags=("${USER_BUILD_TAGS[@]}")
+build_tags=()
+if [[ ${#USER_BUILD_TAGS[@]} -gt 0 ]]; then
+  build_tags=("${USER_BUILD_TAGS[@]}")
+fi
 if [[ "${EMBED_FRONTEND}" == "1" ]]; then
   if [[ "${BUILD_FRONTEND}" == "1" ]]; then
     echo "==> Building web/console"

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -14,8 +14,11 @@ target_goos() {
 
 default_desktop_output() {
   case "$(target_goos)" in
+    darwin)
+      printf '%s\n' "./bin/MisterMorph"
+      ;;
     windows)
-      printf '%s\n' "./bin/mistermorph-desktop.exe"
+      printf '%s\n' "./bin/MisterMorph.exe"
       ;;
     *)
       printf '%s\n' "./bin/mistermorph-desktop"
@@ -25,8 +28,11 @@ default_desktop_output() {
 
 default_backend_output() {
   case "$(target_goos)" in
+    darwin)
+      printf '%s\n' "./bin/mistermorphc"
+      ;;
     windows)
-      printf '%s\n' "./bin/mistermorph.exe"
+      printf '%s\n' "./bin/mistermorphc.exe"
       ;;
     *)
       printf '%s\n' "./bin/mistermorph"
@@ -78,8 +84,8 @@ Default desktop build tags:
   Release build:      wailsdesktop production
 
 Default outputs:
-  desktop: ./bin/mistermorph-desktop (or .exe on Windows)
-  backend: ./bin/mistermorph (or .exe on Windows)
+  desktop: ./bin/MisterMorph on macOS/Windows, ./bin/mistermorph-desktop on Linux
+  backend: ./bin/mistermorphc on macOS/Windows, ./bin/mistermorph on Linux
 
 Notes:
   - --frontend-config accepts an absolute path, a repo-root-relative path, or
@@ -166,9 +172,11 @@ fi
 if [[ "${BUILD_BACKEND}" == "1" ]]; then
   echo "==> Building backend ${BACKEND_OUTPUT}"
   backend_args=(--skip-frontend-build --output "${BACKEND_OUTPUT}")
-  for tag_set in "${USER_BUILD_TAGS[@]}"; do
-    backend_args+=(--tags "${tag_set}")
-  done
+  if [[ ${#USER_BUILD_TAGS[@]} -gt 0 ]]; then
+    for tag_set in "${USER_BUILD_TAGS[@]}"; do
+      backend_args+=(--tags "${tag_set}")
+    done
+  fi
   ./scripts/build-backend.sh "${backend_args[@]}"
 fi
 
@@ -183,7 +191,9 @@ if [[ "${ENABLE_DEVTOOLS}" == "1" ]]; then
 else
   desktop_tags+=(production)
 fi
-desktop_tags+=("${USER_BUILD_TAGS[@]}")
+if [[ ${#USER_BUILD_TAGS[@]} -gt 0 ]]; then
+  desktop_tags+=("${USER_BUILD_TAGS[@]}")
+fi
 
 echo "==> Building desktop ${DESKTOP_OUTPUT}"
 echo "    tags: ${desktop_tags[*]}"
@@ -191,7 +201,11 @@ desktop_ldflags=()
 if [[ "$(target_goos)" == "windows" ]]; then
   desktop_ldflags=(-ldflags "-H=windowsgui")
 fi
-go build "${desktop_ldflags[@]}" -tags "${desktop_tags[*]}" -o "${DESKTOP_OUTPUT}" ./desktop/wails
+if [[ ${#desktop_ldflags[@]} -gt 0 ]]; then
+  go build "${desktop_ldflags[@]}" -tags "${desktop_tags[*]}" -o "${DESKTOP_OUTPUT}" ./desktop/wails
+else
+  go build -tags "${desktop_tags[*]}" -o "${DESKTOP_OUTPUT}" ./desktop/wails
+fi
 
 echo
 echo "Built:"


### PR DESCRIPTION
## Summary
- prefer explicit config paths, otherwise use ~/.morph/config.yaml and ignore cwd config.yaml
- keep desktop release names platform-specific: mac/Windows use MisterMorph + mistermorphc, Linux keeps mistermorph-desktop + mistermorph
- make desktop backend discovery match the bundled CLI names while retaining legacy fallbacks

## Verification
- go test ./cmd/mistermorph ./cmd/mistermorph/consolecmd
- go test -tags 'wailsdesktop production' ./desktop/wails
- bash -n scripts/build-desktop.sh scripts/build-backend.sh desktop/wails/packaging/package-darwin.sh desktop/wails/packaging/package-linux-appimage.sh
- git diff --check