### PR TITLE
[codex] add runtime stop and steer

### DIFF
--- a/agent/engine.go
+++ b/agent/engine.go
@@ -347,6 +347,7 @@ func (e *Engine) Run(ctx context.Context, task string, opts RunOptions) (*Final,
 		planRequired:    planRequired,
 		requestedWrites: requestedWrites,
 		onStream:        opts.OnStream,
+		steerSource:     opts.SteerSource,
 		nextStep:        0,
 	})
 }

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -260,8 +260,8 @@ func (e *Engine) Run(ctx context.Context, task string, opts RunOptions) (*Final,
 	ctx = llmstats.WithRunID(ctx, runID)
 	log := e.log.With("run_id", runID, "model", model)
 	log.Info("run_start", "task_len", len(task))
-	if closer, ok := opts.SteerSource.(interface{ Close() }); ok {
-		defer closer.Close()
+	if opts.SteerSource != nil {
+		defer opts.SteerSource.Close()
 	}
 
 	var systemPrompt string

--- a/agent/engine.go
+++ b/agent/engine.go
@@ -260,6 +260,9 @@ func (e *Engine) Run(ctx context.Context, task string, opts RunOptions) (*Final,
 	ctx = llmstats.WithRunID(ctx, runID)
 	log := e.log.With("run_id", runID, "model", model)
 	log.Info("run_start", "task_len", len(task))
+	if closer, ok := opts.SteerSource.(interface{ Close() }); ok {
+		defer closer.Close()
+	}
 
 	var systemPrompt string
 	if e.promptBuilder != nil {

--- a/agent/engine_events_test.go
+++ b/agent/engine_events_test.go
@@ -1,0 +1,149 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/quailyquaily/mistermorph/internal/llmstats"
+	"github.com/quailyquaily/mistermorph/llm"
+	"github.com/quailyquaily/mistermorph/tools"
+)
+
+type recordingEventSink struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+func (s *recordingEventSink) HandleEvent(_ context.Context, event Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+}
+
+func (s *recordingEventSink) all() []Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+type contextAwareEventSink struct {
+	recordingEventSink
+}
+
+func (s *contextAwareEventSink) HandleEvent(ctx context.Context, event Event) {
+	if ctx != nil && ctx.Err() != nil {
+		return
+	}
+	s.recordingEventSink.HandleEvent(ctx, event)
+}
+
+type cancelingClient struct {
+	cancel context.CancelFunc
+}
+
+func (c cancelingClient) Chat(ctx context.Context, _ llm.Request) (llm.Result, error) {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	<-ctx.Done()
+	return llm.Result{}, ctx.Err()
+}
+
+func TestRun_EmitsTurnStartAndDone(t *testing.T) {
+	client := newMockClient(finalResponse("ok"))
+	engine := New(client, tools.NewRegistry(), Config{}, DefaultPromptSpec())
+	sink := &recordingEventSink{}
+
+	ctx := llmstats.WithRunID(context.Background(), "run_turn_done")
+	ctx = WithEventSinkContext(ctx, sink)
+	final, _, err := engine.Run(ctx, "test", RunOptions{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if final == nil || final.Output != "ok" {
+		t.Fatalf("final = %#v, want output ok", final)
+	}
+
+	events := sink.all()
+	kinds := eventKinds(events)
+	if len(kinds) < 2 {
+		t.Fatalf("events = %#v, want at least turn start/done", events)
+	}
+	if kinds[0] != EventKindTurnStart {
+		t.Fatalf("first event kind = %q, want %q; events=%#v", kinds[0], EventKindTurnStart, kinds)
+	}
+	if kinds[len(kinds)-1] != EventKindTurnDone {
+		t.Fatalf("last event kind = %q, want %q; events=%#v", kinds[len(kinds)-1], EventKindTurnDone, kinds)
+	}
+	for _, ev := range []Event{events[0], events[len(events)-1]} {
+		if strings.TrimSpace(ev.RunID) != "run_turn_done" {
+			t.Fatalf("event RunID = %q, want run_turn_done", ev.RunID)
+		}
+	}
+}
+
+func TestRun_EmitsTurnCanceledWithDetachedContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := cancelingClient{cancel: cancel}
+	engine := New(client, tools.NewRegistry(), Config{}, DefaultPromptSpec())
+	sink := &contextAwareEventSink{}
+
+	ctx = llmstats.WithRunID(ctx, "run_turn_detached_cancel")
+	ctx = WithEventSinkContext(ctx, sink)
+
+	_, _, err := engine.Run(ctx, "test", RunOptions{})
+	if err == nil {
+		t.Fatal("Run() error = nil, want cancellation error")
+	}
+
+	events := sink.all()
+	if !eventsContainKind(events, EventKindTurnStart) {
+		t.Fatalf("events = %#v, want turn_start", events)
+	}
+	if !eventsContainKind(events, EventKindTurnCanceled) {
+		t.Fatalf("events = %#v, want turn_canceled even when run context is canceled", events)
+	}
+}
+
+func TestRun_EmitsTurnCanceledWhenContextCanceled(t *testing.T) {
+	client := newMockClient(llm.Result{})
+	engine := New(client, tools.NewRegistry(), Config{}, DefaultPromptSpec())
+	sink := &recordingEventSink{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = llmstats.WithRunID(ctx, "run_turn_cancel")
+	ctx = WithEventSinkContext(ctx, sink)
+	cancel()
+
+	_, _, err := engine.Run(ctx, "test", RunOptions{})
+	if err == nil {
+		t.Fatal("Run() error = nil, want cancellation error")
+	}
+
+	events := sink.all()
+	kinds := eventKinds(events)
+	if len(kinds) != 2 {
+		t.Fatalf("events = %#v, want exactly turn start/canceled", events)
+	}
+	if kinds[0] != EventKindTurnStart {
+		t.Fatalf("first event kind = %q, want %q", kinds[0], EventKindTurnStart)
+	}
+	if kinds[1] != EventKindTurnCanceled {
+		t.Fatalf("second event kind = %q, want %q", kinds[1], EventKindTurnCanceled)
+	}
+	if strings.TrimSpace(events[1].RunID) != "run_turn_cancel" {
+		t.Fatalf("cancel event RunID = %q, want run_turn_cancel", events[1].RunID)
+	}
+}
+
+func eventKinds(events []Event) []string {
+	out := make([]string, 0, len(events))
+	for _, ev := range events {
+		out = append(out, ev.Kind)
+	}
+	return out
+}

--- a/agent/engine_loop.go
+++ b/agent/engine_loop.go
@@ -618,7 +618,7 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (final *Final
 		}
 	}
 
-	e.applyQueuedSteer(ctx, st, "")
+	e.applyFinalQueuedSteer(ctx, st, "")
 	return e.forceConclusion(ctx, st.messages, st.model, st.scene, st.agentCtx, st.extraParams, st.onStream, log)
 }
 
@@ -626,7 +626,24 @@ func (e *Engine) applyQueuedSteer(ctx context.Context, st *engineLoopState, assi
 	if st == nil || st.steerSource == nil {
 		return false
 	}
+	return e.applySteerItems(ctx, st, st.steerSource.Drain(), assistantText)
+}
+
+func (e *Engine) applyFinalQueuedSteer(ctx context.Context, st *engineLoopState, assistantText string) bool {
+	if st == nil || st.steerSource == nil {
+		return false
+	}
+	if source, ok := st.steerSource.(interface{ DrainAndClose() []string }); ok {
+		return e.applySteerItems(ctx, st, source.DrainAndClose(), assistantText)
+	}
 	items := st.steerSource.Drain()
+	if closer, ok := st.steerSource.(interface{ Close() }); ok {
+		closer.Close()
+	}
+	return e.applySteerItems(ctx, st, items, assistantText)
+}
+
+func (e *Engine) applySteerItems(ctx context.Context, st *engineLoopState, items []string, assistantText string) bool {
 	if len(items) == 0 {
 		return false
 	}

--- a/agent/engine_loop.go
+++ b/agent/engine_loop.go
@@ -633,14 +633,7 @@ func (e *Engine) applyFinalQueuedSteer(ctx context.Context, st *engineLoopState,
 	if st == nil || st.steerSource == nil {
 		return false
 	}
-	if source, ok := st.steerSource.(interface{ DrainAndClose() []string }); ok {
-		return e.applySteerItems(ctx, st, source.DrainAndClose(), assistantText)
-	}
-	items := st.steerSource.Drain()
-	if closer, ok := st.steerSource.(interface{ Close() }); ok {
-		closer.Close()
-	}
-	return e.applySteerItems(ctx, st, items, assistantText)
+	return e.applySteerItems(ctx, st, st.steerSource.DrainAndClose(), assistantText)
 }
 
 func (e *Engine) applySteerItems(ctx context.Context, st *engineLoopState, items []string, assistantText string) bool {

--- a/agent/engine_loop.go
+++ b/agent/engine_loop.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"log/slog"
@@ -29,6 +30,7 @@ type engineLoopState struct {
 	tools                      []llm.Tool
 	planRequired               bool
 	onStream                   llm.StreamHandler
+	steerSource                SteerSource
 	parseFailures              int
 	requestedWrites            []string
 	disableToolsForFormatRetry bool
@@ -45,7 +47,7 @@ type engineLoopState struct {
 
 func newRunID() string { return fmt.Sprintf("%x", rand.Uint64()) }
 
-func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (*Final, *Context, error) {
+func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (final *Final, agentCtx *Context, err error) {
 	if st == nil || st.agentCtx == nil {
 		return nil, nil, fmt.Errorf("nil engine state")
 	}
@@ -57,10 +59,47 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (*Final, *Con
 		log = slog.Default()
 	}
 
+	EmitEvent(ctx, nil, Event{
+		Kind:       EventKindTurnStart,
+		ActivityID: "turn",
+		Status:     "running",
+	})
+	defer func() {
+		event := Event{
+			Kind:       EventKindTurnDone,
+			ActivityID: "turn",
+			Status:     "done",
+		}
+		if err != nil {
+			event.Status = "failed"
+			event.Error = err.Error()
+			var ctxErr error
+			if ctx != nil {
+				ctxErr = ctx.Err()
+			}
+			if ctxErr != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				event.Kind = EventKindTurnCanceled
+				event.Status = "canceled"
+				event.Reason = "context_canceled"
+				if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctxErr, context.DeadlineExceeded) {
+					event.Reason = "context_deadline_exceeded"
+				}
+			}
+		}
+		if event.Kind == EventKindTurnCanceled {
+			EmitEventDetached(ctx, nil, event)
+			return
+		}
+		EmitEvent(ctx, nil, event)
+	}()
+
 	for step := st.nextStep; step < st.agentCtx.MaxSteps; step++ {
 		if err := ctx.Err(); err != nil {
 			log.Warn("run_cancelled", "step", step, "error", err.Error())
 			return nil, st.agentCtx, fmt.Errorf("context cancelled at step %d: %w", step, err)
+		}
+		if st.pendingTool == nil {
+			e.applyQueuedSteer(ctx, st, "")
 		}
 
 		for _, hook := range e.hooks {
@@ -198,6 +237,9 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (*Final, *Con
 			continue
 
 		case TypeFinal, TypeFinalAnswer:
+			if e.applyQueuedSteer(ctx, st, result.Text) {
+				continue
+			}
 			st.agentCtx.RawFinalAnswer = resp.RawFinalAnswer
 			fp := resp.FinalPayload()
 			if fp != nil {
@@ -576,7 +618,55 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (*Final, *Con
 		}
 	}
 
+	e.applyQueuedSteer(ctx, st, "")
 	return e.forceConclusion(ctx, st.messages, st.model, st.scene, st.agentCtx, st.extraParams, st.onStream, log)
+}
+
+func (e *Engine) applyQueuedSteer(ctx context.Context, st *engineLoopState, assistantText string) bool {
+	if st == nil || st.steerSource == nil {
+		return false
+	}
+	items := st.steerSource.Drain()
+	if len(items) == 0 {
+		return false
+	}
+	texts := make([]string, 0, len(items))
+	for _, item := range items {
+		text := strings.TrimSpace(item)
+		if text != "" {
+			texts = append(texts, text)
+		}
+	}
+	if len(texts) == 0 {
+		return false
+	}
+	if text := strings.TrimSpace(assistantText); text != "" {
+		st.messages = append(st.messages, llm.Message{Role: "assistant", Content: text})
+	}
+	for _, text := range texts {
+		st.messages = append(st.messages, llm.Message{
+			Role:    "user",
+			Content: formatSteerMessage(text),
+		})
+	}
+	EmitEvent(ctx, nil, Event{
+		Kind:       EventKindSteerApplied,
+		ActivityID: "steer",
+		Status:     "applied",
+		Text:       strings.Join(texts, "\n\n"),
+		Args: map[string]any{
+			"count": len(texts),
+		},
+	})
+	return true
+}
+
+func formatSteerMessage(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	return "[[ Runtime Steer ]]\nThe user sent this while the current task was running. Apply it to this same turn:\n\n" + text
 }
 
 // guardPreCheck runs the guard pre-tool decision serially. It returns:

--- a/agent/engine_steer_test.go
+++ b/agent/engine_steer_test.go
@@ -32,6 +32,83 @@ func (s *scriptedSteerSource) Close() {
 	s.closed = true
 }
 
+type pushableSteerSource struct {
+	mu     sync.Mutex
+	items  []string
+	closed bool
+}
+
+func (s *pushableSteerSource) Drain() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.items) == 0 {
+		return nil
+	}
+	out := make([]string, len(s.items))
+	copy(out, s.items)
+	s.items = nil
+	return out
+}
+
+func (s *pushableSteerSource) DrainAndClose() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	if len(s.items) == 0 {
+		return nil
+	}
+	out := make([]string, len(s.items))
+	copy(out, s.items)
+	s.items = nil
+	return out
+}
+
+func (s *pushableSteerSource) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	s.items = nil
+}
+
+func (s *pushableSteerSource) Push(input string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return context.Canceled
+	}
+	s.items = append(s.items, input)
+	return nil
+}
+
+type forceConclusionPushClient struct {
+	steer   *pushableSteerSource
+	pushErr error
+
+	mu    sync.Mutex
+	calls []llm.Request
+}
+
+func (c *forceConclusionPushClient) Chat(_ context.Context, req llm.Request) (llm.Result, error) {
+	c.mu.Lock()
+	c.calls = append(c.calls, req)
+	callIndex := len(c.calls)
+	c.mu.Unlock()
+
+	if callIndex == 1 {
+		return llm.Result{Text: `{"type":"plan","steps":["inspect"]}`}, nil
+	}
+	c.pushErr = c.steer.Push("too late for force conclusion")
+	return finalResponse("forced"), nil
+}
+
+func (c *forceConclusionPushClient) allCalls() []llm.Request {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]llm.Request, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
 func TestRun_AppliesQueuedSteerBeforeLLMCall(t *testing.T) {
 	client := newMockClient(finalResponse("ok"))
 	engine := New(client, baseRegistry(), baseCfg(), DefaultPromptSpec())
@@ -73,6 +150,27 @@ func TestRun_ClosesSteerSourceWhenDone(t *testing.T) {
 	steer.mu.Unlock()
 	if !closed {
 		t.Fatal("steer source was not closed after Run()")
+	}
+}
+
+func TestRun_RejectsSteerDuringForceConclusionCall(t *testing.T) {
+	steer := &pushableSteerSource{}
+	client := &forceConclusionPushClient{steer: steer}
+	engine := New(client, baseRegistry(), Config{MaxSteps: 1}, DefaultPromptSpec())
+
+	final, _, err := engine.Run(context.Background(), "test", RunOptions{SteerSource: steer})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got, _ := final.Output.(string)
+	if final == nil || strings.TrimSpace(got) != "forced" {
+		t.Fatalf("final = %#v, want forced", final)
+	}
+	if client.pushErr == nil {
+		t.Fatal("Push() during forceConclusion succeeded; steer would be acknowledged but never consumed")
+	}
+	if calls := client.allCalls(); len(calls) != 2 {
+		t.Fatalf("calls = %d, want plan call and force conclusion call", len(calls))
 	}
 }
 

--- a/agent/engine_steer_test.go
+++ b/agent/engine_steer_test.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/quailyquaily/mistermorph/llm"
+)
+
+type scriptedSteerSource struct {
+	mu      sync.Mutex
+	batches [][]string
+}
+
+func (s *scriptedSteerSource) Drain() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.batches) == 0 {
+		return nil
+	}
+	out := s.batches[0]
+	s.batches = s.batches[1:]
+	return out
+}
+
+func TestRun_AppliesQueuedSteerBeforeLLMCall(t *testing.T) {
+	client := newMockClient(finalResponse("ok"))
+	engine := New(client, baseRegistry(), baseCfg(), DefaultPromptSpec())
+	sink := &recordingEventSink{}
+	steer := &scriptedSteerSource{
+		batches: [][]string{{"prefer a short answer"}},
+	}
+	ctx := WithEventSinkContext(context.Background(), sink)
+
+	_, _, err := engine.Run(ctx, "test", RunOptions{SteerSource: steer})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	calls := client.allCalls()
+	if len(calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(calls))
+	}
+	if !requestContains(calls, 0, "prefer a short answer") {
+		t.Fatalf("first request did not include steer: %#v", calls[0].Messages)
+	}
+	if !eventsContainKind(sink.all(), EventKindSteerApplied) {
+		t.Fatalf("events missing steer_applied: %#v", sink.all())
+	}
+}
+
+func TestRun_AppliesQueuedSteerBeforeAcceptingFinal(t *testing.T) {
+	client := newMockClient(
+		finalResponse("draft"),
+		finalResponse("revised"),
+	)
+	engine := New(client, baseRegistry(), baseCfg(), DefaultPromptSpec())
+	steer := &scriptedSteerSource{
+		batches: [][]string{
+			nil,
+			{"revise with risk notes"},
+			nil,
+		},
+	}
+
+	final, _, err := engine.Run(context.Background(), "test", RunOptions{SteerSource: steer})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got, _ := final.Output.(string)
+	if final == nil || strings.TrimSpace(got) != "revised" {
+		t.Fatalf("final = %#v, want revised", final)
+	}
+
+	calls := client.allCalls()
+	if len(calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(calls))
+	}
+	if !requestContains(calls, 1, "revise with risk notes") {
+		t.Fatalf("second request did not include final-stage steer: %#v", calls[1].Messages)
+	}
+}
+
+func TestRun_AppliesQueuedSteerBeforeForceConclusion(t *testing.T) {
+	client := newMockClient(
+		llm.Result{Text: `{"type":"plan","steps":["inspect"]}`},
+		finalResponse("forced"),
+	)
+	engine := New(client, baseRegistry(), Config{MaxSteps: 1}, DefaultPromptSpec())
+	steer := &scriptedSteerSource{
+		batches: [][]string{
+			nil,
+			{"include the late correction"},
+		},
+	}
+
+	final, _, err := engine.Run(context.Background(), "test", RunOptions{SteerSource: steer})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got, _ := final.Output.(string)
+	if final == nil || strings.TrimSpace(got) != "forced" {
+		t.Fatalf("final = %#v, want forced", final)
+	}
+
+	calls := client.allCalls()
+	if len(calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(calls))
+	}
+	if !requestContains(calls, 1, "include the late correction") {
+		t.Fatalf("force conclusion request did not include late steer: %#v", calls[1].Messages)
+	}
+}
+
+func eventsContainKind(events []Event, kind string) bool {
+	for _, ev := range events {
+		if ev.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/engine_steer_test.go
+++ b/agent/engine_steer_test.go
@@ -12,6 +12,7 @@ import (
 type scriptedSteerSource struct {
 	mu      sync.Mutex
 	batches [][]string
+	closed  bool
 }
 
 func (s *scriptedSteerSource) Drain() []string {
@@ -23,6 +24,12 @@ func (s *scriptedSteerSource) Drain() []string {
 	out := s.batches[0]
 	s.batches = s.batches[1:]
 	return out
+}
+
+func (s *scriptedSteerSource) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
 }
 
 func TestRun_AppliesQueuedSteerBeforeLLMCall(t *testing.T) {
@@ -48,6 +55,24 @@ func TestRun_AppliesQueuedSteerBeforeLLMCall(t *testing.T) {
 	}
 	if !eventsContainKind(sink.all(), EventKindSteerApplied) {
 		t.Fatalf("events missing steer_applied: %#v", sink.all())
+	}
+}
+
+func TestRun_ClosesSteerSourceWhenDone(t *testing.T) {
+	client := newMockClient(finalResponse("ok"))
+	engine := New(client, baseRegistry(), baseCfg(), DefaultPromptSpec())
+	steer := &scriptedSteerSource{}
+
+	_, _, err := engine.Run(context.Background(), "test", RunOptions{SteerSource: steer})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	steer.mu.Lock()
+	closed := steer.closed
+	steer.mu.Unlock()
+	if !closed {
+		t.Fatal("steer source was not closed after Run()")
 	}
 }
 

--- a/agent/engine_steer_test.go
+++ b/agent/engine_steer_test.go
@@ -18,6 +18,21 @@ type scriptedSteerSource struct {
 func (s *scriptedSteerSource) Drain() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	if len(s.batches) == 0 {
+		return nil
+	}
+	out := s.batches[0]
+	s.batches = s.batches[1:]
+	return out
+}
+
+func (s *scriptedSteerSource) DrainAndClose() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
 	if len(s.batches) == 0 {
 		return nil
 	}
@@ -30,6 +45,18 @@ func (s *scriptedSteerSource) Close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.closed = true
+}
+
+func TestSteerSourceExposesCloseOperations(t *testing.T) {
+	source := SteerSource(&scriptedSteerSource{
+		batches: [][]string{{"final note"}},
+	})
+
+	items := source.DrainAndClose()
+	if len(items) != 1 || items[0] != "final note" {
+		t.Fatalf("DrainAndClose() = %#v, want final note", items)
+	}
+	source.Close()
 }
 
 type pushableSteerSource struct {

--- a/agent/events.go
+++ b/agent/events.go
@@ -8,29 +8,39 @@ import (
 )
 
 const (
-	EventKindToolStart    = "tool_start"
-	EventKindToolDone     = "tool_done"
-	EventKindToolOutput   = "tool_output"
-	EventKindSubtaskStart = "subtask_start"
-	EventKindSubtaskDone  = "subtask_done"
+	EventKindTurnStart        = "turn_start"
+	EventKindTurnDone         = "turn_done"
+	EventKindTurnCanceled     = "turn_canceled"
+	EventKindRunStopRequested = "run_stop_requested"
+	EventKindRunStopped       = "run_stopped"
+	EventKindSteerQueued      = "steer_queued"
+	EventKindSteerApplied     = "steer_applied"
+	EventKindToolStart        = "tool_start"
+	EventKindToolDone         = "tool_done"
+	EventKindToolOutput       = "tool_output"
+	EventKindSubtaskStart     = "subtask_start"
+	EventKindSubtaskDone      = "subtask_done"
 )
 
 type Event struct {
-	Kind       string         `json:"kind"`
-	RunID      string         `json:"run_id,omitempty"`
-	Step       int            `json:"step,omitempty"`
-	ActivityID string         `json:"activity_id,omitempty"`
-	ToolName   string         `json:"tool_name,omitempty"`
-	TaskID     string         `json:"task_id,omitempty"`
-	Status     string         `json:"status,omitempty"`
-	Mode       string         `json:"mode,omitempty"`
-	Profile    string         `json:"profile,omitempty"`
-	Stream     string         `json:"stream,omitempty"`
-	Text       string         `json:"text,omitempty"`
-	Summary    string         `json:"summary,omitempty"`
-	OutputKind string         `json:"output_kind,omitempty"`
-	Error      string         `json:"error,omitempty"`
-	Args       map[string]any `json:"args,omitempty"`
+	Kind            string         `json:"kind"`
+	RunID           string         `json:"run_id,omitempty"`
+	Step            int            `json:"step,omitempty"`
+	ActivityID      string         `json:"activity_id,omitempty"`
+	ConversationKey string         `json:"conversation_key,omitempty"`
+	TopicID         string         `json:"topic_id,omitempty"`
+	ToolName        string         `json:"tool_name,omitempty"`
+	TaskID          string         `json:"task_id,omitempty"`
+	Status          string         `json:"status,omitempty"`
+	Reason          string         `json:"reason,omitempty"`
+	Mode            string         `json:"mode,omitempty"`
+	Profile         string         `json:"profile,omitempty"`
+	Stream          string         `json:"stream,omitempty"`
+	Text            string         `json:"text,omitempty"`
+	Summary         string         `json:"summary,omitempty"`
+	OutputKind      string         `json:"output_kind,omitempty"`
+	Error           string         `json:"error,omitempty"`
+	Args            map[string]any `json:"args,omitempty"`
 }
 
 type EventSink interface {
@@ -66,6 +76,14 @@ func EventSinkFromContext(ctx context.Context) (EventSink, bool) {
 }
 
 func EmitEvent(ctx context.Context, sink EventSink, event Event) {
+	emitEvent(ctx, sink, event, ctx)
+}
+
+func EmitEventDetached(ctx context.Context, sink EventSink, event Event) {
+	emitEvent(ctx, sink, event, context.Background())
+}
+
+func emitEvent(ctx context.Context, sink EventSink, event Event, deliveryCtx context.Context) {
 	if sink == nil {
 		var ok bool
 		sink, ok = EventSinkFromContext(ctx)
@@ -76,5 +94,8 @@ func EmitEvent(ctx context.Context, sink EventSink, event Event) {
 	if strings.TrimSpace(event.RunID) == "" {
 		event.RunID = strings.TrimSpace(llmstats.RunIDFromContext(ctx))
 	}
-	sink.HandleEvent(ctx, event)
+	if deliveryCtx == nil {
+		deliveryCtx = context.Background()
+	}
+	sink.HandleEvent(deliveryCtx, event)
 }

--- a/agent/types.go
+++ b/agent/types.go
@@ -76,6 +76,8 @@ type Final struct {
 
 type SteerSource interface {
 	Drain() []string
+	DrainAndClose() []string
+	Close()
 }
 
 type AgentResponse struct {

--- a/agent/types.go
+++ b/agent/types.go
@@ -74,6 +74,10 @@ type Final struct {
 	IsLightweight bool   `json:"is_lightweight,omitempty"`
 }
 
+type SteerSource interface {
+	Drain() []string
+}
+
 type AgentResponse struct {
 	Type           string          `json:"type"`
 	ToolCall       *ToolCall       `json:"tool_call,omitempty"`
@@ -117,6 +121,9 @@ type RunOptions struct {
 	CurrentMessage *llm.Message
 	// OnStream receives provider stream events for each model call in this run.
 	OnStream llm.StreamHandler
+	// SteerSource provides user input that arrived while this run was active.
+	// Items are injected at safe checkpoints before model calls.
+	SteerSource SteerSource
 	// SkipTaskMessage suppresses appending task as a trailing user message.
 	// Useful when the current user input is represented elsewhere and no raw task fallback should be added.
 	SkipTaskMessage bool

--- a/cmd/mistermorph/chatcmd/bubble.go
+++ b/cmd/mistermorph/chatcmd/bubble.go
@@ -22,8 +22,9 @@ type (
 		message string // optional custom message shown next to spinner
 	}
 	agentResultMsg struct {
-		output string
-		err    error
+		output       string
+		err          error
+		keepThinking bool
 	}
 	quitMsg      struct{}
 	tuiOutputMsg struct{ output string }
@@ -165,14 +166,6 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		if m.thinking {
-			// While agent is running, only Ctrl+C is handled (to interrupt)
-			if msg.Type == tea.KeyCtrlC {
-				return m, tea.Quit
-			}
-			return m, nil
-		}
-
 		// Bracketed paste: fold multi-line pastes into a "[Pasted text #N +M lines]"
 		// placeholder so the input box stays compact. The original text is
 		// stashed in m.pastedTexts and re-expanded on submit.
@@ -199,6 +192,10 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch msg.Type {
 		case tea.KeyCtrlC:
+			if m.thinking {
+				go func() { m.submitted <- "/stop" }()
+				return m, nil
+			}
 			return m, tea.Quit
 
 		case tea.KeyEnter:
@@ -251,7 +248,7 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.thinking = msg.on
 		if msg.on {
 			m.thinkingMessage = msg.message
-			m.textarea.Blur()
+			m.textarea.Focus()
 			return m, spinner.Tick
 		}
 		m.thinkingMessage = ""
@@ -262,7 +259,9 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Println(msg.output)
 
 	case agentResultMsg:
-		m.thinking = false
+		if !msg.keepThinking {
+			m.thinking = false
+		}
 		if msg.err != nil {
 			if errors.Is(msg.err, context.Canceled) {
 				return m, tea.Println("\033[33m⚡ Interrupted.\033[0m")
@@ -322,7 +321,7 @@ func (m *chatModel) doAutocomplete() {
 	}
 
 	commands := []string{
-		"/exit", "/quit", "/reset", "/memory", "/remember ",
+		"/exit", "/quit", "/stop", "/reset", "/memory", "/remember ",
 		"/skills", "/init", "/update", "/models",
 		"/workspace", "/workspace attach ", "/workspace detach",
 		"/help",

--- a/cmd/mistermorph/chatcmd/bubble_test.go
+++ b/cmd/mistermorph/chatcmd/bubble_test.go
@@ -137,6 +137,49 @@ func TestChatModelThinkingState(t *testing.T) {
 	}
 }
 
+func TestChatModelSubmitsInputWhileThinking(t *testing.T) {
+	sess := &chatSession{compactMode: false, userName: "testuser"}
+	m := newChatModel(sess)
+	m.thinking = true
+	m.textarea.SetValue("make it shorter")
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	cm := m2.(*chatModel)
+	if cmd == nil {
+		t.Fatal("expected print command after Enter while thinking")
+	}
+	if cm.textarea.Value() != "" {
+		t.Fatalf("textarea value = %q, want reset", cm.textarea.Value())
+	}
+	select {
+	case got := <-cm.submitted:
+		if got != "make it shorter" {
+			t.Fatalf("submitted = %q, want steer text", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for submitted input")
+	}
+}
+
+func TestChatModelCtrlCWhileThinkingSubmitsStop(t *testing.T) {
+	sess := &chatSession{compactMode: false, userName: "testuser"}
+	m := newChatModel(sess)
+	m.thinking = true
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd != nil {
+		t.Fatalf("cmd = %#v, want nil so chat keeps running", cmd)
+	}
+	select {
+	case got := <-m.submitted:
+		if got != "/stop" {
+			t.Fatalf("submitted = %q, want /stop", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for /stop")
+	}
+}
+
 func TestChatModelView(t *testing.T) {
 	sess := &chatSession{compactMode: false, userName: "testuser"}
 	m := newChatModel(sess)
@@ -214,6 +257,21 @@ func TestChatModelAgentResult(t *testing.T) {
 	_ = m3.(*chatModel)
 	if cmd2 == nil {
 		t.Error("expected tea.Println command for error")
+	}
+}
+
+func TestChatModelAgentResultCanKeepThinking(t *testing.T) {
+	sess := &chatSession{compactMode: false, userName: "testuser"}
+	m := newChatModel(sess)
+	m.thinking = true
+
+	m2, cmd := m.Update(agentResultMsg{output: "已收到", keepThinking: true})
+	cm := m2.(*chatModel)
+	if !cm.thinking {
+		t.Fatal("thinking = false, want true for running-turn acknowledgement")
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Println command for acknowledgement")
 	}
 }
 

--- a/cmd/mistermorph/chatcmd/bubble_test.go
+++ b/cmd/mistermorph/chatcmd/bubble_test.go
@@ -275,6 +275,21 @@ func TestChatModelAgentResultCanKeepThinking(t *testing.T) {
 	}
 }
 
+func TestChatModelAgentErrorCanKeepThinking(t *testing.T) {
+	sess := &chatSession{compactMode: false, userName: "testuser"}
+	m := newChatModel(sess)
+	m.thinking = true
+
+	m2, cmd := m.Update(agentResultMsg{err: errTest, keepThinking: true})
+	cm := m2.(*chatModel)
+	if !cm.thinking {
+		t.Fatal("thinking = false, want true for running-turn error")
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Println command for error")
+	}
+}
+
 func TestCountPasteLines(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/cmd/mistermorph/chatcmd/commands.go
+++ b/cmd/mistermorph/chatcmd/commands.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/quailyquaily/mistermorph/internal/chatcommands"
 	"github.com/quailyquaily/mistermorph/internal/llmselect"
+	"github.com/quailyquaily/mistermorph/internal/runtimecontrol"
 	"github.com/quailyquaily/mistermorph/internal/skillsutil"
 	"github.com/quailyquaily/mistermorph/internal/topiccontext"
 	"github.com/quailyquaily/mistermorph/internal/workspace"
@@ -47,7 +48,7 @@ func registerChatCommands(reg *chatcommands.Registry, sess *chatSession, history
 	})
 
 	reg.Register("/stop", func(ctx context.Context, args string) (*chatcommands.Result, error) {
-		return &chatcommands.Result{Reply: "当前没有正在运行的任务。"}, nil
+		return &chatcommands.Result{Reply: runtimecontrol.StopFeedback(false)}, nil
 	})
 
 	reg.Register("/memory", func(ctx context.Context, args string) (*chatcommands.Result, error) {

--- a/cmd/mistermorph/chatcmd/commands.go
+++ b/cmd/mistermorph/chatcmd/commands.go
@@ -46,6 +46,10 @@ func registerChatCommands(reg *chatcommands.Registry, sess *chatSession, history
 		return &chatcommands.Result{Reply: "Session reset."}, nil
 	})
 
+	reg.Register("/stop", func(ctx context.Context, args string) (*chatcommands.Result, error) {
+		return &chatcommands.Result{Reply: "当前没有正在运行的任务。"}, nil
+	})
+
 	reg.Register("/memory", func(ctx context.Context, args string) (*chatcommands.Result, error) {
 		handleMemory(writer, sess.memOrchestrator, sess.subjectID)
 		return &chatcommands.Result{}, nil
@@ -180,6 +184,7 @@ func chatBuiltinCommandsBlock() string {
 	return "## Built-in Chat Commands\n\n" +
 		"The user can type these special commands at any time:\n" +
 		"- `/exit` or `/quit` — exit the chat session\n" +
+		"- `/stop` — stop the current running turn\n" +
 		"- `/reset` — reset the current conversation (clear history, keep memory)\n" +
 		"- `/memory` — display the current project memory\n" +
 		"- `/remember <content>` — add a long-term memory item for the current project\n" +

--- a/cmd/mistermorph/chatcmd/commands_test.go
+++ b/cmd/mistermorph/chatcmd/commands_test.go
@@ -25,7 +25,7 @@ func TestChatRuntimeRegistryIncludesSharedCommands(t *testing.T) {
 	if !handled || res == nil {
 		t.Fatalf("expected /help handled")
 	}
-	for _, want := range []string{"/ctx", "/help", "/models", "/skills", "/think", "/workspace", "/reset"} {
+	for _, want := range []string{"/ctx", "/help", "/models", "/skills", "/think", "/workspace", "/reset", "/stop"} {
 		if !strings.Contains(res.Reply, want) {
 			t.Fatalf("/help reply missing %q: %q", want, res.Reply)
 		}

--- a/cmd/mistermorph/chatcmd/repl.go
+++ b/cmd/mistermorph/chatcmd/repl.go
@@ -190,7 +190,7 @@ func runREPL(sess *chatSession) error {
 						continue
 					}
 					if _, err := active.steerQueue.Push(input); err != nil {
-						safeSend(p, agentResultMsg{err: err})
+						safeSend(p, agentResultMsg{err: err, keepThinking: true})
 						continue
 					}
 					safeSend(p, agentResultMsg{output: runtimecontrol.SteerFeedback(true, true), keepThinking: true})

--- a/cmd/mistermorph/chatcmd/repl.go
+++ b/cmd/mistermorph/chatcmd/repl.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/quailyquaily/mistermorph/agent"
@@ -17,6 +16,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/llmutil"
 	"github.com/quailyquaily/mistermorph/internal/outputfmt"
 	"github.com/quailyquaily/mistermorph/internal/pathroots"
+	"github.com/quailyquaily/mistermorph/internal/runtimecontrol"
 	"github.com/quailyquaily/mistermorph/internal/topiccontext"
 	"github.com/quailyquaily/mistermorph/llm"
 )
@@ -82,14 +82,118 @@ func runREPL(sess *chatSession) error {
 
 	// Agent turn processing goroutine
 	go func() {
+		type activeChatTurn struct {
+			cancel          context.CancelCauseFunc
+			timeoutCancel   context.CancelFunc
+			signalCh        chan os.Signal
+			steerQueue      *runtimecontrol.SteerQueue
+			runInput        string
+			runID           string
+			oldState        *chatRuntimeState
+			temporaryClient llm.Client
+		}
+		type chatTurnResult struct {
+			turn   *activeChatTurn
+			final  *agent.Final
+			runCtx *agent.Context
+			err    error
+			cause  error
+		}
+
 		turn := 0
+		var active *activeChatTurn
+		resultCh := make(chan chatTurnResult, 1)
 		for {
 			select {
 			case <-ctx.Done():
+				if active != nil && active.cancel != nil {
+					active.cancel(context.Canceled)
+				}
 				return
+			case result := <-resultCh:
+				if active == result.turn {
+					active = nil
+				}
+				safeSend(p, thinkingMsg{on: false})
+				if result.turn != nil {
+					if result.turn.signalCh != nil {
+						signal.Stop(result.turn.signalCh)
+					}
+					if result.turn.timeoutCancel != nil {
+						result.turn.timeoutCancel()
+					}
+					if result.turn.cancel != nil {
+						result.turn.cancel(nil)
+					}
+					if result.turn.oldState != nil {
+						restoreChatRuntimeState(sess, result.turn.oldState, result.turn.temporaryClient)
+					}
+				}
+
+				if result.err != nil {
+					if errors.Is(result.cause, runtimecontrol.ErrStoppedByUser) {
+						safeSend(p, agentResultMsg{output: "已停止当前任务。"})
+						continue
+					}
+					if errors.Is(result.err, context.Canceled) {
+						safeSend(p, agentResultMsg{err: result.err})
+						continue
+					}
+					displayErr := strings.TrimSpace(outputfmt.FormatErrorForDisplay(result.err))
+					if displayErr == "" {
+						displayErr = strings.TrimSpace(result.err.Error())
+					}
+					safeSend(p, agentResultMsg{output: displayErr})
+					continue
+				}
+
+				rawOutput := formatRawChatOutput(result.final)
+				displayOutput := formatChatOutput(result.final)
+				safeSend(p, agentResultMsg{output: displayOutput})
+
+				runInput := ""
+				runID := ""
+				if result.turn != nil {
+					runInput = result.turn.runInput
+					runID = result.turn.runID
+				}
+				history = append(history,
+					llm.Message{Role: "user", Content: runInput},
+					llm.Message{Role: "assistant", Content: rawOutput},
+				)
+
+				steps := []agent.Step(nil)
+				if result.runCtx != nil {
+					steps = result.runCtx.Steps
+					sess.logger.Info("chat_turn_done",
+						"turn", turn,
+						"steps", len(result.runCtx.Steps),
+						"llm_rounds", result.runCtx.Metrics.LLMRounds,
+						"total_tokens", result.runCtx.Metrics.TotalTokens,
+					)
+				}
+
+				autoUpdateMemory(io.Discard, sess.logger, sess.memOrchestrator, sess.memWorker, sess.subjectID, runID, runInput, rawOutput, steps)
+				turn++
 			case input := <-model.submitted:
 				input = strings.TrimSpace(input)
 				if input == "" {
+					continue
+				}
+				if active != nil {
+					cmdWord, _ := chatcommands.ParseCommand(input)
+					if chatcommands.NormalizeCommand(cmdWord) == "/stop" {
+						if active.cancel != nil {
+							active.cancel(runtimecontrol.ErrStoppedByUser)
+						}
+						safeSend(p, agentResultMsg{output: runtimecontrol.StopFeedback(true, "任务正在运行中，等待当前模型或工具调用返回。"), keepThinking: true})
+						continue
+					}
+					if _, err := active.steerQueue.Push(input); err != nil {
+						safeSend(p, agentResultMsg{err: err})
+						continue
+					}
+					safeSend(p, agentResultMsg{output: runtimecontrol.SteerFeedback(true, true), keepThinking: true})
 					continue
 				}
 
@@ -143,12 +247,9 @@ func runREPL(sess *chatSession) error {
 				}
 				safeSend(p, thinkingMsg{on: true})
 
-				turnCtx, turnCancel := context.WithCancel(ctx)
+				stopCtx, stopCancel := context.WithCancelCause(ctx)
+				turnCtx, timeoutCancel := context.WithTimeout(stopCtx, sess.timeout)
 				turnCtx = pathroots.WithWorkspaceDir(turnCtx, sess.workspaceDir)
-				go func() {
-					<-time.After(sess.timeout)
-					turnCancel()
-				}()
 				runID := llmstats.NewSyntheticRunID("chat")
 				turnCtx = llmstats.WithRunID(turnCtx, runID)
 				turnCtx = topiccontext.WithScope(turnCtx, topiccontext.Scope{
@@ -159,13 +260,23 @@ func runREPL(sess *chatSession) error {
 
 				sigCh := make(chan os.Signal, 1)
 				signal.Notify(sigCh, os.Interrupt)
+				steerQueue := runtimecontrol.NewSteerQueue(0)
+				active = &activeChatTurn{
+					cancel:          stopCancel,
+					timeoutCancel:   timeoutCancel,
+					signalCh:        sigCh,
+					steerQueue:      steerQueue,
+					runInput:        runInput,
+					runID:           runID,
+					oldState:        oldState,
+					temporaryClient: temporaryClient,
+				}
 				go func() {
 					select {
 					case <-sigCh:
-						turnCancel()
+						stopCancel(runtimecontrol.ErrStoppedByUser)
 					case <-turnCtx.Done():
 					}
-					signal.Stop(sigCh)
 				}()
 
 				memoryContext, memErr := prepareTurnMemoryContext(sess.memOrchestrator, sess.subjectID)
@@ -173,50 +284,24 @@ func runREPL(sess *chatSession) error {
 					sess.logger.Warn("chat_memory_injection_failed", "error", memErr.Error())
 				}
 
-				final, runCtx, err := sess.engine.Run(turnCtx, runInput, agent.RunOptions{
-					Model:         strings.TrimSpace(sess.mainCfg.Model),
-					Scene:         "chat.loop",
-					History:       append([]llm.Message(nil), history...),
-					MemoryContext: memoryContext,
-				})
-
-				safeSend(p, thinkingMsg{on: false})
-				turnCancel()
-				if oldState != nil {
-					restoreChatRuntimeState(sess, oldState, temporaryClient)
-				}
-
-				if err != nil {
-					if errors.Is(err, context.Canceled) {
-						safeSend(p, agentResultMsg{err: err})
-						continue
+				currentTurn := active
+				historySnapshot := append([]llm.Message(nil), history...)
+				go func() {
+					final, runCtx, err := sess.engine.Run(turnCtx, runInput, agent.RunOptions{
+						Model:         strings.TrimSpace(sess.mainCfg.Model),
+						Scene:         "chat.loop",
+						History:       historySnapshot,
+						MemoryContext: memoryContext,
+						SteerSource:   steerQueue,
+					})
+					resultCh <- chatTurnResult{
+						turn:   currentTurn,
+						final:  final,
+						runCtx: runCtx,
+						err:    err,
+						cause:  context.Cause(turnCtx),
 					}
-					displayErr := strings.TrimSpace(outputfmt.FormatErrorForDisplay(err))
-					if displayErr == "" {
-						displayErr = strings.TrimSpace(err.Error())
-					}
-					safeSend(p, agentResultMsg{output: displayErr})
-					continue
-				}
-
-				rawOutput := formatRawChatOutput(final)
-				displayOutput := formatChatOutput(final)
-				safeSend(p, agentResultMsg{output: displayOutput})
-
-				history = append(history,
-					llm.Message{Role: "user", Content: runInput},
-					llm.Message{Role: "assistant", Content: rawOutput},
-				)
-
-				sess.logger.Info("chat_turn_done",
-					"turn", turn,
-					"steps", len(runCtx.Steps),
-					"llm_rounds", runCtx.Metrics.LLMRounds,
-					"total_tokens", runCtx.Metrics.TotalTokens,
-				)
-
-				autoUpdateMemory(io.Discard, sess.logger, sess.memOrchestrator, sess.memWorker, sess.subjectID, runID, runInput, rawOutput, runCtx.Steps)
-				turn++
+				}()
 			}
 		}
 	}()

--- a/cmd/mistermorph/chatcmd/repl.go
+++ b/cmd/mistermorph/chatcmd/repl.go
@@ -132,7 +132,7 @@ func runREPL(sess *chatSession) error {
 
 				if result.err != nil {
 					if errors.Is(result.cause, runtimecontrol.ErrStoppedByUser) {
-						safeSend(p, agentResultMsg{output: "已停止当前任务。"})
+						safeSend(p, agentResultMsg{output: runtimecontrol.StopFeedback(true)})
 						continue
 					}
 					if errors.Is(result.err, context.Canceled) {
@@ -186,7 +186,7 @@ func runREPL(sess *chatSession) error {
 						if active.cancel != nil {
 							active.cancel(runtimecontrol.ErrStoppedByUser)
 						}
-						safeSend(p, agentResultMsg{output: runtimecontrol.StopFeedback(true, "任务正在运行中，等待当前模型或工具调用返回。"), keepThinking: true})
+						safeSend(p, agentResultMsg{output: runtimecontrol.StopFeedback(true), keepThinking: true})
 						continue
 					}
 					if _, err := active.steerQueue.Push(input); err != nil {

--- a/cmd/mistermorph/consolecmd/local_runtime.go
+++ b/cmd/mistermorph/consolecmd/local_runtime.go
@@ -1090,7 +1090,7 @@ func (r *consoleLocalRuntime) submitTask(ctx context.Context, req daemonruntime.
 		return resp, err
 	}
 	if result := r.trySteerConsoleRun(task, strings.TrimSpace(req.TopicID)); result.Found {
-		output := formatConsoleSteerResponse(result)
+		output := runtimecontrol.SteerFeedback(result.Found, result.Queued)
 		resp, err := r.submitSyntheticTask(
 			generation,
 			task,
@@ -1160,7 +1160,7 @@ func (r *consoleLocalRuntime) stopTask(_ context.Context, req daemonruntime.Stop
 		TaskID:   taskID,
 		TopicID:  topicID,
 		Progress: strings.TrimSpace(result.Progress),
-		Message:  formatConsoleStopResponse(result),
+		Message:  runtimecontrol.StopFeedback(result.Found),
 	}, nil
 }
 
@@ -1178,7 +1178,7 @@ func (r *consoleLocalRuntime) handleConsoleRuntimeCommand(generation *consoleLoc
 		if r != nil && r.runControl != nil {
 			result = r.runControl.Stop("console", conversationKey, "/stop")
 		}
-		output := formatConsoleStopResponse(result)
+		output := runtimecontrol.StopFeedback(result.Found)
 		resp, submitErr := r.submitSyntheticTask(generation, task, output, timeout, topicID, strings.TrimSpace(req.TopicTitle), strings.TrimSpace(req.WorkspaceDir), trigger)
 		return resp, true, submitErr
 	}
@@ -1221,27 +1221,6 @@ func (r *consoleLocalRuntime) handleConsoleRuntimeCommand(generation *consoleLoc
 	}
 	resp, submitErr := r.submitSyntheticTask(generation, task, output, timeout, topicID, strings.TrimSpace(req.TopicTitle), workspaceDir, trigger)
 	return resp, true, submitErr
-}
-
-func formatConsoleStopResponse(result runtimecontrol.StopResult) string {
-	if !result.Found {
-		return "当前没有正在运行的任务。"
-	}
-	parts := []string{"已请求停止当前任务。"}
-	if progress := strings.TrimSpace(result.Progress); progress != "" {
-		parts = append(parts, "当前进展："+progress)
-	}
-	return strings.Join(parts, "\n")
-}
-
-func formatConsoleSteerResponse(result runtimecontrol.SteerResult) string {
-	if !result.Found {
-		return "当前没有正在运行的任务。"
-	}
-	if !result.Queued {
-		return "当前任务正在运行，但暂时无法接收新的补充输入。"
-	}
-	return "👌"
 }
 
 func buildConsoleStopProgress(plan *consolePlanProgress, activity *consoleActivityProgress) string {

--- a/cmd/mistermorph/consolecmd/local_runtime.go
+++ b/cmd/mistermorph/consolecmd/local_runtime.go
@@ -41,6 +41,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/personautil"
 	"github.com/quailyquaily/mistermorph/internal/proaccount"
 	"github.com/quailyquaily/mistermorph/internal/promptprofile"
+	"github.com/quailyquaily/mistermorph/internal/runtimecontrol"
 	"github.com/quailyquaily/mistermorph/internal/skillsutil"
 	"github.com/quailyquaily/mistermorph/internal/statepaths"
 	"github.com/quailyquaily/mistermorph/internal/streaming"
@@ -116,6 +117,7 @@ type consoleLocalRuntime struct {
 	nextGeneration        uint64
 	pendingJobsMu         sync.Mutex
 	pendingJobs           map[string]consoleLocalTaskJob
+	runControl            *runtimecontrol.RunControl
 	managedRuntimeMu      sync.RWMutex
 	managedRuntimeRunning map[string]bool
 	workersCtx            context.Context
@@ -148,6 +150,7 @@ func newConsoleLocalRuntime(cfg serveConfig, reader *viper.Viper) (*consoleLocal
 	out := &consoleLocalRuntime{
 		inspectors:            inspectors,
 		pendingJobs:           map[string]consoleLocalTaskJob{},
+		runControl:            runtimecontrol.New(),
 		managedRuntimeRunning: map[string]bool{},
 	}
 	workersCtx, cancelWorkers := context.WithCancel(context.Background())
@@ -978,6 +981,7 @@ func (r *consoleLocalRuntime) routesOptions(authToken string) daemonruntime.Rout
 		TopicReader:     r.store,
 		TopicDeleter:    topicDeleterFunc(r.deleteTopic),
 		Submit:          r.submitTask,
+		Stop:            r.stopTask,
 		WorkspaceGet:    r.workspaceDirForTopic,
 		WorkspacePut:    r.setWorkspaceDirForTopic,
 		WorkspaceDelete: r.deleteWorkspaceDirForTopic,
@@ -1085,6 +1089,23 @@ func (r *consoleLocalRuntime) submitTask(ctx context.Context, req daemonruntime.
 		}
 		return resp, err
 	}
+	if result := r.trySteerConsoleRun(task, strings.TrimSpace(req.TopicID)); result.Found {
+		output := formatConsoleSteerResponse(result)
+		resp, err := r.submitSyntheticTask(
+			generation,
+			task,
+			output,
+			timeout,
+			strings.TrimSpace(req.TopicID),
+			strings.TrimSpace(req.TopicTitle),
+			strings.TrimSpace(req.WorkspaceDir),
+			trigger,
+		)
+		if err == nil {
+			releaseGeneration = false
+		}
+		return resp, err
+	}
 	model := strings.TrimSpace(req.Model)
 	resp, err := r.submitTaskViaBus(
 		ctx,
@@ -1103,6 +1124,46 @@ func (r *consoleLocalRuntime) submitTask(ctx context.Context, req daemonruntime.
 	return resp, err
 }
 
+func (r *consoleLocalRuntime) trySteerConsoleRun(task string, topicID string) runtimecontrol.SteerResult {
+	if r == nil || r.runControl == nil || strings.TrimSpace(task) == "" {
+		return runtimecontrol.SteerResult{}
+	}
+	return r.runControl.Steer("console", buildConsoleConversationKey(topicID), task)
+}
+
+func (r *consoleLocalRuntime) stopTask(_ context.Context, req daemonruntime.StopTaskRequest) (daemonruntime.StopTaskResponse, error) {
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		reason = "/stop"
+	}
+	taskID := strings.TrimSpace(req.TaskID)
+	topicID := strings.TrimSpace(req.TopicID)
+	if taskID == "" && topicID == "" {
+		return daemonruntime.StopTaskResponse{}, daemonruntime.BadRequest("task_id or topic_id is required")
+	}
+
+	result := runtimecontrol.StopResult{}
+	if r != nil && r.runControl != nil {
+		if taskID != "" {
+			result = r.runControl.StopTask("console", taskID, reason)
+		} else {
+			result = r.runControl.Stop("console", buildConsoleConversationKey(topicID), reason)
+		}
+	}
+	status := "not_found"
+	if result.Found {
+		status = "stopping"
+	}
+	return daemonruntime.StopTaskResponse{
+		Status:   status,
+		Found:    result.Found,
+		TaskID:   taskID,
+		TopicID:  topicID,
+		Progress: strings.TrimSpace(result.Progress),
+		Message:  formatConsoleStopResponse(result),
+	}, nil
+}
+
 func (r *consoleLocalRuntime) handleConsoleRuntimeCommand(generation *consoleLocalRuntimeGeneration, req daemonruntime.SubmitTaskRequest, timeout time.Duration, trigger daemonruntime.TaskTrigger) (daemonruntime.SubmitTaskResponse, bool, error) {
 	task := strings.TrimSpace(req.Task)
 	cmdWord, _ := chatcommands.ParseCommand(task)
@@ -1111,6 +1172,16 @@ func (r *consoleLocalRuntime) handleConsoleRuntimeCommand(generation *consoleLoc
 		return daemonruntime.SubmitTaskResponse{}, false, nil
 	}
 	topicID := strings.TrimSpace(req.TopicID)
+	if normalizedCmd == "/stop" {
+		conversationKey := buildConsoleConversationKey(topicID)
+		result := runtimecontrol.StopResult{}
+		if r != nil && r.runControl != nil {
+			result = r.runControl.Stop("console", conversationKey, "/stop")
+		}
+		output := formatConsoleStopResponse(result)
+		resp, submitErr := r.submitSyntheticTask(generation, task, output, timeout, topicID, strings.TrimSpace(req.TopicTitle), strings.TrimSpace(req.WorkspaceDir), trigger)
+		return resp, true, submitErr
+	}
 	if (normalizedCmd == "/ctx" || normalizedCmd == "/workspace") && topicID == "" {
 		return daemonruntime.SubmitTaskResponse{}, true, daemonruntime.BadRequest("topic_id is required for " + normalizedCmd)
 	}
@@ -1150,6 +1221,87 @@ func (r *consoleLocalRuntime) handleConsoleRuntimeCommand(generation *consoleLoc
 	}
 	resp, submitErr := r.submitSyntheticTask(generation, task, output, timeout, topicID, strings.TrimSpace(req.TopicTitle), workspaceDir, trigger)
 	return resp, true, submitErr
+}
+
+func formatConsoleStopResponse(result runtimecontrol.StopResult) string {
+	if !result.Found {
+		return "当前没有正在运行的任务。"
+	}
+	parts := []string{"已请求停止当前任务。"}
+	if progress := strings.TrimSpace(result.Progress); progress != "" {
+		parts = append(parts, "当前进展："+progress)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func formatConsoleSteerResponse(result runtimecontrol.SteerResult) string {
+	if !result.Found {
+		return "当前没有正在运行的任务。"
+	}
+	if !result.Queued {
+		return "当前任务正在运行，但暂时无法接收新的补充输入。"
+	}
+	return "已收到，会作为当前任务的补充输入处理。"
+}
+
+func buildConsoleStopProgress(plan *consolePlanProgress, activity *consoleActivityProgress) string {
+	items := make([]string, 0, 4)
+	if plan != nil && len(plan.Steps) > 0 {
+		planTotal := len(plan.Steps)
+		planCompleted := 0
+		planCurrent := ""
+		for _, step := range plan.Steps {
+			status := strings.TrimSpace(step.Status)
+			if status == agent.PlanStatusCompleted {
+				planCompleted++
+				continue
+			}
+			if planCurrent == "" {
+				planCurrent = strings.TrimSpace(step.Step)
+			}
+		}
+		if planCurrent == "" && planCompleted < planTotal {
+			for _, step := range plan.Steps {
+				if strings.TrimSpace(step.Step) != "" {
+					planCurrent = strings.TrimSpace(step.Step)
+					break
+				}
+			}
+		}
+		items = append(items, fmt.Sprintf("计划 %d/%d", planCompleted, planTotal))
+		if planCurrent != "" {
+			items = append(items, "当前步骤 "+planCurrent)
+		}
+	}
+	if activity != nil {
+		toolCalls := 0
+		for _, entry := range activity.History {
+			if strings.TrimSpace(entry.Kind) == "tool" {
+				toolCalls++
+			}
+		}
+		if toolCalls > 0 {
+			items = append(items, fmt.Sprintf("工具调用 %d", toolCalls))
+		}
+		if current := activity.Current; current != nil {
+			parts := []string{strings.TrimSpace(current.Kind), strings.TrimSpace(current.Name), strings.TrimSpace(current.Status)}
+			if currentActivity := strings.TrimSpace(strings.Join(nonEmptyStrings(parts), " ")); currentActivity != "" {
+				items = append(items, "当前活动 "+currentActivity)
+			}
+		}
+	}
+	return strings.Join(items, "，")
+}
+
+func nonEmptyStrings(items []string) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 func (r *consoleLocalRuntime) submitSyntheticTask(generation *consoleLocalRuntimeGeneration, task string, output string, timeout time.Duration, topicID string, topicTitle string, workspaceDir string, trigger daemonruntime.TaskTrigger) (daemonruntime.SubmitTaskResponse, error) {
@@ -1265,8 +1417,6 @@ func (r *consoleLocalRuntime) handleTaskJob(workerCtx context.Context, conversat
 		return streamTracker.Handle(event, streamer.Handle)
 	}
 
-	runCtx, cancel := context.WithTimeout(workerCtx, job.Timeout)
-	runCtx = agent.WithEventSinkContext(runCtx, eventSink)
 	planStepUpdate := func(runCtx *agent.Context, _ agent.PlanStepUpdate) {
 		progress := buildConsolePlanProgress(consoleTaskPlan(nil, runCtx))
 		if progress == nil {
@@ -1281,9 +1431,55 @@ func (r *consoleLocalRuntime) handleTaskJob(workerCtx context.Context, conversat
 		}
 	}
 
-	final, agentCtx, runErr := r.runTask(runCtx, conversationKey, job, onStream, planStepUpdate)
-	contextDeadline := daemonruntime.IsContextDeadline(runCtx, runErr)
-	cancel()
+	snapshot := func() string {
+		progressMu.Lock()
+		plan := cloneConsolePlanProgress(latestPlan)
+		activity := cloneConsoleActivityProgress(latestActivity)
+		progressMu.Unlock()
+		return buildConsoleStopProgress(plan, activity)
+	}
+	var steerSource agent.SteerSource
+	var lease *runtimecontrol.RunLease
+	var runCtx context.Context
+	var fallbackCancel context.CancelFunc
+	if r.runControl != nil {
+		var err error
+		lease, err = r.runControl.StartLease(workerCtx, job.Timeout, runtimecontrol.ActiveRun{
+			Runtime:         "console",
+			ConversationKey: conversationKey,
+			TopicID:         job.TopicID,
+			TaskID:          job.TaskID,
+			RunID:           job.TaskID,
+			Snapshot:        snapshot,
+			EventSink:       eventSink,
+		})
+		if err != nil {
+			eventSink.Close()
+			displayErr := strings.TrimSpace(err.Error())
+			_ = replySink.Abort(context.Background(), errors.New(displayErr))
+			streamTracker.LogSummary("failed")
+			runtimecore.MarkTaskFailed(r.store, job.TaskID, displayErr, false)
+			return
+		}
+		runCtx = lease.Context
+		steerSource = lease.SteerQueue
+	} else {
+		runCtx, fallbackCancel = context.WithTimeout(workerCtx, job.Timeout)
+	}
+	if runCtx == nil {
+		runCtx = workerCtx
+	}
+	runCtx = agent.WithEventSinkContext(runCtx, eventSink)
+
+	final, agentCtx, runErr := r.runTask(runCtx, conversationKey, job, onStream, steerSource, planStepUpdate)
+	contextCanceled := daemonruntime.IsContextDeadline(runCtx, runErr)
+	userStopped := false
+	if lease != nil {
+		userStopped = lease.UserStopped()
+		lease.Finish()
+	} else if fallbackCancel != nil {
+		fallbackCancel()
+	}
 
 	if runErr != nil {
 		eventSink.Close()
@@ -1291,9 +1487,15 @@ func (r *consoleLocalRuntime) handleTaskJob(workerCtx context.Context, conversat
 		if displayErr == "" {
 			displayErr = strings.TrimSpace(runErr.Error())
 		}
+		if userStopped {
+			displayErr = "stopped by user"
+		}
 		_ = replySink.Abort(context.Background(), errors.New(displayErr))
 		streamTracker.LogSummary("failed")
-		runtimecore.MarkTaskFailed(r.store, job.TaskID, displayErr, contextDeadline)
+		runtimecore.MarkTaskFailed(r.store, job.TaskID, displayErr, contextCanceled || userStopped)
+		if userStopped && r.streamHub != nil {
+			r.streamHub.PublishStatus(job.TaskID, string(daemonruntime.TaskCanceled))
+		}
 		return
 	}
 
@@ -1333,7 +1535,7 @@ func (r *consoleLocalRuntime) handleTaskJob(workerCtx context.Context, conversat
 	r.maybeRefreshTopicTitle(job, output)
 }
 
-func (r *consoleLocalRuntime) runTask(ctx context.Context, conversationKey string, job consoleLocalTaskJob, onStream llm.StreamHandler, planStepUpdate func(*agent.Context, agent.PlanStepUpdate)) (*agent.Final, *agent.Context, error) {
+func (r *consoleLocalRuntime) runTask(ctx context.Context, conversationKey string, job consoleLocalTaskJob, onStream llm.StreamHandler, steerSource agent.SteerSource, planStepUpdate func(*agent.Context, agent.PlanStepUpdate)) (*agent.Final, *agent.Context, error) {
 	if r == nil {
 		return nil, nil, fmt.Errorf("console runtime is not initialized")
 	}
@@ -1447,6 +1649,7 @@ func (r *consoleLocalRuntime) runTask(ctx context.Context, conversationKey strin
 		CurrentMessage:          currentMsg,
 		Registry:                reg,
 		OnStream:                onStream,
+		SteerSource:             steerSource,
 		Meta:                    meta,
 		PromptAugment:           promptAugment,
 		PlanStepUpdate:          planStepUpdate,

--- a/cmd/mistermorph/consolecmd/local_runtime.go
+++ b/cmd/mistermorph/consolecmd/local_runtime.go
@@ -1241,7 +1241,7 @@ func formatConsoleSteerResponse(result runtimecontrol.SteerResult) string {
 	if !result.Queued {
 		return "当前任务正在运行，但暂时无法接收新的补充输入。"
 	}
-	return "已收到，会作为当前任务的补充输入处理。"
+	return "👌"
 }
 
 func buildConsoleStopProgress(plan *consolePlanProgress, activity *consoleActivityProgress) string {

--- a/cmd/mistermorph/consolecmd/local_runtime.go
+++ b/cmd/mistermorph/consolecmd/local_runtime.go
@@ -1441,7 +1441,6 @@ func (r *consoleLocalRuntime) handleTaskJob(workerCtx context.Context, conversat
 	var steerSource agent.SteerSource
 	var lease *runtimecontrol.RunLease
 	var runCtx context.Context
-	var fallbackCancel context.CancelFunc
 	if r.runControl != nil {
 		var err error
 		lease, err = r.runControl.StartLease(workerCtx, job.Timeout, runtimecontrol.ActiveRun{
@@ -1464,7 +1463,9 @@ func (r *consoleLocalRuntime) handleTaskJob(workerCtx context.Context, conversat
 		runCtx = lease.Context
 		steerSource = lease.SteerQueue
 	} else {
-		runCtx, fallbackCancel = context.WithTimeout(workerCtx, job.Timeout)
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(workerCtx, job.Timeout)
+		defer cancel()
 	}
 	if runCtx == nil {
 		runCtx = workerCtx
@@ -1477,8 +1478,6 @@ func (r *consoleLocalRuntime) handleTaskJob(workerCtx context.Context, conversat
 	if lease != nil {
 		userStopped = lease.UserStopped()
 		lease.Finish()
-	} else if fallbackCancel != nil {
-		fallbackCancel()
 	}
 
 	if runErr != nil {

--- a/cmd/mistermorph/consolecmd/local_runtime_test.go
+++ b/cmd/mistermorph/consolecmd/local_runtime_test.go
@@ -3,6 +3,7 @@ package consolecmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/daemonruntime"
 	"github.com/quailyquaily/mistermorph/internal/llmconfig"
 	"github.com/quailyquaily/mistermorph/internal/llmutil"
+	"github.com/quailyquaily/mistermorph/internal/runtimecontrol"
 	"github.com/quailyquaily/mistermorph/internal/workspace"
 	"github.com/quailyquaily/mistermorph/llm"
 	"github.com/quailyquaily/mistermorph/tools"
@@ -52,6 +54,21 @@ func (c *consoleReactLLMClient) Chat(_ context.Context, req llm.Request) (llm.Re
 		}, nil
 	}
 	return llm.Result{Text: `{"type":"final","output":"fallback","is_lightweight":false}`}, nil
+}
+
+type consoleBlockingLLMClient struct {
+	entered chan struct{}
+}
+
+func (c *consoleBlockingLLMClient) Chat(ctx context.Context, _ llm.Request) (llm.Result, error) {
+	if c.entered != nil {
+		select {
+		case c.entered <- struct{}{}:
+		default:
+		}
+	}
+	<-ctx.Done()
+	return llm.Result{}, ctx.Err()
 }
 
 func TestConsoleLocalRoutesOptionsPoke(t *testing.T) {
@@ -217,7 +234,7 @@ func TestConsoleLocalRuntimeMessageReactContinuesToFinalText(t *testing.T) {
 		CreatedAt:       time.Date(2026, time.May, 29, 12, 0, 0, 0, time.UTC),
 		Generation:      generation,
 		Trigger:         daemonruntime.TaskTrigger{Source: "ui"},
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("runTask() error = %v", err)
 	}
@@ -857,5 +874,324 @@ func TestConsoleLocalRuntimeSubmitTaskHandlesHelpCommand(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("final.output missing %q: %q", want, output)
 		}
+	}
+}
+
+func TestConsoleLocalRuntimeSubmitTaskHandlesStopCommand(t *testing.T) {
+	store, err := daemonruntime.NewConsoleFileStore(daemonruntime.ConsoleFileStoreOptions{
+		Persist: false,
+	})
+	if err != nil {
+		t.Fatalf("NewConsoleFileStore() error = %v", err)
+	}
+	topic, err := store.CreateTopic("Topic A")
+	if err != nil {
+		t.Fatalf("CreateTopic() error = %v", err)
+	}
+	reader := viper.New()
+	generation := &consoleLocalRuntimeGeneration{reader: reader}
+	control := runtimecontrol.New()
+	rt := &consoleLocalRuntime{
+		store:      store,
+		generation: generation,
+		runControl: control,
+	}
+	runCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	conversationKey := buildConsoleConversationKey(topic.ID)
+	if err := control.Start(runtimecontrol.ActiveRun{
+		Runtime:         "console",
+		ConversationKey: conversationKey,
+		TopicID:         topic.ID,
+		TaskID:          "task_active",
+		RunID:           "task_active",
+		Cancel:          cancel,
+		Snapshot: func() string {
+			return "LLM 轮次 2，计划 1/3"
+		},
+	}); err != nil {
+		t.Fatalf("RunControl.Start() error = %v", err)
+	}
+
+	resp, err := rt.submitTask(context.Background(), daemonruntime.SubmitTaskRequest{
+		Task:    "/stop",
+		TopicID: topic.ID,
+	})
+	if err != nil {
+		t.Fatalf("submitTask(/stop) error = %v", err)
+	}
+	if resp.Status != daemonruntime.TaskDone {
+		t.Fatalf("resp.Status = %q, want %q", resp.Status, daemonruntime.TaskDone)
+	}
+	if !errors.Is(context.Cause(runCtx), runtimecontrol.ErrStoppedByUser) {
+		t.Fatalf("context cause = %v, want ErrStoppedByUser", context.Cause(runCtx))
+	}
+	task, ok := store.Get(resp.ID)
+	if !ok || task == nil {
+		t.Fatalf("store.Get(%q) missing", resp.ID)
+	}
+	result, _ := task.Result.(map[string]any)
+	final, _ := result["final"].(map[string]any)
+	output := strings.TrimSpace(fmt.Sprint(final["output"]))
+	for _, want := range []string{"已请求停止当前任务", "LLM 轮次 2", "计划 1/3"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("final.output missing %q: %q", want, output)
+		}
+	}
+}
+
+func TestConsoleLocalRuntimeStopTaskByTaskIDAndTopicID(t *testing.T) {
+	store, err := daemonruntime.NewConsoleFileStore(daemonruntime.ConsoleFileStoreOptions{
+		Persist: false,
+	})
+	if err != nil {
+		t.Fatalf("NewConsoleFileStore() error = %v", err)
+	}
+	topic, err := store.CreateTopic("Topic A")
+	if err != nil {
+		t.Fatalf("CreateTopic() error = %v", err)
+	}
+	rt := &consoleLocalRuntime{
+		store:      store,
+		runControl: runtimecontrol.New(),
+	}
+
+	startActive := func(taskID string) context.Context {
+		t.Helper()
+		ctx, cancel := context.WithCancelCause(context.Background())
+		if err := rt.runControl.Start(runtimecontrol.ActiveRun{
+			Runtime:         "console",
+			ConversationKey: buildConsoleConversationKey(topic.ID),
+			TopicID:         topic.ID,
+			TaskID:          taskID,
+			Cancel:          cancel,
+			Snapshot: func() string {
+				return "计划 1/2"
+			},
+		}); err != nil {
+			t.Fatalf("RunControl.Start() error = %v", err)
+		}
+		return ctx
+	}
+
+	taskCtx := startActive("task_active")
+	byTask, err := rt.stopTask(context.Background(), daemonruntime.StopTaskRequest{
+		TaskID: "task_active",
+	})
+	if err != nil {
+		t.Fatalf("stopTask(task_id) error = %v", err)
+	}
+	if !byTask.Found || byTask.TaskID != "task_active" || byTask.Status != "stopping" || byTask.Progress != "计划 1/2" {
+		t.Fatalf("stopTask(task_id) = %+v", byTask)
+	}
+	if !errors.Is(context.Cause(taskCtx), runtimecontrol.ErrStoppedByUser) {
+		t.Fatalf("task context cause = %v, want ErrStoppedByUser", context.Cause(taskCtx))
+	}
+	rt.runControl.Finish("console", buildConsoleConversationKey(topic.ID), "task_active")
+
+	topicCtx := startActive("task_topic")
+	byTopic, err := rt.stopTask(context.Background(), daemonruntime.StopTaskRequest{
+		TopicID: topic.ID,
+	})
+	if err != nil {
+		t.Fatalf("stopTask(topic_id) error = %v", err)
+	}
+	if !byTopic.Found || byTopic.TopicID != topic.ID || byTopic.Status != "stopping" || byTopic.Progress != "计划 1/2" {
+		t.Fatalf("stopTask(topic_id) = %+v", byTopic)
+	}
+	if !errors.Is(context.Cause(topicCtx), runtimecontrol.ErrStoppedByUser) {
+		t.Fatalf("topic context cause = %v, want ErrStoppedByUser", context.Cause(topicCtx))
+	}
+}
+
+func TestConsoleLocalRuntimeStopCommandCancelsRunningTask(t *testing.T) {
+	store, err := daemonruntime.NewConsoleFileStore(daemonruntime.ConsoleFileStoreOptions{
+		Persist: false,
+	})
+	if err != nil {
+		t.Fatalf("NewConsoleFileStore() error = %v", err)
+	}
+	topic, err := store.CreateTopic("Topic A")
+	if err != nil {
+		t.Fatalf("CreateTopic() error = %v", err)
+	}
+	reader := viper.New()
+	reader.Set("timeout", time.Minute)
+	logger := slog.Default()
+	route := llmutil.ResolvedRoute{
+		ClientConfig: llmconfig.ClientConfig{
+			Provider: "test",
+			Model:    "test-model",
+		},
+	}
+	client := &consoleBlockingLLMClient{entered: make(chan struct{}, 1)}
+	baseRegistry := tools.NewRegistry()
+	commonDeps := depsutil.CommonDependencies{
+		Logger: func() (*slog.Logger, error) {
+			return logger, nil
+		},
+		LogOptions: func() agent.LogOptions {
+			return agent.LogOptions{}
+		},
+		ResolveLLMRoute: func(string) (llmutil.ResolvedRoute, error) {
+			return route, nil
+		},
+		CreateLLMClient: func(llmutil.ResolvedRoute) (llm.Client, error) {
+			return client, nil
+		},
+		Registry: func() *tools.Registry {
+			return baseRegistry
+		},
+		PromptSpec: func(context.Context, *slog.Logger, agent.LogOptions, string, llm.Client, string, []string) (agent.PromptSpec, []string, error) {
+			return agent.PromptSpec{}, nil, nil
+		},
+	}
+	taskRuntime, err := taskruntime.Bootstrap(commonDeps, taskruntime.BootstrapOptions{
+		AgentConfig: agent.Config{
+			MaxSteps:        1,
+			ParseRetries:    0,
+			ToolRepeatLimit: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Bootstrap() error = %v", err)
+	}
+	generation := &consoleLocalRuntimeGeneration{
+		reader:     reader,
+		logger:     logger,
+		commonDeps: commonDeps,
+		bundle: &consoleLocalRuntimeBundle{
+			taskRuntime: taskRuntime,
+		},
+	}
+	generation.acquire()
+	rt := &consoleLocalRuntime{
+		store:      store,
+		streamHub:  newConsoleStreamHub(),
+		generation: generation,
+		runControl: runtimecontrol.New(),
+	}
+	job := consoleLocalTaskJob{
+		TaskID:          "task_running",
+		ConversationKey: buildConsoleConversationKey(topic.ID),
+		TopicID:         topic.ID,
+		Task:            "long task",
+		Timeout:         time.Minute,
+		CreatedAt:       time.Date(2026, time.June, 3, 12, 0, 0, 0, time.UTC),
+		Trigger:         daemonruntime.TaskTrigger{Source: "ui"},
+		Generation:      generation,
+	}
+	if err := store.UpsertWithTrigger(daemonruntime.TaskInfo{
+		ID:        job.TaskID,
+		Status:    daemonruntime.TaskQueued,
+		Task:      job.Task,
+		Model:     "test-model",
+		Timeout:   job.Timeout.String(),
+		CreatedAt: job.CreatedAt,
+		TopicID:   topic.ID,
+	}, job.Trigger, ""); err != nil {
+		t.Fatalf("UpsertWithTrigger() error = %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		rt.handleTaskJob(context.Background(), job.ConversationKey, job)
+	}()
+
+	select {
+	case <-client.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("LLM client was not called")
+	}
+	resp, err := rt.submitTask(context.Background(), daemonruntime.SubmitTaskRequest{
+		Task:    "/stop",
+		TopicID: topic.ID,
+	})
+	if err != nil {
+		t.Fatalf("submitTask(/stop) error = %v", err)
+	}
+	if resp.Status != daemonruntime.TaskDone {
+		t.Fatalf("stop resp.Status = %q, want %q", resp.Status, daemonruntime.TaskDone)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("running task did not stop")
+	}
+	task, ok := store.Get(job.TaskID)
+	if !ok || task == nil {
+		t.Fatalf("store.Get(%q) missing", job.TaskID)
+	}
+	if task.Status != daemonruntime.TaskCanceled {
+		t.Fatalf("task.Status = %q, want %q; error=%q", task.Status, daemonruntime.TaskCanceled, task.Error)
+	}
+	if strings.TrimSpace(task.Error) != "stopped by user" {
+		t.Fatalf("task.Error = %q, want stopped by user", task.Error)
+	}
+}
+
+func TestConsoleLocalRuntimeSubmitTaskSteersRunningTask(t *testing.T) {
+	store, err := daemonruntime.NewConsoleFileStore(daemonruntime.ConsoleFileStoreOptions{
+		Persist: false,
+	})
+	if err != nil {
+		t.Fatalf("NewConsoleFileStore() error = %v", err)
+	}
+	topic, err := store.CreateTopic("Topic A")
+	if err != nil {
+		t.Fatalf("CreateTopic() error = %v", err)
+	}
+	reader := viper.New()
+	generation := &consoleLocalRuntimeGeneration{reader: reader}
+	control := runtimecontrol.New()
+	queue := runtimecontrol.NewSteerQueue(0)
+	rt := &consoleLocalRuntime{
+		store:      store,
+		generation: generation,
+		runControl: control,
+	}
+	runCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	conversationKey := buildConsoleConversationKey(topic.ID)
+	if err := control.Start(runtimecontrol.ActiveRun{
+		Runtime:         "console",
+		ConversationKey: conversationKey,
+		TopicID:         topic.ID,
+		TaskID:          "task_active",
+		RunID:           "task_active",
+		Cancel:          cancel,
+		SteerQueue:      queue,
+	}); err != nil {
+		t.Fatalf("RunControl.Start() error = %v", err)
+	}
+
+	resp, err := rt.submitTask(context.Background(), daemonruntime.SubmitTaskRequest{
+		Task:    "请改成简短回答",
+		TopicID: topic.ID,
+	})
+	if err != nil {
+		t.Fatalf("submitTask(steer) error = %v", err)
+	}
+	if resp.Status != daemonruntime.TaskDone {
+		t.Fatalf("resp.Status = %q, want %q", resp.Status, daemonruntime.TaskDone)
+	}
+	if runCtx.Err() != nil {
+		t.Fatalf("steer canceled active run: %v", runCtx.Err())
+	}
+	items := queue.Drain()
+	if len(items) != 1 || strings.TrimSpace(items[0]) != "请改成简短回答" {
+		t.Fatalf("steer queue = %#v, want one queued input", items)
+	}
+	task, ok := store.Get(resp.ID)
+	if !ok || task == nil {
+		t.Fatalf("store.Get(%q) missing", resp.ID)
+	}
+	result, _ := task.Result.(map[string]any)
+	final, _ := result["final"].(map[string]any)
+	output := strings.TrimSpace(fmt.Sprint(final["output"]))
+	if !strings.Contains(output, "已收到") || !strings.Contains(output, "当前任务") {
+		t.Fatalf("final.output = %q, want steer acknowledgement", output)
 	}
 }

--- a/cmd/mistermorph/consolecmd/local_runtime_test.go
+++ b/cmd/mistermorph/consolecmd/local_runtime_test.go
@@ -933,10 +933,8 @@ func TestConsoleLocalRuntimeSubmitTaskHandlesStopCommand(t *testing.T) {
 	result, _ := task.Result.(map[string]any)
 	final, _ := result["final"].(map[string]any)
 	output := strings.TrimSpace(fmt.Sprint(final["output"]))
-	for _, want := range []string{"已请求停止当前任务", "LLM 轮次 2", "计划 1/3"} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("final.output missing %q: %q", want, output)
-		}
+	if output != runtimecontrol.FeedbackStopped {
+		t.Fatalf("final.output = %q, want stopped acknowledgement", output)
 	}
 }
 
@@ -1191,7 +1189,7 @@ func TestConsoleLocalRuntimeSubmitTaskSteersRunningTask(t *testing.T) {
 	result, _ := task.Result.(map[string]any)
 	final, _ := result["final"].(map[string]any)
 	output := strings.TrimSpace(fmt.Sprint(final["output"]))
-	if output != "👌" {
+	if output != runtimecontrol.FeedbackSteerAccepted {
 		t.Fatalf("final.output = %q, want steer acknowledgement", output)
 	}
 }

--- a/cmd/mistermorph/consolecmd/local_runtime_test.go
+++ b/cmd/mistermorph/consolecmd/local_runtime_test.go
@@ -1191,7 +1191,7 @@ func TestConsoleLocalRuntimeSubmitTaskSteersRunningTask(t *testing.T) {
 	result, _ := task.Result.(map[string]any)
 	final, _ := result["final"].(map[string]any)
 	output := strings.TrimSpace(fmt.Sprint(final["output"]))
-	if !strings.Contains(output, "已收到") || !strings.Contains(output, "当前任务") {
+	if output != "👌" {
 		t.Fatalf("final.output = %q, want steer acknowledgement", output)
 	}
 }

--- a/docs/feat/feat_20260603_runtime_stop_and_steer.md
+++ b/docs/feat/feat_20260603_runtime_stop_and_steer.md
@@ -1,0 +1,691 @@
+---
+date: 2026-06-03
+title: Runtime /stop 与 steer 方案
+status: draft
+---
+
+# Runtime /stop 与 steer 方案
+
+## 1) 范围
+
+这份方案只处理三个能力：
+
+1. `/stop`：用户可以停止当前 runtime 中当前 conversation 正在运行的任务，并收到可读的进展摘要和停止确认。
+2. steer：用户在任务运行中继续输入时，这段输入可以进入当前 agent turn，而不是只能排成下一个独立任务。
+3. 窄版 turn event：为 `/stop` 和 steer 提供明确的状态事件，让 UI 和 audit 不靠文本猜状态。
+
+第一阶段优先做 agent loop 和 Console Local，因为它们已经有 task store、stream hub、chat command registry 和 per-conversation runner。后续再扩到 Telegram、Slack、Lark、LINE、managed runtime 和 CLI chat。
+
+不在本方案内做：
+
+- 完整照搬 Codex 的 Session/Turn/History 架构。
+- fork、rollback、resume tree。
+- 后台 shell 进程管理。
+- 跨 runtime 的全局停止。
+- 对已经发给模型的 tool call 做半途改写。
+- 完整 app-server protocol、可 replay 的 turn item stream、turn diff 和 compaction event。
+
+## 2) 当前事实
+
+从现有代码看，底层已有一部分停止能力：
+
+- `agent.Engine.Run(...)` 接收 `context.Context`，每个 step 开始会检查 `ctx.Err()`。
+- LLM client、tool 执行、subtask runner 都沿用同一个 ctx。
+- `bash` 通过 `exec.CommandContext(...)` 执行，ctx 取消会终止命令进程。
+- ACP client 在 ctx 取消时会发送 `session/cancel`。
+- `agent.Context` 已经记录 `Plan`、`Steps`、`Metrics`，可以生成停止时的进展摘要。
+- `agent.Event` 已有 `tool_start`、`tool_output`、`tool_done`、`subtask_start`、`subtask_done`。
+- Console 已经有 `streamHub` 和 event preview sink，可以显示工具活动。
+
+缺的是 runtime 层的控制句柄：
+
+- `internal/channelruntime/core.ConversationRunner` 只负责按 conversation 排队和串行执行，不保存当前 run 的 cancel func。
+- Console Local 的 `pendingJobs` 只覆盖任务进入 bus 到 enqueue 前的短暂阶段，不代表正在运行的任务。
+- 实现前，`daemonruntime` 只有 `POST /tasks`、`GET /tasks`、`GET /tasks/{id}`，没有停止或 steer 的控制端点。
+- `chatcommands.NewRuntimeRegistry(...)` 还没有 `/stop`。
+- `agent.Event` 还没有 turn 生命周期、stop 和 steer 事件。
+- CLI chat 在 thinking 状态下不接收普通输入，Ctrl+C 当前更接近退出整个 chat，而不是停止当前 turn 后留在会话里。
+
+所以 `/stop` 不应该写成一个普通 agent prompt，也不应该只更新 task 状态。它需要 runtime 拿到当前 run 的 cancel func，并让 agent/tool/LLM 都沿 ctx 退出。
+
+## 3) 第一性原则
+
+`/stop` 的本质是用户撤回当前任务的继续执行许可。正确行为是：
+
+- 找到同一 runtime、同一 conversation 的当前 active run。
+- 取消该 run 的 ctx。
+- 不再调用下一轮 LLM。
+- 尽力终止正在运行的工具。
+- 把任务状态标为 `canceled`，原因是用户停止，不是超时。
+- 返回当前进展和“已停止”或“正在停止”的明确反馈。
+
+steer 的本质是用户在当前任务仍在执行时修改约束或补充信息。正确行为是：
+
+- 运行中输入先进入一个有序队列。
+- agent 在安全检查点把这些输入作为新的 user message 注入当前 turn。
+- 注入后继续同一个 run，而不是新建一个 task。
+- 如果用户需要立刻打断当前 LLM 请求或工具，应使用 `/stop`。
+
+这里的安全检查点指：
+
+- 每次 LLM 调用前。
+- 工具批次结束后、下一次 LLM 调用前。
+- 模型返回 final 之后、真正结束 run 之前。
+
+不在工具调用半途插入 steer。原因很简单：tool call 已经进入 provider history，如果跳过对应 tool output，历史结构会损坏。要打断工具，用 `/stop`。
+
+## 4) 核心设计
+
+### 4.1 RunControl
+
+新增一个 runtime 控制组件，例如 `internal/runtimecontrol`。它不是已有函数的薄封装，它真正拥有两类状态，并提供一个可选的进展文本回调：
+
+- 当前 active run：runtime、conversation key、task id、run id、cancel func。
+- 当前 steer queue：运行中用户输入，按收到顺序保存。
+- 当前进展文本：由具体 runtime 本地生成，`RunControl` 不理解 plan、metrics、stream activity 的结构。
+
+当前实现采用窄结构：
+
+```go
+type ActiveRun struct {
+    Runtime         string
+    ConversationKey string
+    TopicID         string
+    TaskID          string
+    RunID           string
+    Cancel          context.CancelCauseFunc
+    Snapshot        func() string
+    SteerQueue      *SteerQueue
+}
+
+type StopResult struct {
+    Found    bool
+    Progress string
+}
+```
+
+`RunControl` 提供这些操作：
+
+- `Start(run ActiveRun)`：run 开始前注册。相同 conversation 已有 active run 时返回错误。
+- `StartLease(parent, timeout, run)`：为 worker 创建 cancel-cause ctx、timeout ctx、steer queue，并注册 active run。Console 和 channel runtime 都走这条路径。
+- `Finish(runtime, conversationKey, taskID)`：run 结束后移除，返回是否真的清理了 active run。
+- `Stop(runtime, conversationKey, reason)`：查找 active run，记录 stop request，调用 cancel。
+- `StopTask(runtime, taskID, reason)`：按 task id 精确查找 active run，记录 stop request，调用 cancel。
+- `Steer(runtime, conversationKey, input)`：查找 active run，把 input 放进 queue。
+
+`Stop` 必须幂等。用户重复输入 `/stop` 时，不应报错；应返回同一个任务的当前停止进展。
+
+### 4.2 Runtime 支持范围
+
+`/stop` 的语义在所有 runtime 中保持一致：
+
+- 只停止同一 runtime、同一 conversation/topic/thread 的当前 active run。
+- 不停止其他 conversation，也不做跨 runtime 的全局停止。
+- 没有 active run 时，返回“当前没有正在运行的任务”。
+- 已经在停止中的 run，重复 `/stop` 返回当前停止进展。
+
+各 runtime 的入口不同，但语义相同：
+
+- Console Local：`/stop` command、`POST /topics/{topic_id}/stop`、`POST /tasks/{id}/stop`。
+- Telegram/Slack/Lark/LINE standalone runtime：同一 chat/thread 内的 `/stop`。
+- Console managed runtime：被 Console 托管启动的 Telegram/Slack/Lark runtime 也按 standalone runtime 的同一语义执行 `/stop`；managed 只改变进程托管方式，不改变用户语义。
+- CLI chat：运行中输入 `/stop` 取消当前 turn，不退出 chat；空闲时 `/exit` 或 `/quit` 仍退出 chat。
+
+### 4.3 停止原因
+
+现在很多路径只看到 `context.Canceled`，无法区分用户停止、runtime 关闭和超时。Go 版本已经支持 cancel cause，建议在 run 外层用：
+
+```go
+runCtx, cancel := context.WithCancelCause(workerCtx)
+```
+
+停止时使用明确原因：
+
+```go
+cancel(runtimecontrol.ErrStoppedByUser)
+```
+
+任务收尾时读取 `context.Cause(runCtx)`：
+
+- `ErrStoppedByUser`：状态写 `canceled`，错误文本写 `stopped by user`。
+- `context.DeadlineExceeded`：状态写 `canceled`，错误文本写超时。
+- runtime 关闭导致的取消：状态写 `canceled`，错误文本写 runtime stopped。
+
+这样 UI 和日志不会把用户主动停止误报成普通错误。
+
+### 4.4 停止进展
+
+停止反馈不需要完整 dump。当前最小实现不定义通用 `ProgressSnapshot`，因为不同 runtime 能拿到的进展来源不同。`RunControl` 只接受：
+
+```go
+Snapshot func() string
+```
+
+Console 已经在 `handleTaskJob(...)` 里维护 `latestPlan` 和 `latestActivity`，所以 Console 本地把它们渲染成短文本，例如：
+
+```text
+计划 1/3，当前步骤 run tests，工具调用 2
+```
+
+如果后续 HTTP stop endpoint 需要结构化 JSON，再在 daemonruntime 层定义响应结构，不提前放进 `RunControl`。
+
+反馈文本建议：
+
+- 没有 active run：`当前没有正在运行的任务。`
+- 收到停止请求但 run 还没退出：`已请求停止当前任务。当前进展：...`
+- run 已退出：`已停止当前任务。当前进展：...`
+
+### 4.5 窄版 turn event
+
+这次只补 `/stop` 和 steer 需要的事件，不做完整 turn item 协议。
+
+agent loop 发：
+
+- `turn_start`：一次 `Engine.Run(...)` 开始。
+- `turn_done`：正常 final 返回。
+- `turn_canceled`：ctx 取消导致 run 结束。
+- `steer_applied`：pending steer 已经注入 prompt history，下一次 LLM 请求会看到。
+
+runtime/control 发：
+
+- `run_stop_requested`：用户或 HTTP control endpoint 请求停止 active run。
+- `run_stopped`：active run 已按用户停止原因收尾。
+- `steer_queued`：运行中输入已进入 active run 的 steer queue。
+
+事件字段沿用现有 `agent.Event`，只按需补少量字段：
+
+```go
+type Event struct {
+    Kind            string
+    RunID           string
+    TaskID          string
+    ConversationKey string
+    TopicID         string
+    Status          string
+    Reason          string
+    Text            string
+    Summary         string
+    Args            map[string]any
+}
+```
+
+这些字段不要求一次全部填满。事件的基本规则：
+
+- `turn_*` 事件由 agent loop 产生，表示模型任务生命周期。
+- `run_*` 事件由 runtime/control 产生，表示用户控制动作和结果。
+- `steer_queued` 和 `steer_applied` 成对出现；如果 run 被 stop，queued 但未 applied 的 steer 应留在 task result 中。
+- task store 仍是任务最终状态的来源，event stream 只负责实时观察和 audit。
+
+## 5) `/stop` 流程
+
+### 5.1 Console Local
+
+`POST /tasks` 收到 task 为 `/stop` 时，不创建普通 queued task。
+
+流程：
+
+1. 解析 topic id，得到 `conversationKey`。
+2. 调用 `RunControl.Stop("console", conversationKey, "/stop")`。
+3. 如果没有 active run，返回一个 synthetic done task，输出“当前没有正在运行的任务。”
+4. 如果有 active run，立即返回一个 synthetic done task，输出“已请求停止...”和当前进展。
+5. 被停止的 active task 自己在 `handleTaskJob(...)` 收尾时写成 `canceled`。
+6. stream hub 发布 active task 的 `canceled` 状态，让 UI 能更新原任务。
+
+这样 `/stop` 本身仍然是用户可见的一条 command 回复，但真正被停止的是原 active task。
+
+### 5.2 HTTP 控制端点
+
+为了让 Console UI 不必伪造 slash command，当前实现同时增加：
+
+- `POST /tasks/{id}/stop`
+- `POST /topics/{topic_id}/stop`
+
+`/tasks/{id}/stop` 用 task id 精确停止。`/topics/{topic_id}/stop` 停止当前 topic 的 active run，适合聊天输入框和移动端 UI。
+
+返回 JSON：
+
+```json
+{
+  "status": "stopping",
+  "found": true,
+  "task_id": "console_...",
+  "topic_id": "topic_...",
+  "progress": "计划 1/3，当前步骤 run tests，工具调用 2",
+  "message": "已请求停止当前任务。\n当前进展：计划 1/3，当前步骤 run tests，工具调用 2"
+}
+```
+
+### 5.3 Channel runtimes 和 managed runtime
+
+Telegram、Slack、Lark、LINE 的 `/stop` 语义应和 Console 一致：
+
+- command 必须在同一 conversation 生效。
+- 群聊里仍遵循现有显式触发规则。未明确发给 agent 的 `/stop` 不应误停。
+- 停止成功后发送短回复。
+- 如果没有 active run，回复没有正在运行的任务。
+
+Channel runtime 当前也用 `ConversationRunner` 串行任务。接入时同样在 run 开始前注册 active run，结束后移除。
+
+Console managed runtime 启动的是同一类 Telegram/Slack/Lark runtime。它们必须复用同一套 `/stop` 行为：
+
+- 用户仍在原聊天软件里发送 `/stop`。
+- 停止的是该 managed child runtime 中同 conversation 的 active run。
+- Console supervisor 只负责进程生命周期，不改变 `/stop` 语义。
+
+### 5.4 CLI chat
+
+CLI chat 的 `/stop` 语义也应一致：
+
+- 运行中输入 `/stop` 取消当前 turn，并打印停止反馈。
+- 取消后保留 chat session 和历史，不退出进程。
+- 空闲时 `/stop` 返回没有正在运行的任务。
+- Ctrl+C 的语义和 `/stop` 对齐：运行中取消当前 turn，空闲时退出 chat。
+
+### 5.5 Pending approval
+
+approval pending 也是当前任务的一种暂停状态。最小处理：
+
+- 如果 active run 已经返回 pending approval，`RunControl` 里没有 active run，此时 `/stop` 要能按 task id 或 topic 查到 pending task。
+- pending task 被 `/stop` 后写成 `canceled`。
+- resume 时如果 task 已经 `canceled`，拒绝继续执行。
+
+如果 guard store 已支持拒绝 approval request，可以同步把 approval 标成 rejected；如果没有，先用 task 状态阻止 resume。
+
+## 6) steer 流程
+
+### 6.1 Runtime 接收
+
+运行中普通输入的处理规则：
+
+- 如果同一 conversation 没有 active run：按现有逻辑创建新 task。
+- 如果有 active run，且输入不是 runtime command：作为 steer 输入进入 active run。
+- 被接受为 steer 时，runtime 必须立刻给用户一条短反馈，说明输入已收到并会加入当前任务。
+- 如果输入是 `/stop`：走停止流程。
+- 其他 slash command 保持现有 command 语义，不注入 agent turn。
+
+推荐反馈文本：
+
+- Console：`已收到，已加入当前运行中的任务。`
+- Channel runtime：`已收到，会在当前任务的下一步处理。`
+- CLI chat：`已收到，会加入当前 turn。`
+
+Console `POST /tasks` 可以在 response 上增加兼容字段：
+
+```go
+type SubmitTaskResponse struct {
+    ID           string     `json:"id"`
+    Status       TaskStatus `json:"status"`
+    TopicID      string     `json:"topic_id,omitempty"`
+    AcceptedAs   string     `json:"accepted_as,omitempty"`    // task|steer|command
+    TargetTaskID string     `json:"target_task_id,omitempty"` // steer/command target
+    SteerID      string     `json:"steer_id,omitempty"`
+    Message      string     `json:"message,omitempty"`
+}
+```
+
+旧客户端忽略新增字段即可。
+
+### 6.2 SteerQueue
+
+steer queue 的第一阶段只保证顺序和有界。去重依赖 channel message id 或 console submit id，需要和 `steer_events` 持久化一起做，先不提前放进内存队列。
+
+当前结构只存文本：
+
+```go
+type SteerSource interface {
+    Drain() []string
+}
+```
+
+规则：
+
+- 队列按收到顺序 drain。
+- 队列设置最大条数。超限时拒绝新 steer，并提示用户当前任务输入过多。
+- 如果后续做 `steer_events`，再给 steer 增加 id、source、created_at、applied_at。
+
+### 6.3 注入 agent turn
+
+在 `agent.RunOptions` 增加 steer source：
+
+```go
+type SteerSource interface {
+    Drain() []string
+}
+```
+
+`engineLoopState` 持有该 source。loop 在安全检查点调用 drain，并把 steer 合并成 user message：
+
+```text
+[[ Runtime Steer ]]
+The user sent this while the current task was running. Apply it to this same turn:
+
+...
+```
+
+注入点：
+
+1. 每次 LLM 调用前：先 drain，再调用 hooks，再请求模型。
+2. 工具批次结束后：进入下一轮 loop 时自然 drain。
+3. 模型返回 final 后：如果此时 drain 到 steer，不返回 final；追加 assistant 文本，再追加 steer message，继续下一轮。
+
+不在 tool call 执行前抢占当前 tool call。原因是 provider history 需要 tool call 和 tool output 成对出现。用户要阻止当前工具继续执行，应使用 `/stop`。
+
+### 6.4 持久化
+
+steer 输入后续必须可追踪，否则 topic history 会丢失用户补充的信息。当前第一阶段先让 steer 进入 active turn；持久化放到下一阶段。
+
+Console 后续最小做法：
+
+- active task 的 `Result` 增加 `steer_events`。
+- 每个 steer 记录 id、source、text、created_at、applied_at。
+- `buildConsoleTopicHistory(...)` 后续渲染历史时，把已完成 task 的 steer events 作为该 task 内的 inbound user 补充消息。
+
+这不要求立刻引入完整 History Manager。等后续做结构化 history 时，再把 steer events 迁过去。
+
+## 7) UI 和 audit 反馈
+
+Console UI 至少需要显示四类状态：
+
+- turn running：agent turn 已开始。
+- steer queued：用户输入已进入当前任务。
+- steer acknowledged：runtime 已向用户确认收到 steer。
+- steer applied：agent 已在下一轮模型请求中看到这段输入。
+- stopped/canceled：当前任务已停止。
+
+最小事件流：
+
+- `turn_start`
+- `turn_done`
+- `turn_canceled`
+- `run_stop_requested`
+- `run_stopped`
+- `steer_queued`
+- `steer_applied`
+
+这些事件用于实时 UI 和 audit，不替代 task store。task store 仍然决定任务最终状态，event stream 只说明状态变化发生过。
+
+## 8) 实施阶段
+
+### Phase 1：最小 turn event schema
+
+先写测试：
+
+- agent run 正常 final 时发出 `turn_start` 和 `turn_done`。
+- agent run 被 ctx 取消时发出 `turn_start` 和 `turn_canceled`。
+- 事件里带 run id、task id 或 conversation key 中至少一个可关联字段。
+- 现有 tool/subtask event 行为不变。
+
+实现：
+
+- 扩展 `agent.Event` 常量和必要字段。
+- `engine_loop.go` 在 run 开始、正常结束、取消结束时发事件。
+- Console event sink 可以接收新事件；暂时不要求完整 UI 改版。
+
+验收：
+
+- task audit 或 stream 里能看到 turn 生命周期事件。
+- 没有引入 History Manager。
+
+### Phase 2：Console Local `/stop`
+
+先写测试：
+
+- `RunControl.Stop` 对 active run 调用 cancel，重复 stop 幂等。
+- 没有 active run 时返回 not found。
+- Console `/stop` 不创建普通 queued task。
+- 被停止的 active task 最终状态是 `canceled`，错误原因是 `stopped by user`。
+- 停止反馈包含 plan/metrics/steps 中至少一类进展信息。
+- 停止请求发出 `run_stop_requested`，任务收尾发出 `run_stopped` 或 `turn_canceled`。
+
+实现：
+
+- 增加 `internal/runtimecontrol`。
+- `consoleLocalRuntime` 持有一个 control registry。
+- `handleTaskJob(...)` 创建 run ctx 时使用 cancel cause。
+- run 开始注册 active run，defer finish。
+- `handleConsoleRuntimeCommand(...)` 注册 `/stop`。
+- `routesOptions(...)` 给 daemon handler 注入 stop handler。
+- stop path 发 `run_stop_requested`，active task 收尾时发 `run_stopped`。
+
+验收：
+
+- Console 输入 `/stop` 能停止同 topic 正在运行的任务。
+- 长 shell 命令能随着 ctx 取消退出。
+- UI 任务状态从 `running` 变为 `canceled`。
+
+### Phase 3：agent steer source
+
+先写测试：
+
+- mock LLM 第一轮调用工具，工具结束后 drain 到 steer，第二轮请求包含 steer message。
+- mock LLM 返回 final 时，如果 pending steer 存在，不结束 run，而是继续下一轮。
+- 多条 steer 按顺序合并。
+- 没有 steer 时现有 agent 测试行为不变。
+- steer 注入 prompt history 时发 `steer_applied`。
+
+实现：
+
+- 增加窄版 `agent.SteerSource`，接口为 `Drain() []string`。
+- `RunOptions` 增加 `SteerSource`。
+- `engine_loop.go` 在安全检查点注入 steer。
+- 发出 `steer_applied` event。
+
+验收：
+
+- steer 能进入当前 run 的下一次模型请求。
+- 不破坏 tool call/output 配对。
+
+### Phase 4：Console steer
+
+先写测试：
+
+- 同 topic 有 active run 时，普通 `POST /tasks` 被接受为 steer，不创建新 queued task。
+- response 带 `accepted_as=steer`、`target_task_id`、`steer_id`。
+- response 或 synthetic reply 包含已收到 steer 的短反馈。
+- active task 的 result 记录 `steer_events`。
+- 下一次 LLM 请求可以看到 steer。
+- 收到运行中输入时发 `steer_queued`。
+
+实现：
+
+- Console submit path 在创建 task 前调用 `RunControl.Steer(...)`。
+- 如果返回 found，说明 active run 存在，当前输入作为 steer 处理。
+- stream hub 发布 `steer_queued`。
+- `taskruntime.Run(...)` 把 steer source 传给 agent。
+
+验收：
+
+- 用户在 Console 中连续输入时，第二条输入进入第一条任务的 turn。
+- UI 能显示输入已加入当前任务。
+- 用户能立刻看到 steer 已收到的反馈。
+
+### Phase 5：Channel runtimes 和 managed runtime
+
+先写测试：
+
+- Telegram/Slack/Lark/LINE 的 command registry 或现有 command 分支识别 `/stop`。
+- 同 conversation 有 active run 时，新 inbound message 进入 steer。
+- 新 inbound message 作为 steer 被接受时，channel 回复已收到。
+- 群聊未显式触发的消息不 steer。
+- 重复 message id 不重复注入。
+
+实现：
+
+- 给各 channel runtime 接入同一个 `RunControl`。
+- 在 enqueue 前判断 active run。
+- `/stop` 走 control registry。
+
+验收：
+
+- 各 channel 的长任务可以被同 conversation 的 `/stop` 停止。
+- 运行中补充输入会进入当前任务。
+- managed runtime 与 standalone runtime 的 `/stop` 和 steer 用户语义一致。
+
+### Phase 6：CLI chat
+
+CLI chat 当前 thinking 时禁用输入。它要支持 steer，需要让 TUI 在 thinking 状态仍能提交文本。
+
+先写测试：
+
+- thinking 状态下输入 `/stop` 只取消当前 turn，不退出 chat。
+- thinking 状态下普通输入进入 steer queue。
+- thinking 状态下普通输入被接受为 steer 时，CLI 打印已收到。
+- Ctrl+C 的语义重新明确：一次取消当前 turn，空闲时退出 chat。
+
+实现：
+
+- chat model thinking 状态保留输入框。
+- turn goroutine 不再独占 command dispatch。
+- 当前 turn 的 cancel func 和 steer queue 注册到 chat session。
+
+验收：
+
+- CLI chat 能在任务运行中 stop/steer，并保持会话继续可用。
+
+## 9) 风险与处理
+
+工具不响应 ctx：
+
+- Go 代码无法强杀任意不合作的 tool goroutine。
+- 已有 shell 工具使用 `exec.CommandContext`，可以先覆盖主要长任务场景。
+- 后续对长生命周期工具逐个补 ctx 响应测试。
+
+steer 和 tool call 冲突：
+
+- MVP 不抢占已开始的 tool batch。
+- 用户要阻止工具继续执行，使用 `/stop`。
+
+历史记录丢 steer：
+
+- MVP 先把 steer 写入 active task result。
+- 后续 History Manager 可用后，再改成结构化 history item。
+
+用户其实想排新任务：
+
+- Console 运行中普通输入默认 steer。
+- 需要新任务队列时，可以后续增加显式 `/queue <task>` 或 UI 按钮。本方案先不做。
+
+## 10) 最小结论与 Checklist
+
+这三个能力应先以 runtime 控制和窄版事件为中心实现，而不是靠 prompt 约定。
+
+`/stop` 的最小正确实现是：runtime 记录 active run，slash command 或 HTTP endpoint 调用 cancel cause，active task 收尾为 `canceled`，同时输出进展摘要。
+
+steer 的最小正确实现是：runtime 把运行中输入放入 active run 的有序队列，agent loop 在安全检查点把它作为 user message 注入当前 turn，并记录 queued/applied 事件。
+
+turn event 的最小正确实现是：agent loop 发 `turn_start`、`turn_done`、`turn_canceled`，runtime/control 发 `run_stop_requested`、`run_stopped`、`steer_queued`，让 UI 和 audit 能看到状态变化。
+
+这条路径不要求先重写 history，也不要求先做完整 Codex session。它补的是当前长任务最直接的控制和观察缺口。
+
+### 10.1 代码检查后的拆解
+
+当前代码里的关键接入点：
+
+- `agent/events.go`：已有 event sink 和 tool/subtask event，适合扩展 turn/stop/steer event。
+- `agent/engine_loop.go`：run loop 已检查 ctx，工具批次后会回到下一轮 LLM 调用，适合加 steer 安全检查点。
+- `agent/types.go`：`RunOptions` 还没有 steer source。
+- `cmd/mistermorph/consolecmd/local_runtime.go`：`handleTaskJob(...)` 是 Console active run 注册、cancel cause、进展文本和收尾状态的主接入点。
+- `cmd/mistermorph/consolecmd/local_runtime_bus.go`：Console submit 现在会直接创建 task，steer 判断必须放在创建 task 前。
+- `internal/daemonruntime/server.go`：HTTP 只有 task submit/read，没有 stop control handler。
+- `internal/channelruntime/core/runner.go`：runner 只排队，不保存 active run；不要把 cancel 状态塞进 runner。
+- `internal/channelruntime/{telegram,slack,lark,line}/runtime.go`：每个 channel 都有自己的 worker runCtx 和 command 分支，需要分别接入 `/stop` 和 steer。
+- `cmd/mistermorph/chatcmd/bubble.go`：thinking 状态下当前忽略普通输入，CLI steer 需要改 TUI 输入行为。
+- `cmd/mistermorph/chatcmd/repl.go`：当前 turn 的 cancel func 和 steer queue 需要由 chat session 持有。
+
+### 10.2 实施 Checklist
+
+Phase 1：最小 turn event schema
+
+- [x] 先补 `agent` 测试：正常 final 发 `turn_start`、`turn_done`。
+- [x] 先补 `agent` 测试：ctx 取消发 `turn_start`、`turn_canceled`。
+- [ ] 先补 Console event sink 测试：未知新 event 不影响现有 tool/subtask preview。
+- [x] 在 `agent/events.go` 增加 `turn_start`、`turn_done`、`turn_canceled`、`run_stop_requested`、`run_stopped`、`steer_queued`、`steer_applied`。
+- [x] 按需给 `agent.Event` 增加 `ConversationKey`、`TopicID`、`Reason` 字段。
+- [x] 在 `agent/engine_loop.go` 的 run 开始、正常结束、取消结束发 turn event。
+- [x] 取消结束事件使用 detached delivery context，避免 sink 因 run ctx 已取消而丢事件。
+- [ ] 调整 Console activity/preview 处理，让新 event 能进 audit/stream，但不要求完整 UI 改版。
+- [x] 跑 `go test ./agent ./cmd/mistermorph/consolecmd`。
+
+Phase 2：共用 `RunControl` 和 `SteerQueue`
+
+- [x] 先补 `internal/runtimecontrol` 测试：`Start`/`Finish` 注册和清理 active run。
+- [x] 先补测试：`Stop` 调用 cancel cause，重复 stop 幂等。
+- [x] 先补测试：`Steer` 按顺序进入队列并按顺序 drain。
+- [ ] 先补测试：`Steer` 有队列上限。
+- [ ] 先补测试：`Steer` 按 message id 去重。
+- [x] 实现 `internal/runtimecontrol`，包含 active run registry、进展文本回调、stop result、steer queue。
+- [x] 实现 `RunControl.StartLease(...)`，收拢 worker 的 cancel-cause ctx、timeout ctx、steer queue、active run 清理。
+- [x] 定义 `ErrStoppedByUser`，并提供 stop/steer 的短反馈文案常量或 helper。
+- [x] 跑 `go test ./internal/runtimecontrol`。
+
+Phase 3：Console Local `/stop`
+
+- [x] 先补 Console 测试：`/stop` 不创建普通 queued task。
+- [x] 先补 Console 测试：active run 被 `/stop` 后最终状态为 `canceled`，错误原因为 `stopped by user`。
+- [x] 先补 daemonruntime 路由测试：`POST /tasks/{id}/stop`、`POST /topics/{topic_id}/stop` 调用 stop handler。
+- [x] 在 `consoleLocalRuntime` 持有 `RunControl`。
+- [x] 在 `handleTaskJob(...)` 使用 `context.WithCancelCause`，注册 active run，defer finish。
+- [x] 用 `latestPlan`、`latestActivity` 组装停止进展文本。
+- [x] 在 `/stop` command 中调用 `RunControl.Stop(...)`。
+- [x] 在 HTTP stop handler 中调用 `RunControl.Stop(...)` / `RunControl.StopTask(...)`。
+- [x] `/stop` 返回 synthetic done task，输出停止请求和进展摘要。
+- [x] active task 收尾时按 cancel cause 写 `canceled`，并发 `run_stopped`。
+- [x] 跑 `go test ./cmd/mistermorph/consolecmd ./internal/daemonruntime`。
+
+Phase 4：agent steer source
+
+- [ ] 先补 `agent` 测试：工具批次结束后 drain steer，下一轮 LLM 请求包含 steer message。
+- [x] 先补 `agent` 测试：max steps 后、`forceConclusion` 前 drain steer。
+- [x] 先补 `agent` 测试：模型返回 final 但有 pending steer 时，不结束 run，继续下一轮。
+- [x] 先补 `agent` 测试：steer 注入时发 `steer_applied`。
+- [x] 在 `agent/types.go` 增加窄版 `SteerSource` 和 `RunOptions.SteerSource`。
+- [x] 在 `engineLoopState` 保存 steer source。
+- [x] 在每次 LLM 调用前 drain steer，追加 runtime steer user message。
+- [x] 在 final 返回前再检查一次 steer；有 steer 时追加 assistant 文本和 steer message 后继续。
+- [x] 确保不在 tool call 半途插入 steer，不破坏 tool call/output 配对。
+- [x] 跑 `go test ./agent`。
+
+Phase 5：Console steer
+
+- [x] 先补 Console 测试：同 topic active run 存在时，普通 submit 被接受为 steer，不创建新 queued task。
+- [ ] 先补 Console 测试：submit response 带 `accepted_as=steer`、`target_task_id`、`steer_id`、反馈文本。
+- [ ] 先补 Console 测试：active task result 记录 `steer_events`。
+- [ ] 扩展 `daemonruntime.SubmitTaskResponse` 兼容字段。
+- [x] 在 Console submit 创建 task 前查询 active run；命中则调用 `RunControl.Steer(...)`。
+- [x] 立即向用户返回“已收到”反馈，并发 `steer_queued`。
+- [x] 将 `SteerSource` 通过 `taskruntime.RunRequest` 传到 `agent.RunOptions`。
+- [ ] 在 Console task result 中保存 queued/applied steer events。
+- [x] 跑 `go test ./cmd/mistermorph/consolecmd ./internal/channelruntime/taskruntime ./internal/daemonruntime`。
+
+Phase 6：Channel runtimes 和 managed runtime
+
+- [ ] 先补 Telegram 测试：同 chat active run 时 `/stop` 停止当前 run。
+- [ ] 先补 Slack/Lark/LINE command 测试：`/stop` 被识别并返回一致反馈。
+- [ ] 先补 channel 测试：运行中普通 inbound message 被接受为 steer，并回复已收到。
+- [ ] 先补 channel 测试：群聊未显式触发的消息不 stop、不 steer。
+- [x] 先补 Slack 测试：active run control key 使用 thread scope，避免同频道不同 thread 互相 stop/steer。
+- [x] 给 channel runtime dependencies 或 run options 接入 `RunControl`。
+- [x] 在各 channel worker runCtx 创建处通过 `RunLease` 注册 active run，收尾时 finish。
+- [x] 在各 channel command 分支加入 `/stop`。
+- [x] 在 enqueue 前判断 active run；命中则写 steer queue，不创建新 task。
+- [x] managed runtime 复用 channel runtime 的同一 `RunControl` 语义，不单独定义一套行为。
+- [x] 跑 `go test ./internal/channelruntime/telegram ./internal/channelruntime/slack ./internal/channelruntime/lark ./internal/channelruntime/line ./cmd/mistermorph/consolecmd`。
+
+Phase 7：CLI chat
+
+- [x] 先补 bubble 测试：thinking 状态可以输入并提交文本。
+- [ ] 先补 REPL 测试：thinking 状态 `/stop` 取消当前 turn，不退出 chat。
+- [ ] 先补 REPL 测试：thinking 状态普通输入进入 steer queue，并打印已收到。
+- [x] 修改 `chatModel.Update(...)`，thinking 状态保留输入框，Ctrl+C 只请求取消当前 turn。
+- [x] 在 `runREPL(...)` 中保存当前 turn cancel func 和 steer queue。
+- [x] CLI `/stop` 使用同一 stop reason，取消后保留 history 和 session。
+- [x] 将 CLI steer source 传给 `agent.RunOptions`。
+- [x] 跑 `go test ./cmd/mistermorph/chatcmd`。
+
+Phase 8：全量验证
+
+- [x] 跑 `go test ./...`。
+- [ ] 手动验证 Console：长 shell 任务运行中输入 `/stop`，原 task 变 `canceled`。
+- [ ] 手动验证 Console：长任务运行中输入普通文本，收到 steer 反馈，下一轮 LLM 看到 steer。
+- [ ] 手动验证 CLI chat：运行中 `/stop` 取消 turn，chat 继续可用。
+- [ ] 手动验证至少一个 managed runtime：原聊天软件里 `/stop` 能停止 child runtime 的当前 run。

--- a/docs/feat/feat_20260603_runtime_stop_and_steer.md
+++ b/docs/feat/feat_20260603_runtime_stop_and_steer.md
@@ -121,8 +121,8 @@ type StopResult struct {
 
 - 只停止同一 runtime、同一 conversation/topic/thread 的当前 active run。
 - 不停止其他 conversation，也不做跨 runtime 的全局停止。
-- 没有 active run 时，返回“当前没有正在运行的任务”。
-- 已经在停止中的 run，重复 `/stop` 返回当前停止进展。
+- 没有 active run 时，返回 `🤔`。
+- 已经在停止中的 run，重复 `/stop` 返回 `👌`。
 
 各 runtime 的入口不同，但语义相同：
 
@@ -171,8 +171,8 @@ Console 已经在 `handleTaskJob(...)` 里维护 `latestPlan` 和 `latestActivit
 
 反馈文本建议：
 
-- 没有 active run：`当前没有正在运行的任务。`
-- 找到 active run 并请求停止：`已停止当前任务。`
+- 没有 active run：`🤔`
+- 找到 active run 并请求停止：`👌`
 
 ### 4.5 窄版 turn event
 
@@ -225,8 +225,8 @@ type Event struct {
 
 1. 解析 topic id，得到 `conversationKey`。
 2. 调用 `RunControl.Stop("console", conversationKey, "/stop")`。
-3. 如果没有 active run，返回一个 synthetic done task，输出“当前没有正在运行的任务。”
-4. 如果有 active run，立即返回一个 synthetic done task，输出 `已停止当前任务。`。
+3. 如果没有 active run，返回一个 synthetic done task，输出 `🤔`。
+4. 如果有 active run，立即返回一个 synthetic done task，输出 `👌`。
 5. 被停止的 active task 自己在 `handleTaskJob(...)` 收尾时写成 `canceled`。
 6. stream hub 发布 active task 的 `canceled` 状态，让 UI 能更新原任务。
 
@@ -250,7 +250,7 @@ type Event struct {
   "task_id": "console_...",
   "topic_id": "topic_...",
   "progress": "计划 1/3，当前步骤 run tests，工具调用 2",
-  "message": "已停止当前任务。"
+  "message": "👌"
 }
 ```
 

--- a/docs/feat/feat_20260603_runtime_stop_and_steer.md
+++ b/docs/feat/feat_20260603_runtime_stop_and_steer.md
@@ -299,15 +299,15 @@ approval pending 也是当前任务的一种暂停状态。最小处理：
 
 - 如果同一 conversation 没有 active run：按现有逻辑创建新 task。
 - 如果有 active run，且输入不是 runtime command：作为 steer 输入进入 active run。
-- 被接受为 steer 时，runtime 必须立刻给用户一条短反馈，说明输入已收到并会加入当前任务。
+- 被接受为 steer 时，runtime 必须立刻给用户短反馈；当前反馈为 `👌`。
 - 如果输入是 `/stop`：走停止流程。
 - 其他 slash command 保持现有 command 语义，不注入 agent turn。
 
 推荐反馈文本：
 
-- Console：`已收到，已加入当前运行中的任务。`
-- Channel runtime：`已收到，会在当前任务的下一步处理。`
-- CLI chat：`已收到，会加入当前 turn。`
+- Console：`👌`
+- Channel runtime：`👌`
+- CLI chat：`👌`
 
 Console `POST /tasks` 可以在 response 上增加兼容字段：
 
@@ -485,7 +485,7 @@ Console UI 至少需要显示四类状态：
 
 - 同 topic 有 active run 时，普通 `POST /tasks` 被接受为 steer，不创建新 queued task。
 - response 带 `accepted_as=steer`、`target_task_id`、`steer_id`。
-- response 或 synthetic reply 包含已收到 steer 的短反馈。
+- response 或 synthetic reply 包含 `👌` steer 反馈。
 - active task 的 result 记录 `steer_events`。
 - 下一次 LLM 请求可以看到 steer。
 - 收到运行中输入时发 `steer_queued`。
@@ -501,7 +501,7 @@ Console UI 至少需要显示四类状态：
 
 - 用户在 Console 中连续输入时，第二条输入进入第一条任务的 turn。
 - UI 能显示输入已加入当前任务。
-- 用户能立刻看到 steer 已收到的反馈。
+- 用户能立刻看到 `👌` steer 反馈。
 
 ### Phase 5：Channel runtimes 和 managed runtime
 
@@ -509,7 +509,7 @@ Console UI 至少需要显示四类状态：
 
 - Telegram/Slack/Lark/LINE 的 command registry 或现有 command 分支识别 `/stop`。
 - 同 conversation 有 active run 时，新 inbound message 进入 steer。
-- 新 inbound message 作为 steer 被接受时，channel 回复已收到。
+- 新 inbound message 作为 steer 被接受时，channel 回复 `👌`。
 - 群聊未显式触发的消息不 steer。
 - 重复 message id 不重复注入。
 
@@ -533,7 +533,7 @@ CLI chat 当前 thinking 时禁用输入。它要支持 steer，需要让 TUI �
 
 - thinking 状态下输入 `/stop` 只取消当前 turn，不退出 chat。
 - thinking 状态下普通输入进入 steer queue。
-- thinking 状态下普通输入被接受为 steer 时，CLI 打印已收到。
+- thinking 状态下普通输入被接受为 steer 时，CLI 打印 `👌`。
 - Ctrl+C 的语义重新明确：一次取消当前 turn，空闲时退出 chat。
 
 实现：
@@ -656,7 +656,7 @@ Phase 5：Console steer
 - [ ] 先补 Console 测试：active task result 记录 `steer_events`。
 - [ ] 扩展 `daemonruntime.SubmitTaskResponse` 兼容字段。
 - [x] 在 Console submit 创建 task 前查询 active run；命中则调用 `RunControl.Steer(...)`。
-- [x] 立即向用户返回“已收到”反馈，并发 `steer_queued`。
+- [x] 立即向用户返回 `👌` 反馈，并发 `steer_queued`。
 - [x] 将 `SteerSource` 通过 `taskruntime.RunRequest` 传到 `agent.RunOptions`。
 - [ ] 在 Console task result 中保存 queued/applied steer events。
 - [x] 跑 `go test ./cmd/mistermorph/consolecmd ./internal/channelruntime/taskruntime ./internal/daemonruntime`。
@@ -665,7 +665,7 @@ Phase 6：Channel runtimes 和 managed runtime
 
 - [ ] 先补 Telegram 测试：同 chat active run 时 `/stop` 停止当前 run。
 - [ ] 先补 Slack/Lark/LINE command 测试：`/stop` 被识别并返回一致反馈。
-- [ ] 先补 channel 测试：运行中普通 inbound message 被接受为 steer，并回复已收到。
+- [ ] 先补 channel 测试：运行中普通 inbound message 被接受为 steer，并回复 `👌`。
 - [ ] 先补 channel 测试：群聊未显式触发的消息不 stop、不 steer。
 - [x] 先补 Slack 测试：active run control key 使用 thread scope，避免同频道不同 thread 互相 stop/steer。
 - [x] 给 channel runtime dependencies 或 run options 接入 `RunControl`。
@@ -679,7 +679,7 @@ Phase 7：CLI chat
 
 - [x] 先补 bubble 测试：thinking 状态可以输入并提交文本。
 - [ ] 先补 REPL 测试：thinking 状态 `/stop` 取消当前 turn，不退出 chat。
-- [ ] 先补 REPL 测试：thinking 状态普通输入进入 steer queue，并打印已收到。
+- [ ] 先补 REPL 测试：thinking 状态普通输入进入 steer queue，并打印 `👌`。
 - [x] 修改 `chatModel.Update(...)`，thinking 状态保留输入框，Ctrl+C 只请求取消当前 turn。
 - [x] 在 `runREPL(...)` 中保存当前 turn cancel func 和 steer queue。
 - [x] CLI `/stop` 使用同一 stop reason，取消后保留 history 和 session。

--- a/docs/feat/feat_20260603_runtime_stop_and_steer.md
+++ b/docs/feat/feat_20260603_runtime_stop_and_steer.md
@@ -57,7 +57,7 @@ status: draft
 - 不再调用下一轮 LLM。
 - 尽力终止正在运行的工具。
 - 把任务状态标为 `canceled`，原因是用户停止，不是超时。
-- 返回当前进展和“已停止”或“正在停止”的明确反馈。
+- 返回统一的停止反馈。
 
 steer 的本质是用户在当前任务仍在执行时修改约束或补充信息。正确行为是：
 
@@ -78,11 +78,11 @@ steer 的本质是用户在当前任务仍在执行时修改约束或补充信�
 
 ### 4.1 RunControl
 
-新增一个 runtime 控制组件，例如 `internal/runtimecontrol`。它不是已有函数的薄封装，它真正拥有两类状态，并提供一个可选的进展文本回调：
+新增一个 runtime 控制组件，例如 `internal/runtimecontrol`。它不是已有函数的薄封装，它真正拥有两类状态，并支持一个可选的进展文本回调：
 
 - 当前 active run：runtime、conversation key、task id、run id、cancel func。
 - 当前 steer queue：运行中用户输入，按收到顺序保存。
-- 当前进展文本：由具体 runtime 本地生成，`RunControl` 不理解 plan、metrics、stream activity 的结构。
+- 可选 snapshot：由具体 runtime 本地生成，`RunControl` 不理解 plan、metrics、stream activity 的结构；stop 反馈不拼接它。
 
 当前实现采用窄结构：
 
@@ -172,8 +172,7 @@ Console 已经在 `handleTaskJob(...)` 里维护 `latestPlan` 和 `latestActivit
 反馈文本建议：
 
 - 没有 active run：`当前没有正在运行的任务。`
-- 收到停止请求但 run 还没退出：`已请求停止当前任务。当前进展：...`
-- run 已退出：`已停止当前任务。当前进展：...`
+- 找到 active run 并请求停止：`已停止当前任务。`
 
 ### 4.5 窄版 turn event
 
@@ -227,7 +226,7 @@ type Event struct {
 1. 解析 topic id，得到 `conversationKey`。
 2. 调用 `RunControl.Stop("console", conversationKey, "/stop")`。
 3. 如果没有 active run，返回一个 synthetic done task，输出“当前没有正在运行的任务。”
-4. 如果有 active run，立即返回一个 synthetic done task，输出“已请求停止...”和当前进展。
+4. 如果有 active run，立即返回一个 synthetic done task，输出 `已停止当前任务。`。
 5. 被停止的 active task 自己在 `handleTaskJob(...)` 收尾时写成 `canceled`。
 6. stream hub 发布 active task 的 `canceled` 状态，让 UI 能更新原任务。
 
@@ -251,7 +250,7 @@ type Event struct {
   "task_id": "console_...",
   "topic_id": "topic_...",
   "progress": "计划 1/3，当前步骤 run tests，工具调用 2",
-  "message": "已请求停止当前任务。\n当前进展：计划 1/3，当前步骤 run tests，工具调用 2"
+  "message": "已停止当前任务。"
 }
 ```
 

--- a/docs/feat/feat_20260603_runtime_stop_and_steer.md
+++ b/docs/feat/feat_20260603_runtime_stop_and_steer.md
@@ -334,6 +334,8 @@ steer queue 的第一阶段只保证顺序和有界。去重依赖 channel messa
 ```go
 type SteerSource interface {
     Drain() []string
+    DrainAndClose() []string
+    Close()
 }
 ```
 
@@ -350,6 +352,8 @@ type SteerSource interface {
 ```go
 type SteerSource interface {
     Drain() []string
+    DrainAndClose() []string
+    Close()
 }
 ```
 
@@ -465,7 +469,7 @@ Console UI 至少需要显示四类状态：
 
 实现：
 
-- 增加窄版 `agent.SteerSource`，接口为 `Drain() []string`。
+- 增加 `agent.SteerSource`，接口为 `Drain()`、`DrainAndClose()`、`Close()`。
 - `RunOptions` 增加 `SteerSource`。
 - `engine_loop.go` 在安全检查点注入 steer。
 - 发出 `steer_applied` event。

--- a/internal/channelruntime/lark/model_command.go
+++ b/internal/channelruntime/lark/model_command.go
@@ -41,6 +41,11 @@ func maybeHandleLarkCommand(ctx context.Context, d Dependencies, inprocBus *busr
 	return true, publishErr
 }
 
+func isLarkStopCommand(text string) bool {
+	cmdWord, _ := chatcommands.ParseCommand(text)
+	return chatcommands.NormalizeCommand(cmdWord) == "/stop"
+}
+
 func skillCommandForRuntime(fn HandleSkillCommandFunc, currentSkills []string) chatcommands.SkillCommandFunc {
 	if fn == nil {
 		return nil

--- a/internal/channelruntime/lark/runtime.go
+++ b/internal/channelruntime/lark/runtime.go
@@ -199,9 +199,6 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				TopicID:         job.ChatID,
 				TaskID:          job.TaskID,
 				RunID:           job.TaskID,
-				Snapshot: func() string {
-					return "任务正在运行中，等待当前模型或工具调用返回。"
-				},
 			})
 			if err != nil {
 				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, strings.TrimSpace(err.Error()), false)
@@ -234,7 +231,7 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				)
 				errorText := "error: " + displayErr
 				if userStopped {
-					errorText = "已停止当前任务。"
+					errorText = runtimecontrol.StopFeedback(true)
 				}
 				errorCorrelationID := fmt.Sprintf("lark:error:%s:%s", job.ChatID, job.MessageID)
 				_, err := publishLarkBusOutbound(workerCtx, inprocBus, job.ChatID, errorText, job.MessageID, errorCorrelationID)
@@ -309,7 +306,7 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		if isLarkStopCommand(inbound.Text) {
 			result := runControl.Stop("lark", msg.ConversationKey, "/stop")
 			correlationID := fmt.Sprintf("lark:stop:%s:%s", inbound.ChatID, inbound.MessageID)
-			_, publishErr := publishLarkBusOutbound(ctx, inprocBus, inbound.ChatID, runtimecontrol.StopFeedback(result.Found, result.Progress), inbound.MessageID, correlationID)
+			_, publishErr := publishLarkBusOutbound(ctx, inprocBus, inbound.ChatID, runtimecontrol.StopFeedback(result.Found), inbound.MessageID, correlationID)
 			return publishErr
 		}
 		if handledCommand, cmdErr := maybeHandleLarkCommand(ctx, d, inprocBus, workspaceStore, msg.ConversationKey, inbound, currentSkills); handledCommand {

--- a/internal/channelruntime/lark/runtime.go
+++ b/internal/channelruntime/lark/runtime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/llmstats"
 	"github.com/quailyquaily/mistermorph/internal/pathroots"
 	"github.com/quailyquaily/mistermorph/internal/personautil"
+	"github.com/quailyquaily/mistermorph/internal/runtimecontrol"
 	"github.com/quailyquaily/mistermorph/internal/statepaths"
 	"github.com/quailyquaily/mistermorph/internal/workspace"
 )
@@ -119,6 +120,7 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		MemoryOrchestrator:      memRuntime.Orchestrator,
 		MemoryProjectionWorker:  memRuntime.ProjectionWorker,
 	}
+	runControl := runtimecontrol.New()
 	addressingLLMTimeout := addressingRoute.ClientConfig.RequestTimeout
 	if addressingLLMTimeout <= 0 {
 		addressingLLMTimeout = requestTimeout
@@ -191,28 +193,49 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				h = nil
 			}
 			runtimecore.MarkTaskRunning(daemonStore, job.TaskID)
-			runCtx, cancel := context.WithTimeout(workerCtx, taskTimeout)
+			lease, err := runControl.StartLease(workerCtx, taskTimeout, runtimecontrol.ActiveRun{
+				Runtime:         "lark",
+				ConversationKey: conversationKey,
+				TopicID:         job.ChatID,
+				TaskID:          job.TaskID,
+				RunID:           job.TaskID,
+				Snapshot: func() string {
+					return "任务正在运行中，等待当前模型或工具调用返回。"
+				},
+			})
+			if err != nil {
+				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, strings.TrimSpace(err.Error()), false)
+				return
+			}
 			final, _, loadedSkills, runErr := runLarkTask(
-				runCtx,
+				lease.Context,
 				execRuntime,
 				job,
 				h,
 				sticky,
 				taskRuntimeOpts,
+				lease.SteerQueue,
 			)
-			cancel()
+			userStopped := lease.UserStopped()
+			lease.Finish()
 			if runErr != nil {
 				if workerCtx.Err() != nil {
 					return
 				}
 				displayErr := depsutil.FormatRuntimeError(runErr)
-				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, displayErr, false)
+				if userStopped {
+					displayErr = "stopped by user"
+				}
+				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, displayErr, userStopped)
 				logger.Warn("lark_task_error",
 					"chat_id", job.ChatID,
 					"message_id", job.MessageID,
 					"error", displayErr,
 				)
 				errorText := "error: " + displayErr
+				if userStopped {
+					errorText = "已停止当前任务。"
+				}
 				errorCorrelationID := fmt.Sprintf("lark:error:%s:%s", job.ChatID, job.MessageID)
 				_, err := publishLarkBusOutbound(workerCtx, inprocBus, job.ChatID, errorText, job.MessageID, errorCorrelationID)
 				if err != nil {
@@ -283,6 +306,12 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		mu.Lock()
 		currentSkills := append([]string(nil), stickySkillsByConv[msg.ConversationKey]...)
 		mu.Unlock()
+		if isLarkStopCommand(inbound.Text) {
+			result := runControl.Stop("lark", msg.ConversationKey, "/stop")
+			correlationID := fmt.Sprintf("lark:stop:%s:%s", inbound.ChatID, inbound.MessageID)
+			_, publishErr := publishLarkBusOutbound(ctx, inprocBus, inbound.ChatID, runtimecontrol.StopFeedback(result.Found, result.Progress), inbound.MessageID, correlationID)
+			return publishErr
+		}
 		if handledCommand, cmdErr := maybeHandleLarkCommand(ctx, d, inprocBus, workspaceStore, msg.ConversationKey, inbound, currentSkills); handledCommand {
 			return cmdErr
 		}
@@ -339,6 +368,13 @@ func runLarkLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				"impulse", dec.Addressing.Impulse,
 				"is_lightweight", dec.Addressing.IsLightweight,
 			)
+		}
+		if len(inbound.ImageKeys) == 0 && len(inbound.ImageAttachments) == 0 {
+			if result := runControl.Steer("lark", msg.ConversationKey, text); result.Found {
+				correlationID := fmt.Sprintf("lark:steer:%s:%s", inbound.ChatID, inbound.MessageID)
+				_, publishErr := publishLarkBusOutbound(ctx, inprocBus, inbound.ChatID, runtimecontrol.SteerFeedback(result.Found, result.Queued), inbound.MessageID, correlationID)
+				return publishErr
+			}
 		}
 		workspaceDir, err := workspace.LookupWorkspaceDir(workspaceStore, msg.ConversationKey)
 		if err != nil {

--- a/internal/channelruntime/lark/runtime_task.go
+++ b/internal/channelruntime/lark/runtime_task.go
@@ -71,6 +71,7 @@ func runLarkTask(
 	history []chathistory.ChatHistoryItem,
 	stickySkills []string,
 	runtimeOpts runtimeTaskOptions,
+	steerSource agent.SteerSource,
 ) (*agent.Final, *agent.Context, []string, error) {
 	if rt == nil {
 		return nil, nil, nil, fmt.Errorf("lark task runtime is nil")
@@ -180,6 +181,7 @@ func runLarkTask(
 			toolsutil.SetTodoUpdateToolAddContext(reg, todoResolveContextForLark(job))
 			promptprofile.AppendLarkRuntimeBlocks(spec, isLarkGroupChat(job.ChatType), strings.Join(larktools.StandardReactionEmojiTypes(), ","))
 		},
+		SteerSource:        steerSource,
 		Memory:             memoryHooks,
 		ImageToolScope:     strings.TrimSpace(job.ConversationKey),
 		ImageToolRetention: toolsutil.ImageToolRetentionCountdown,

--- a/internal/channelruntime/line/model_command.go
+++ b/internal/channelruntime/line/model_command.go
@@ -41,6 +41,11 @@ func maybeHandleLineCommand(ctx context.Context, d Dependencies, inprocBus *busr
 	return true, publishErr
 }
 
+func isLineStopCommand(text string) bool {
+	cmdWord, _ := chatcommands.ParseCommand(text)
+	return chatcommands.NormalizeCommand(cmdWord) == "/stop"
+}
+
 func skillCommandForRuntime(fn HandleSkillCommandFunc, currentSkills []string) chatcommands.SkillCommandFunc {
 	if fn == nil {
 		return nil

--- a/internal/channelruntime/line/runtime.go
+++ b/internal/channelruntime/line/runtime.go
@@ -238,9 +238,6 @@ func runLineLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				TopicID:         job.ChatID,
 				TaskID:          job.TaskID,
 				RunID:           job.TaskID,
-				Snapshot: func() string {
-					return "任务正在运行中，等待当前模型或工具调用返回。"
-				},
 			})
 			if err != nil {
 				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, strings.TrimSpace(err.Error()), false)
@@ -273,7 +270,7 @@ func runLineLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				)
 				errorText := "error: " + displayErr
 				if userStopped {
-					errorText = "已停止当前任务。"
+					errorText = runtimecontrol.StopFeedback(true)
 				}
 				errorCorrelationID := fmt.Sprintf("line:error:%s:%s", job.ChatID, job.MessageID)
 				_, err := publishLineBusOutbound(workerCtx, inprocBus, job.ChatID, errorText, job.ReplyToken, errorCorrelationID)
@@ -347,7 +344,7 @@ func runLineLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		if isLineStopCommand(inbound.Text) {
 			result := runControl.Stop("line", msg.ConversationKey, "/stop")
 			correlationID := fmt.Sprintf("line:stop:%s:%s", inbound.ChatID, inbound.MessageID)
-			_, publishErr := publishLineBusOutbound(ctx, inprocBus, inbound.ChatID, runtimecontrol.StopFeedback(result.Found, result.Progress), inbound.ReplyToken, correlationID)
+			_, publishErr := publishLineBusOutbound(ctx, inprocBus, inbound.ChatID, runtimecontrol.StopFeedback(result.Found), inbound.ReplyToken, correlationID)
 			return publishErr
 		}
 		if handledCommand, cmdErr := maybeHandleLineCommand(ctx, d, inprocBus, workspaceStore, msg.ConversationKey, inbound, currentSkills); handledCommand {

--- a/internal/channelruntime/line/runtime.go
+++ b/internal/channelruntime/line/runtime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/pathroots"
 	"github.com/quailyquaily/mistermorph/internal/pathutil"
 	"github.com/quailyquaily/mistermorph/internal/personautil"
+	"github.com/quailyquaily/mistermorph/internal/runtimecontrol"
 	"github.com/quailyquaily/mistermorph/internal/statepaths"
 	"github.com/quailyquaily/mistermorph/internal/telegramutil"
 	"github.com/quailyquaily/mistermorph/internal/workspace"
@@ -140,6 +141,7 @@ func runLineLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		MemoryOrchestrator:      memRuntime.Orchestrator,
 		MemoryProjectionWorker:  memRuntime.ProjectionWorker,
 	}
+	runControl := runtimecontrol.New()
 	fileCacheDir := pathutil.ExpandHomePath(strings.TrimSpace(opts.FileCacheDir))
 	if fileCacheDir == "" {
 		return fmt.Errorf("line file cache dir is required for image recognition")
@@ -230,28 +232,49 @@ func runLineLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				h = nil
 			}
 			runtimecore.MarkTaskRunning(daemonStore, job.TaskID)
-			runCtx, cancel := context.WithTimeout(workerCtx, taskTimeout)
+			lease, err := runControl.StartLease(workerCtx, taskTimeout, runtimecontrol.ActiveRun{
+				Runtime:         "line",
+				ConversationKey: conversationKey,
+				TopicID:         job.ChatID,
+				TaskID:          job.TaskID,
+				RunID:           job.TaskID,
+				Snapshot: func() string {
+					return "任务正在运行中，等待当前模型或工具调用返回。"
+				},
+			})
+			if err != nil {
+				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, strings.TrimSpace(err.Error()), false)
+				return
+			}
 			final, _, loadedSkills, runErr := runLineTask(
-				runCtx,
+				lease.Context,
 				execRuntime,
 				job,
 				h,
 				sticky,
 				taskRuntimeOpts,
+				lease.SteerQueue,
 			)
-			cancel()
+			userStopped := lease.UserStopped()
+			lease.Finish()
 			if runErr != nil {
 				if workerCtx.Err() != nil {
 					return
 				}
 				displayErr := depsutil.FormatRuntimeError(runErr)
-				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, displayErr, false)
+				if userStopped {
+					displayErr = "stopped by user"
+				}
+				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, displayErr, userStopped)
 				logger.Warn("line_task_error",
 					"chat_id", job.ChatID,
 					"message_id", job.MessageID,
 					"error", displayErr,
 				)
 				errorText := "error: " + displayErr
+				if userStopped {
+					errorText = "已停止当前任务。"
+				}
 				errorCorrelationID := fmt.Sprintf("line:error:%s:%s", job.ChatID, job.MessageID)
 				_, err := publishLineBusOutbound(workerCtx, inprocBus, job.ChatID, errorText, job.ReplyToken, errorCorrelationID)
 				if err != nil {
@@ -321,6 +344,12 @@ func runLineLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 		mu.Lock()
 		currentSkills := append([]string(nil), stickySkillsByConv[msg.ConversationKey]...)
 		mu.Unlock()
+		if isLineStopCommand(inbound.Text) {
+			result := runControl.Stop("line", msg.ConversationKey, "/stop")
+			correlationID := fmt.Sprintf("line:stop:%s:%s", inbound.ChatID, inbound.MessageID)
+			_, publishErr := publishLineBusOutbound(ctx, inprocBus, inbound.ChatID, runtimecontrol.StopFeedback(result.Found, result.Progress), inbound.ReplyToken, correlationID)
+			return publishErr
+		}
 		if handledCommand, cmdErr := maybeHandleLineCommand(ctx, d, inprocBus, workspaceStore, msg.ConversationKey, inbound, currentSkills); handledCommand {
 			return cmdErr
 		}
@@ -381,6 +410,13 @@ func runLineLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) e
 				"impulse", dec.Addressing.Impulse,
 				"is_lightweight", dec.Addressing.IsLightweight,
 			)
+		}
+		if !inbound.ImagePending && len(inbound.ImageAttachments) == 0 {
+			if result := runControl.Steer("line", msg.ConversationKey, text); result.Found {
+				correlationID := fmt.Sprintf("line:steer:%s:%s", inbound.ChatID, inbound.MessageID)
+				_, publishErr := publishLineBusOutbound(ctx, inprocBus, inbound.ChatID, runtimecontrol.SteerFeedback(result.Found, result.Queued), inbound.ReplyToken, correlationID)
+				return publishErr
+			}
 		}
 		workspaceDir, err := workspace.LookupWorkspaceDir(workspaceStore, msg.ConversationKey)
 		if err != nil {

--- a/internal/channelruntime/line/runtime_task.go
+++ b/internal/channelruntime/line/runtime_task.go
@@ -48,6 +48,7 @@ func runLineTask(
 	history []chathistory.ChatHistoryItem,
 	stickySkills []string,
 	runtimeOpts runtimeTaskOptions,
+	steerSource agent.SteerSource,
 ) (*agent.Final, *agent.Context, []string, error) {
 	if rt == nil {
 		return nil, nil, nil, fmt.Errorf("line task runtime is nil")
@@ -153,6 +154,7 @@ func runLineTask(
 			toolsutil.SetTodoUpdateToolAddContext(reg, todoResolveContextForLine(job))
 			promptprofile.AppendLineRuntimeBlocks(spec, isLineGroupChat(job.ChatType))
 		},
+		SteerSource:        steerSource,
 		Memory:             memoryHooks,
 		ImageToolScope:     strings.TrimSpace(job.ConversationKey),
 		ImageToolRetention: toolsutil.ImageToolRetentionCountdown,

--- a/internal/channelruntime/slack/model_command.go
+++ b/internal/channelruntime/slack/model_command.go
@@ -52,6 +52,15 @@ func maybeHandleSlackCommand(ctx context.Context, d Dependencies, inprocBus *bus
 	return true, publishErr
 }
 
+func isSlackStopCommand(event slackInboundEvent, botUserID string) bool {
+	if isSlackGroupChat(event.ChatType) && !slackCommandExplicitlyAddressed(event.Text, botUserID) {
+		return false
+	}
+	text := normalizeSlackCommandText(event.Text, botUserID)
+	cmdWord, _ := chatcommands.ParseCommand(text)
+	return chatcommands.NormalizeCommand(cmdWord) == "/stop"
+}
+
 func skillCommandForRuntime(fn HandleSkillCommandFunc, currentSkills []string) chatcommands.SkillCommandFunc {
 	if fn == nil {
 		return nil

--- a/internal/channelruntime/slack/runtime.go
+++ b/internal/channelruntime/slack/runtime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/llmstats"
 	"github.com/quailyquaily/mistermorph/internal/pathroots"
 	"github.com/quailyquaily/mistermorph/internal/personautil"
+	"github.com/quailyquaily/mistermorph/internal/runtimecontrol"
 	"github.com/quailyquaily/mistermorph/internal/statepaths"
 	"github.com/quailyquaily/mistermorph/internal/workspace"
 	slacktools "github.com/quailyquaily/mistermorph/tools/slack"
@@ -86,6 +87,32 @@ const slackUserIdentityCacheTTL = 6 * time.Hour
 const slackCommonReactionEmojiNamesCSV = "+1,-1,ok_hand,clap,pray,tada,muscle,handshake,white_check_mark,heavy_check_mark,x,100,eyes,warning,rotating_light,bangbang,exclamation,question,grey_question,grey_exclamation,triangular_flag_on_post,fire,hourglass_flowing_sand,hourglass,repeat,rewind,fast_forward,construction,hammer_and_wrench,wrench,gear,rocket,bug,mag,mag_right,memo,bookmark_tabs,link,paperclip,pushpin,bell,loudspeaker,computer,file_folder,wave,thinking_face,face_with_monocle,neutral_face,slightly_smiling_face,slightly_frowning_face,joy,sob,sweat_smile,grimacing,calendar,clock1,clock3,clock6,clock9,stopwatch,bar_chart,chart_with_upwards_trend,chart_with_downwards_trend,clipboard"
 
 var slackCommonReactionEmojiNameSet = buildSlackCommonReactionEmojiNameSet()
+
+func slackRunControlConversationKeyForJob(job slackJob) string {
+	return slackRunControlConversationKey(job.ConversationKey, job.TeamID, job.ChannelID, job.MessageTS, job.ThreadTS)
+}
+
+func slackRunControlConversationKeyForInbound(inbound slackbus.InboundMessage) string {
+	fallback, _ := buildSlackConversationKey(inbound.TeamID, inbound.ChannelID)
+	return slackRunControlConversationKey(fallback, inbound.TeamID, inbound.ChannelID, inbound.MessageTS, inbound.ThreadTS)
+}
+
+func slackRunControlConversationKeyForEvent(event slackInboundEvent) string {
+	fallback, _ := buildSlackConversationKey(event.TeamID, event.ChannelID)
+	return slackRunControlConversationKey(fallback, event.TeamID, event.ChannelID, event.MessageTS, event.ThreadTS)
+}
+
+func slackRunControlConversationKey(fallback, teamID, channelID, messageTS, threadTS string) string {
+	threadTS = strings.TrimSpace(threadTS)
+	if threadTS != "" && threadTS == strings.TrimSpace(messageTS) {
+		threadTS = ""
+	}
+	key, err := buildSlackHistoryScopeKey(teamID, channelID, threadTS)
+	if err == nil && strings.TrimSpace(key) != "" {
+		return strings.TrimSpace(key)
+	}
+	return strings.TrimSpace(fallback)
+}
 
 type slackUserIdentityCacheEntry struct {
 	Username    string
@@ -258,6 +285,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 		MemoryOrchestrator:      memRuntime.Orchestrator,
 		MemoryProjectionWorker:  memRuntime.ProjectionWorker,
 	}
+	runControl := runtimecontrol.New()
 	taskTimeout := opts.TaskTimeout
 	maxConc := opts.MaxConcurrency
 	sem := make(chan struct{}, maxConc)
@@ -415,9 +443,26 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 					callSlackDirectOutboundHook(workerCtx, logger, hooks, job, planText, fmt.Sprintf("slack:plan:%s:%s", job.ChannelID, job.MessageTS))
 				}
 			}
-			runCtx, cancel := context.WithTimeout(workerCtx, taskTimeout)
+			runControlKey := slackRunControlConversationKeyForJob(job)
+			if runControlKey == "" {
+				runControlKey = conversationKey
+			}
+			lease, err := runControl.StartLease(workerCtx, taskTimeout, runtimecontrol.ActiveRun{
+				Runtime:         "slack",
+				ConversationKey: runControlKey,
+				TopicID:         slackContextTopicID(job),
+				TaskID:          job.TaskID,
+				RunID:           job.TaskID,
+				Snapshot: func() string {
+					return "任务正在运行中，等待当前模型或工具调用返回。"
+				},
+			})
+			if err != nil {
+				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, strings.TrimSpace(err.Error()), false)
+				return
+			}
 			final, agentCtx, loadedSkills, reaction, runErr := runSlackTask(
-				runCtx,
+				lease.Context,
 				execRuntime,
 				api,
 				job,
@@ -428,9 +473,11 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 				availableEmojiNames,
 				fileCacheDir,
 				taskRuntimeOpts,
+				lease.SteerQueue,
 				planUpdateHook,
 			)
-			cancel()
+			userStopped := lease.UserStopped()
+			lease.Finish()
 
 			if workerCtx.Err() != nil {
 				return
@@ -438,7 +485,10 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 			planPreserved := finalizeSlackPlanProgressMessage(workerCtx, logger, hooks, job, workingMessage, agentCtx)
 			if runErr != nil {
 				displayErr := depsutil.FormatRuntimeError(runErr)
-				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, displayErr, isSlackTaskContextCanceled(runErr))
+				if userStopped {
+					displayErr = "stopped by user"
+				}
+				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, displayErr, isSlackTaskContextCanceled(runErr) || userStopped)
 				callErrorHook(workerCtx, logger, hooks, ErrorEvent{
 					Stage:           ErrorStageRunTask,
 					ConversationKey: job.ConversationKey,
@@ -448,6 +498,9 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 					Err:             runErr,
 				})
 				errorText := "error: " + displayErr
+				if userStopped {
+					errorText = "已停止当前任务。"
+				}
 				errorCorrelationID := fmt.Sprintf("slack:error:%s:%s", job.ChannelID, job.MessageTS)
 				if !planPreserved {
 					if updated, updateErr := workingMessage.Update(workerCtx, errorText); updated {
@@ -591,6 +644,17 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 		text := strings.TrimSpace(inbound.Text)
 		if text == "" {
 			return fmt.Errorf("slack inbound text is required")
+		}
+		if len(inbound.ImageAttachments) == 0 {
+			controlKey := slackRunControlConversationKeyForInbound(inbound)
+			if controlKey == "" {
+				controlKey = msg.ConversationKey
+			}
+			if result := runControl.Steer("slack", controlKey, text); result.Found {
+				correlationID := fmt.Sprintf("slack:steer:%s:%s", inbound.ChannelID, inbound.MessageTS)
+				_, publishErr := publishSlackBusOutbound(ctx, inprocBus, inbound.TeamID, inbound.ChannelID, runtimecontrol.SteerFeedback(result.Found, result.Queued), inbound.ThreadTS, correlationID)
+				return publishErr
+			}
 		}
 		workspaceDir, err := workspace.LookupWorkspaceDir(workspaceStore, msg.ConversationKey)
 		if err != nil {
@@ -840,6 +904,18 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 			mu.Lock()
 			currentSkills := append([]string(nil), stickySkillsByConv[historyScopeKey]...)
 			mu.Unlock()
+			if isSlackStopCommand(event, botUserID) {
+				controlKey := slackRunControlConversationKeyForEvent(event)
+				if controlKey == "" {
+					controlKey = conversationKey
+				}
+				result := runControl.Stop("slack", controlKey, "/stop")
+				correlationID := fmt.Sprintf("slack:stop:%s:%s", event.ChannelID, event.MessageTS)
+				if _, publishErr := publishSlackBusOutbound(context.Background(), inprocBus, event.TeamID, event.ChannelID, runtimecontrol.StopFeedback(result.Found, result.Progress), event.ThreadTS, correlationID); publishErr != nil {
+					logger.Warn("slack_bus_publish_error", "channel_id", event.ChannelID, "message_ts", event.MessageTS, "bus_error_code", busErrorCodeString(publishErr), "error", publishErr.Error())
+				}
+				return nil
+			}
 			handledCommand, cmdErr := maybeHandleSlackCommand(context.Background(), d, inprocBus, workspaceStore, conversationKey, event, botUserID, currentSkills)
 			if cmdErr != nil {
 				logger.Warn("slack_command_error",

--- a/internal/channelruntime/slack/runtime.go
+++ b/internal/channelruntime/slack/runtime.go
@@ -453,9 +453,6 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 				TopicID:         slackContextTopicID(job),
 				TaskID:          job.TaskID,
 				RunID:           job.TaskID,
-				Snapshot: func() string {
-					return "任务正在运行中，等待当前模型或工具调用返回。"
-				},
 			})
 			if err != nil {
 				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, strings.TrimSpace(err.Error()), false)
@@ -499,7 +496,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 				})
 				errorText := "error: " + displayErr
 				if userStopped {
-					errorText = "已停止当前任务。"
+					errorText = runtimecontrol.StopFeedback(true)
 				}
 				errorCorrelationID := fmt.Sprintf("slack:error:%s:%s", job.ChannelID, job.MessageTS)
 				if !planPreserved {
@@ -911,7 +908,7 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts runtimeLoopOptions) 
 				}
 				result := runControl.Stop("slack", controlKey, "/stop")
 				correlationID := fmt.Sprintf("slack:stop:%s:%s", event.ChannelID, event.MessageTS)
-				if _, publishErr := publishSlackBusOutbound(context.Background(), inprocBus, event.TeamID, event.ChannelID, runtimecontrol.StopFeedback(result.Found, result.Progress), event.ThreadTS, correlationID); publishErr != nil {
+				if _, publishErr := publishSlackBusOutbound(context.Background(), inprocBus, event.TeamID, event.ChannelID, runtimecontrol.StopFeedback(result.Found), event.ThreadTS, correlationID); publishErr != nil {
 					logger.Warn("slack_bus_publish_error", "channel_id", event.ChannelID, "message_ts", event.MessageTS, "bus_error_code", busErrorCodeString(publishErr), "error", publishErr.Error())
 				}
 				return nil

--- a/internal/channelruntime/slack/runtime_task.go
+++ b/internal/channelruntime/slack/runtime_task.go
@@ -52,6 +52,7 @@ func runSlackTask(
 	availableEmojiNames []string,
 	fileCacheDir string,
 	runtimeOpts runtimeTaskOptions,
+	steerSource agent.SteerSource,
 	planStepUpdate func(*agent.Context, agent.PlanStepUpdate),
 ) (*agent.Final, *agent.Context, []string, *slacktools.Reaction, error) {
 	if rt == nil {
@@ -177,6 +178,7 @@ func runSlackTask(
 			promptprofile.AppendSlackRuntimeBlocks(spec, isSlackGroupChat(job.ChatType), job.MentionUsers, strings.Join(availableEmojiNames, ","))
 		},
 		PlanStepUpdate:     planStepUpdate,
+		SteerSource:        steerSource,
 		Memory:             memoryHooks,
 		ImageToolScope:     slackHistoryScopeKeyForJob(job),
 		ImageToolRetention: toolsutil.ImageToolRetentionCountdown,

--- a/internal/channelruntime/slack/runtime_test.go
+++ b/internal/channelruntime/slack/runtime_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	slackbus "github.com/quailyquaily/mistermorph/internal/bus/adapters/slack"
 )
 
 func TestParseSlackInboundEvent_AppMention(t *testing.T) {
@@ -227,6 +229,52 @@ func TestParseSlackInboundEventIgnoresNonImageFileShare(t *testing.T) {
 	}
 	if ok {
 		t.Fatalf("parseSlackInboundEvent() ok=true, want false")
+	}
+}
+
+func TestSlackRuntimeControlKeyUsesThreadScope(t *testing.T) {
+	jobKey := slackRunControlConversationKeyForJob(slackJob{
+		ConversationKey: "slack:T111:C222",
+		TeamID:          "T111",
+		ChannelID:       "C222",
+		MessageTS:       "1739667600.000200",
+		ThreadTS:        "1739667600.000100",
+	})
+	if jobKey != "slack:T111:C222:thread:1739667600.000100" {
+		t.Fatalf("job control key = %q, want thread-scoped key", jobKey)
+	}
+
+	inboundKey := slackRunControlConversationKeyForInbound(slackbus.InboundMessage{
+		TeamID:    "T111",
+		ChannelID: "C222",
+		MessageTS: "1739667600.000300",
+		ThreadTS:  "1739667600.000100",
+	})
+	if inboundKey != jobKey {
+		t.Fatalf("inbound control key = %q, want %q", inboundKey, jobKey)
+	}
+
+	eventKey := slackRunControlConversationKeyForEvent(slackInboundEvent{
+		TeamID:    "T111",
+		ChannelID: "C222",
+		MessageTS: "1739667600.000400",
+		ThreadTS:  "1739667600.000100",
+	})
+	if eventKey != jobKey {
+		t.Fatalf("event control key = %q, want %q", eventKey, jobKey)
+	}
+}
+
+func TestSlackRuntimeControlKeyKeepsRootMessageChannelScoped(t *testing.T) {
+	key := slackRunControlConversationKeyForJob(slackJob{
+		ConversationKey: "slack:T111:C222",
+		TeamID:          "T111",
+		ChannelID:       "C222",
+		MessageTS:       "1739667600.000100",
+		ThreadTS:        "1739667600.000100",
+	})
+	if key != "slack:T111:C222" {
+		t.Fatalf("root message control key = %q, want channel key", key)
 	}
 }
 

--- a/internal/channelruntime/taskruntime/runtime.go
+++ b/internal/channelruntime/taskruntime/runtime.go
@@ -87,6 +87,7 @@ type RunRequest struct {
 	PromptAugment           PromptAugmentFunc
 	PlanStepUpdate          func(*agent.Context, agent.PlanStepUpdate)
 	OnStream                llm.StreamHandler
+	SteerSource             agent.SteerSource
 	Memory                  MemoryHooks
 	EngineToolsConfig       *agent.EngineToolsConfig
 	ImageToolScope          string
@@ -340,6 +341,7 @@ func (rt *Runtime) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		MemoryContext:  memoryContext,
 		CurrentMessage: req.CurrentMessage,
 		OnStream:       req.OnStream,
+		SteerSource:    req.SteerSource,
 	})
 	if err != nil {
 		return RunResult{Final: final, Context: runCtx, LoadedSkills: loadedSkills}, err

--- a/internal/channelruntime/telegram/runtime.go
+++ b/internal/channelruntime/telegram/runtime.go
@@ -29,6 +29,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/llmstats"
 	"github.com/quailyquaily/mistermorph/internal/pathroots"
 	"github.com/quailyquaily/mistermorph/internal/personautil"
+	"github.com/quailyquaily/mistermorph/internal/runtimecontrol"
 	"github.com/quailyquaily/mistermorph/internal/statepaths"
 	"github.com/quailyquaily/mistermorph/internal/telegramutil"
 	"github.com/quailyquaily/mistermorph/internal/topiccontext"
@@ -233,6 +234,7 @@ func runTelegramLoop(ctx context.Context, d Dependencies, opts runtimeLoopOption
 		MemoryOrchestrator:      memRuntime.Orchestrator,
 		MemoryProjectionWorker:  memRuntime.ProjectionWorker,
 	}
+	runControl := runtimecontrol.New()
 	pollTimeout := opts.PollTimeout
 	taskTimeout := opts.TaskTimeout
 	maxConc := opts.MaxConcurrency
@@ -570,16 +572,33 @@ func runTelegramLoop(ctx context.Context, d Dependencies, opts runtimeLoopOption
 			defer typingStop()
 			runtimecore.MarkTaskRunning(daemonStore, job.TaskID)
 
-			runCtx, cancel := context.WithTimeout(workerCtx, taskTimeout)
-			final, _, loadedSkills, reaction, runErr := runTelegramTask(runCtx, execRuntime, api, fileCacheDir, filesMaxBytes, allowed, job, botUser, h, telegramHistoryCap, sticky, requestTimeout, taskRuntimeOpts, publishTelegramText)
-			cancel()
+			lease, err := runControl.StartLease(workerCtx, taskTimeout, runtimecontrol.ActiveRun{
+				Runtime:         "telegram",
+				ConversationKey: conversationKey,
+				TopicID:         telegramContextTopicID(job),
+				TaskID:          job.TaskID,
+				RunID:           job.TaskID,
+				Snapshot: func() string {
+					return "任务正在运行中，等待当前模型或工具调用返回。"
+				},
+			})
+			if err != nil {
+				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, strings.TrimSpace(err.Error()), false)
+				return
+			}
+			final, _, loadedSkills, reaction, runErr := runTelegramTask(lease.Context, execRuntime, api, fileCacheDir, filesMaxBytes, allowed, job, botUser, h, telegramHistoryCap, sticky, requestTimeout, taskRuntimeOpts, lease.SteerQueue, publishTelegramText)
+			userStopped := lease.UserStopped()
+			lease.Finish()
 
 			if runErr != nil {
 				if workerCtx.Err() != nil {
 					return
 				}
 				displayErr := depsutil.FormatRuntimeError(runErr)
-				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, displayErr, isTaskContextCanceled(runErr))
+				if userStopped {
+					displayErr = "stopped by user"
+				}
+				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, displayErr, isTaskContextCanceled(runErr) || userStopped)
 				callErrorHook(workerCtx, logger, hooks, ErrorEvent{
 					Stage:     ErrorStageRunTask,
 					ChatID:    chatID,
@@ -587,7 +606,11 @@ func runTelegramLoop(ctx context.Context, d Dependencies, opts runtimeLoopOption
 					Err:       runErr,
 				})
 				errorCorrelationID := fmt.Sprintf("telegram:error:%d:%d", chatID, job.MessageID)
-				if _, err := publishTelegramBusOutbound(workerCtx, inprocBus, chatID, job.MessageThreadID, "error: "+displayErr, "", errorCorrelationID); err != nil {
+				errorText := "error: " + displayErr
+				if userStopped {
+					errorText = "已停止当前任务。"
+				}
+				if _, err := publishTelegramBusOutbound(workerCtx, inprocBus, chatID, job.MessageThreadID, errorText, "", errorCorrelationID); err != nil {
 					logger.Warn("telegram_bus_publish_error", "channel", busruntime.ChannelTelegram, "chat_id", chatID, "bus_error_code", busErrorCodeString(err), "error", err.Error())
 					callErrorHook(workerCtx, logger, hooks, ErrorEvent{
 						Stage:     ErrorStagePublishErrorReply,
@@ -875,9 +898,18 @@ func runTelegramLoop(ctx context.Context, d Dependencies, opts runtimeLoopOption
 			normalizedCmd := chatcommands.NormalizeCommand(cmdWord)
 			replyToMessageID := int64(0)
 			switch normalizedCmd {
+			case "/stop":
+				if len(allowed) > 0 && !allowed[chatID] {
+					logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
+					sendTelegramUnauthorizedMessage(api, chatID, messageThreadID, chatType)
+					continue
+				}
+				result := runControl.Stop("telegram", conversationKey, "/stop")
+				_ = api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, htmlstd.EscapeString(runtimecontrol.StopFeedback(result.Found, result.Progress)), true)
+				continue
 			case "/help":
 				help := "Send a message and I will run it as an agent task.\n" +
-					"Commands: /think, /models, /skills, /ctx, /workspace, /reset, /id\n\n" +
+					"Commands: /think, /stop, /models, /skills, /ctx, /workspace, /reset, /id\n\n" +
 					"Group chats: reply to me, or mention @" + botUser + ".\n" +
 					"You can also send a file (document/photo). It will be downloaded under file_cache_dir/telegram/ and the agent can process it.\n" +
 					"Note: if Bot Privacy Mode is enabled, I may not receive normal group messages."
@@ -1119,6 +1151,15 @@ func runTelegramLoop(ctx context.Context, d Dependencies, opts runtimeLoopOption
 			mentionUsers := dedupeNonEmptyStrings(mentionCandidates)
 			if isGroup && mentionUserSnapshotLimit > 0 && len(mentionUsers) > mentionUserSnapshotLimit {
 				mentionUsers = mentionUsers[:mentionUserSnapshotLimit]
+			}
+			if len(downloaded) == 0 && len(imageAttachments) == 0 {
+				if result := runControl.Steer("telegram", conversationKey, text); result.Found {
+					correlationID := fmt.Sprintf("telegram:steer:%d:%d", chatID, msg.MessageID)
+					if _, publishErr := publishTelegramBusOutbound(context.Background(), inprocBus, chatID, messageThreadID, runtimecontrol.SteerFeedback(result.Found, result.Queued), "", correlationID); publishErr != nil {
+						logger.Warn("telegram_bus_publish_error", "channel", busruntime.ChannelTelegram, "chat_id", chatID, "message_id", msg.MessageID, "bus_error_code", busErrorCodeString(publishErr), "error", publishErr.Error())
+					}
+					continue
+				}
 			}
 			accepted, publishErr := telegramInboundAdapter.HandleInboundMessage(context.Background(), telegrambus.InboundMessage{
 				ChatID:           chatID,

--- a/internal/channelruntime/telegram/runtime.go
+++ b/internal/channelruntime/telegram/runtime.go
@@ -578,9 +578,6 @@ func runTelegramLoop(ctx context.Context, d Dependencies, opts runtimeLoopOption
 				TopicID:         telegramContextTopicID(job),
 				TaskID:          job.TaskID,
 				RunID:           job.TaskID,
-				Snapshot: func() string {
-					return "任务正在运行中，等待当前模型或工具调用返回。"
-				},
 			})
 			if err != nil {
 				runtimecore.MarkTaskFailed(daemonStore, job.TaskID, strings.TrimSpace(err.Error()), false)
@@ -608,7 +605,7 @@ func runTelegramLoop(ctx context.Context, d Dependencies, opts runtimeLoopOption
 				errorCorrelationID := fmt.Sprintf("telegram:error:%d:%d", chatID, job.MessageID)
 				errorText := "error: " + displayErr
 				if userStopped {
-					errorText = "已停止当前任务。"
+					errorText = runtimecontrol.StopFeedback(true)
 				}
 				if _, err := publishTelegramBusOutbound(workerCtx, inprocBus, chatID, job.MessageThreadID, errorText, "", errorCorrelationID); err != nil {
 					logger.Warn("telegram_bus_publish_error", "channel", busruntime.ChannelTelegram, "chat_id", chatID, "bus_error_code", busErrorCodeString(err), "error", err.Error())
@@ -905,7 +902,7 @@ func runTelegramLoop(ctx context.Context, d Dependencies, opts runtimeLoopOption
 					continue
 				}
 				result := runControl.Stop("telegram", conversationKey, "/stop")
-				_ = api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, htmlstd.EscapeString(runtimecontrol.StopFeedback(result.Found, result.Progress)), true)
+				_ = api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, htmlstd.EscapeString(runtimecontrol.StopFeedback(result.Found)), true)
 				continue
 			case "/help":
 				help := "Send a message and I will run it as an agent task.\n" +

--- a/internal/channelruntime/telegram/runtime_task.go
+++ b/internal/channelruntime/telegram/runtime_task.go
@@ -53,7 +53,7 @@ const (
 
 var encodeImageToWebP = defaultEncodeImageToWebP
 
-func runTelegramTask(ctx context.Context, rt *taskruntime.Runtime, api *telegramAPI, fileCacheDir string, filesMaxBytes int64, allowedIDs map[int64]bool, job telegramJob, botUsername string, history []chathistory.ChatHistoryItem, historyCap int, stickySkills []string, requestTimeout time.Duration, runtimeOpts runtimeTaskOptions, sendTelegramText func(context.Context, int64, int64, string, string) error) (*agent.Final, *agent.Context, []string, *telegramtools.Reaction, error) {
+func runTelegramTask(ctx context.Context, rt *taskruntime.Runtime, api *telegramAPI, fileCacheDir string, filesMaxBytes int64, allowedIDs map[int64]bool, job telegramJob, botUsername string, history []chathistory.ChatHistoryItem, historyCap int, stickySkills []string, requestTimeout time.Duration, runtimeOpts runtimeTaskOptions, steerSource agent.SteerSource, sendTelegramText func(context.Context, int64, int64, string, string) error) (*agent.Final, *agent.Context, []string, *telegramtools.Reaction, error) {
 	if rt == nil {
 		return nil, nil, nil, nil, fmt.Errorf("telegram task runtime is nil")
 	}
@@ -197,6 +197,7 @@ func runTelegramTask(ctx context.Context, rt *taskruntime.Runtime, api *telegram
 			promptprofile.AppendTelegramRuntimeBlocks(spec, isGroupChat(job.ChatType), job.MentionUsers, strings.Join(telegramtools.StandardReactionEmojis(), ","))
 		},
 		PlanStepUpdate:     planUpdateHook,
+		SteerSource:        steerSource,
 		Memory:             memoryHooks,
 		ImageToolScope:     strings.TrimSpace(job.ConversationKey),
 		ImageToolRetention: toolsutil.ImageToolRetentionCountdown,

--- a/internal/daemonruntime/server.go
+++ b/internal/daemonruntime/server.go
@@ -39,6 +39,7 @@ import (
 )
 
 type SubmitFunc func(ctx context.Context, req SubmitTaskRequest) (SubmitTaskResponse, error)
+type StopFunc func(ctx context.Context, req StopTaskRequest) (StopTaskResponse, error)
 type OverviewFunc func(ctx context.Context) (map[string]any, error)
 type PokeFunc func(ctx context.Context, input PokeInput) error
 type WorkspaceGetFunc func(ctx context.Context, topicID string) (string, error)
@@ -384,6 +385,7 @@ type RoutesOptions struct {
 	TopicReader          TopicReader
 	TopicDeleter         TopicDeleter
 	Submit               SubmitFunc
+	Stop                 StopFunc
 	Overview             OverviewFunc
 	Poke                 PokeFunc
 	WorkspaceGet         WorkspaceGetFunc
@@ -466,6 +468,7 @@ func RegisterRoutes(mux *http.ServeMux, opts RoutesOptions) {
 	topicReader := opts.TopicReader
 	topicDeleter := opts.TopicDeleter
 	submit := opts.Submit
+	stop := opts.Stop
 	instanceID := buildRuntimeInstanceID()
 	overview := opts.Overview
 	poke := opts.Poke
@@ -1520,24 +1523,59 @@ func RegisterRoutes(mux *http.ServeMux, opts RoutesOptions) {
 	})
 
 	mux.HandleFunc("/tasks/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
 		if !checkAuth(r, authToken) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		suffix := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/tasks/"))
+		if suffix == "" {
+			http.Error(w, "missing task_id", http.StatusBadRequest)
+			return
+		}
+		if strings.HasSuffix(suffix, "/stop") {
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			if stop == nil {
+				http.Error(w, "stop is unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			taskID := strings.TrimSpace(strings.TrimSuffix(suffix, "/stop"))
+			if taskID == "" || strings.Contains(taskID, "/") {
+				http.Error(w, "missing task_id", http.StatusBadRequest)
+				return
+			}
+			resp, err := stop(r.Context(), StopTaskRequest{
+				TaskID: taskID,
+				Reason: "/stop",
+			})
+			if err != nil {
+				if msg, ok := badRequestMessage(err); ok {
+					http.Error(w, msg, http.StatusBadRequest)
+					return
+				}
+				http.Error(w, strings.TrimSpace(err.Error()), http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 		if reader == nil {
 			http.Error(w, "task reader is unavailable", http.StatusServiceUnavailable)
 			return
 		}
-		id := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/tasks/"))
-		if id == "" {
-			http.Error(w, "missing id", http.StatusBadRequest)
+		if strings.Contains(suffix, "/") {
+			http.NotFound(w, r)
 			return
 		}
-		info, ok := reader.Get(id)
+		info, ok := reader.Get(suffix)
 		if !ok || info == nil {
 			http.NotFound(w, r)
 			return
@@ -1547,21 +1585,56 @@ func RegisterRoutes(mux *http.ServeMux, opts RoutesOptions) {
 	})
 
 	mux.HandleFunc("/topics/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
 		if !checkAuth(r, authToken) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		suffix := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/topics/"))
+		if suffix == "" {
+			http.Error(w, "missing topic_id", http.StatusBadRequest)
+			return
+		}
+		if strings.HasSuffix(suffix, "/stop") {
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			if stop == nil {
+				http.Error(w, "stop is unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			topicID := strings.TrimSpace(strings.TrimSuffix(suffix, "/stop"))
+			if topicID == "" || strings.Contains(topicID, "/") {
+				http.Error(w, "missing topic_id", http.StatusBadRequest)
+				return
+			}
+			resp, err := stop(r.Context(), StopTaskRequest{
+				TopicID: topicID,
+				Reason:  "/stop",
+			})
+			if err != nil {
+				if msg, ok := badRequestMessage(err); ok {
+					http.Error(w, msg, http.StatusBadRequest)
+					return
+				}
+				http.Error(w, strings.TrimSpace(err.Error()), http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 		if topicDeleter == nil {
 			http.Error(w, "topic delete is unavailable", http.StatusServiceUnavailable)
 			return
 		}
-		id := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/topics/"))
-		if id == "" {
-			http.Error(w, "missing topic_id", http.StatusBadRequest)
+		id := suffix
+		if strings.Contains(id, "/") {
+			http.NotFound(w, r)
 			return
 		}
 		if !topicDeleter.DeleteTopic(id) {

--- a/internal/daemonruntime/server_tasks_test.go
+++ b/internal/daemonruntime/server_tasks_test.go
@@ -277,3 +277,65 @@ func TestTasksRouteSubmitReturnsTopicID(t *testing.T) {
 		t.Fatalf("payload.TopicID = %q, want topic_new", payload.TopicID)
 	}
 }
+
+func TestStopRoutesCallStopHandler(t *testing.T) {
+	var calls []StopTaskRequest
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, RoutesOptions{
+		Mode:      "console",
+		AuthToken: "token",
+		Stop: func(_ context.Context, req StopTaskRequest) (StopTaskResponse, error) {
+			calls = append(calls, req)
+			return StopTaskResponse{
+				Status:   "stopping",
+				Found:    true,
+				TaskID:   req.TaskID,
+				TopicID:  req.TopicID,
+				Progress: "计划 1/3",
+				Message:  "已请求停止当前任务。\n当前进展：计划 1/3",
+			}, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/tasks/task_1/stop", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("task stop status = %d, want %d (%s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var taskPayload StopTaskResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &taskPayload); err != nil {
+		t.Fatalf("json.Unmarshal(task) error = %v", err)
+	}
+	if taskPayload.TaskID != "task_1" || taskPayload.Status != "stopping" || taskPayload.Progress != "计划 1/3" {
+		t.Fatalf("task stop payload = %+v", taskPayload)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/topics/topic_a/stop", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("topic stop status = %d, want %d (%s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var topicPayload StopTaskResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &topicPayload); err != nil {
+		t.Fatalf("json.Unmarshal(topic) error = %v", err)
+	}
+	if topicPayload.TopicID != "topic_a" || topicPayload.Status != "stopping" || topicPayload.Progress != "计划 1/3" {
+		t.Fatalf("topic stop payload = %+v", topicPayload)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("calls len = %d, want 2", len(calls))
+	}
+	if calls[0].TaskID != "task_1" || calls[0].TopicID != "" {
+		t.Fatalf("task stop call = %+v", calls[0])
+	}
+	if calls[1].TaskID != "" || calls[1].TopicID != "topic_a" {
+		t.Fatalf("topic stop call = %+v", calls[1])
+	}
+}

--- a/internal/daemonruntime/server_tasks_test.go
+++ b/internal/daemonruntime/server_tasks_test.go
@@ -292,7 +292,6 @@ func TestStopRoutesCallStopHandler(t *testing.T) {
 				TaskID:   req.TaskID,
 				TopicID:  req.TopicID,
 				Progress: "计划 1/3",
-				Message:  "已请求停止当前任务。\n当前进展：计划 1/3",
 			}, nil
 		},
 	})

--- a/internal/daemonruntime/types.go
+++ b/internal/daemonruntime/types.go
@@ -32,6 +32,21 @@ type SubmitTaskResponse struct {
 	TopicID string     `json:"topic_id,omitempty"`
 }
 
+type StopTaskRequest struct {
+	TaskID  string `json:"task_id,omitempty"`
+	TopicID string `json:"topic_id,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type StopTaskResponse struct {
+	Status   string `json:"status"`
+	Found    bool   `json:"found"`
+	TaskID   string `json:"task_id,omitempty"`
+	TopicID  string `json:"topic_id,omitempty"`
+	Progress string `json:"progress,omitempty"`
+	Message  string `json:"message,omitempty"`
+}
+
 type TaskInfo struct {
 	ID                string     `json:"id"`
 	Status            TaskStatus `json:"status"`

--- a/internal/runtimecontrol/control.go
+++ b/internal/runtimecontrol/control.go
@@ -330,5 +330,5 @@ func SteerFeedback(found bool, queued bool) string {
 	if !queued {
 		return "当前任务正在运行，但暂时无法接收新的补充输入。"
 	}
-	return "已收到，会作为当前任务的补充输入处理。"
+	return "👌"
 }

--- a/internal/runtimecontrol/control.go
+++ b/internal/runtimecontrol/control.go
@@ -14,9 +14,9 @@ import (
 var ErrStoppedByUser = errors.New("stopped by user")
 
 const (
-	FeedbackNoActiveRun      = "当前没有正在运行的任务。"
-	FeedbackStopped          = "已停止当前任务。"
-	FeedbackSteerUnavailable = "当前任务正在运行，但暂时无法接收新的补充输入。"
+	FeedbackNoActiveRun      = "🤔"
+	FeedbackStopped          = "👌"
+	FeedbackSteerUnavailable = "😵‍💫"
 	FeedbackSteerAccepted    = "👌"
 )
 

--- a/internal/runtimecontrol/control.go
+++ b/internal/runtimecontrol/control.go
@@ -13,6 +13,13 @@ import (
 
 var ErrStoppedByUser = errors.New("stopped by user")
 
+const (
+	FeedbackNoActiveRun      = "当前没有正在运行的任务。"
+	FeedbackStopped          = "已停止当前任务。"
+	FeedbackSteerUnavailable = "当前任务正在运行，但暂时无法接收新的补充输入。"
+	FeedbackSteerAccepted    = "👌"
+)
+
 type ActiveRun struct {
 	Runtime         string
 	ConversationKey string
@@ -312,23 +319,19 @@ func emitControlEvent(entry *activeRun, kind string, reason string, text string)
 	})
 }
 
-func StopFeedback(found bool, progress string) string {
+func StopFeedback(found bool) string {
 	if !found {
-		return "当前没有正在运行的任务。"
+		return FeedbackNoActiveRun
 	}
-	progress = strings.TrimSpace(progress)
-	if progress == "" {
-		return "已请求停止当前任务。"
-	}
-	return "已请求停止当前任务。\n当前进展：" + progress
+	return FeedbackStopped
 }
 
 func SteerFeedback(found bool, queued bool) string {
 	if !found {
-		return "当前没有正在运行的任务。"
+		return FeedbackNoActiveRun
 	}
 	if !queued {
-		return "当前任务正在运行，但暂时无法接收新的补充输入。"
+		return FeedbackSteerUnavailable
 	}
-	return "👌"
+	return FeedbackSteerAccepted
 }

--- a/internal/runtimecontrol/control.go
+++ b/internal/runtimecontrol/control.go
@@ -1,0 +1,329 @@
+package runtimecontrol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/quailyquaily/mistermorph/agent"
+)
+
+var ErrStoppedByUser = errors.New("stopped by user")
+
+type ActiveRun struct {
+	Runtime         string
+	ConversationKey string
+	TopicID         string
+	TaskID          string
+	RunID           string
+	Cancel          context.CancelCauseFunc
+	Snapshot        func() string
+	SteerQueue      *SteerQueue
+	EventSink       agent.EventSink
+}
+
+type StopResult struct {
+	Found    bool   `json:"found"`
+	Progress string `json:"progress,omitempty"`
+}
+
+type SteerResult struct {
+	Found  bool `json:"found"`
+	Queued bool `json:"queued"`
+}
+
+type RunControl struct {
+	mu     sync.Mutex
+	active map[runKey]*activeRun
+}
+
+type runKey struct {
+	runtime         string
+	conversationKey string
+}
+
+type activeRun struct {
+	Runtime         string
+	ConversationKey string
+	TopicID         string
+	TaskID          string
+	RunID           string
+	Cancel          context.CancelCauseFunc
+	Snapshot        func() string
+	SteerQueue      *SteerQueue
+	EventSink       agent.EventSink
+
+	stopRequested bool
+	stopReason    string
+}
+
+type RunLease struct {
+	Context    context.Context
+	SteerQueue *SteerQueue
+
+	control         *RunControl
+	runtime         string
+	conversationKey string
+	taskID          string
+	stopCancel      context.CancelCauseFunc
+	timeoutCancel   context.CancelFunc
+	finished        bool
+}
+
+func New() *RunControl {
+	return &RunControl{
+		active: map[runKey]*activeRun{},
+	}
+}
+
+func (c *RunControl) StartLease(parent context.Context, timeout time.Duration, run ActiveRun) (*RunLease, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	stopCtx, stopCancel := context.WithCancelCause(parent)
+	runCtx := stopCtx
+	timeoutCancel := context.CancelFunc(func() {})
+	if timeout > 0 {
+		runCtx, timeoutCancel = context.WithTimeout(stopCtx, timeout)
+	}
+	queue := run.SteerQueue
+	if queue == nil {
+		queue = NewSteerQueue(0)
+	}
+	run.Cancel = stopCancel
+	run.SteerQueue = queue
+	if err := c.Start(run); err != nil {
+		timeoutCancel()
+		stopCancel(nil)
+		return nil, err
+	}
+	return &RunLease{
+		Context:         runCtx,
+		SteerQueue:      queue,
+		control:         c,
+		runtime:         strings.TrimSpace(run.Runtime),
+		conversationKey: strings.TrimSpace(run.ConversationKey),
+		taskID:          strings.TrimSpace(run.TaskID),
+		stopCancel:      stopCancel,
+		timeoutCancel:   timeoutCancel,
+	}, nil
+}
+
+func (l *RunLease) UserStopped() bool {
+	return l != nil && errors.Is(context.Cause(l.Context), ErrStoppedByUser)
+}
+
+func (l *RunLease) Finish() bool {
+	if l == nil || l.finished {
+		return false
+	}
+	l.finished = true
+	if l.timeoutCancel != nil {
+		l.timeoutCancel()
+	}
+	if l.stopCancel != nil {
+		l.stopCancel(nil)
+	}
+	if l.control == nil {
+		return false
+	}
+	return l.control.Finish(l.runtime, l.conversationKey, l.taskID)
+}
+
+func (c *RunControl) Start(run ActiveRun) error {
+	if c == nil {
+		return fmt.Errorf("run control is nil")
+	}
+	key, err := keyFrom(run.Runtime, run.ConversationKey)
+	if err != nil {
+		return err
+	}
+	taskID := strings.TrimSpace(run.TaskID)
+	if taskID == "" {
+		return fmt.Errorf("task id is required")
+	}
+	entry := &activeRun{
+		Runtime:         key.runtime,
+		ConversationKey: key.conversationKey,
+		TopicID:         strings.TrimSpace(run.TopicID),
+		TaskID:          taskID,
+		RunID:           strings.TrimSpace(run.RunID),
+		Cancel:          run.Cancel,
+		Snapshot:        run.Snapshot,
+		SteerQueue:      run.SteerQueue,
+		EventSink:       run.EventSink,
+	}
+	if entry.SteerQueue == nil {
+		entry.SteerQueue = NewSteerQueue(0)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.active[key]; exists {
+		return fmt.Errorf("active run already exists for runtime %q conversation %q", key.runtime, key.conversationKey)
+	}
+	c.active[key] = entry
+	return nil
+}
+
+func (c *RunControl) Stop(runtime string, conversationKey string, reason string) StopResult {
+	key, err := keyFrom(runtime, conversationKey)
+	if c == nil || err != nil {
+		return StopResult{}
+	}
+	return c.stopByKey(key, reason, "")
+}
+
+func (c *RunControl) StopTask(runtime string, taskID string, reason string) StopResult {
+	runtime = strings.TrimSpace(runtime)
+	taskID = strings.TrimSpace(taskID)
+	if c == nil || runtime == "" || taskID == "" {
+		return StopResult{}
+	}
+
+	c.mu.Lock()
+	var key runKey
+	found := false
+	for candidate, entry := range c.active {
+		if candidate.runtime == runtime && entry != nil && strings.TrimSpace(entry.TaskID) == taskID {
+			key = candidate
+			found = true
+			break
+		}
+	}
+	c.mu.Unlock()
+	if !found {
+		return StopResult{}
+	}
+	return c.stopByKey(key, reason, taskID)
+}
+
+func (c *RunControl) Finish(runtime string, conversationKey string, taskID string) bool {
+	key, err := keyFrom(runtime, conversationKey)
+	if c == nil || err != nil {
+		return false
+	}
+	taskID = strings.TrimSpace(taskID)
+	c.mu.Lock()
+	entry := c.active[key]
+	if entry == nil || strings.TrimSpace(entry.TaskID) != taskID {
+		c.mu.Unlock()
+		return false
+	}
+	delete(c.active, key)
+	wasStopped := entry.stopRequested
+	c.mu.Unlock()
+
+	if wasStopped {
+		emitControlEvent(entry, agent.EventKindRunStopped, entry.stopReason, "")
+	}
+	return true
+}
+
+func (c *RunControl) Steer(runtime string, conversationKey string, input string) SteerResult {
+	key, err := keyFrom(runtime, conversationKey)
+	input = strings.TrimSpace(input)
+	if c == nil || err != nil || input == "" {
+		return SteerResult{}
+	}
+
+	c.mu.Lock()
+	entry := c.active[key]
+	c.mu.Unlock()
+	if entry == nil || entry.SteerQueue == nil {
+		return SteerResult{}
+	}
+	if _, pushErr := entry.SteerQueue.Push(input); pushErr != nil {
+		return SteerResult{Found: true}
+	}
+	emitControlEvent(entry, agent.EventKindSteerQueued, "", input)
+	return SteerResult{Found: true, Queued: true}
+}
+
+func (c *RunControl) stopByKey(key runKey, reason string, expectedTaskID string) StopResult {
+	reason = strings.TrimSpace(reason)
+	expectedTaskID = strings.TrimSpace(expectedTaskID)
+	c.mu.Lock()
+	entry := c.active[key]
+	if entry == nil || (expectedTaskID != "" && strings.TrimSpace(entry.TaskID) != expectedTaskID) {
+		c.mu.Unlock()
+		return StopResult{}
+	}
+	shouldCancel := !entry.stopRequested
+	if shouldCancel {
+		entry.stopRequested = true
+		entry.stopReason = reason
+	}
+	c.mu.Unlock()
+
+	if shouldCancel {
+		emitControlEvent(entry, agent.EventKindRunStopRequested, reason, "")
+		if entry.Cancel != nil {
+			entry.Cancel(ErrStoppedByUser)
+		}
+	}
+	return StopResult{
+		Found:    true,
+		Progress: snapshotFor(entry),
+	}
+}
+
+func keyFrom(runtime string, conversationKey string) (runKey, error) {
+	key := runKey{
+		runtime:         strings.TrimSpace(runtime),
+		conversationKey: strings.TrimSpace(conversationKey),
+	}
+	if key.runtime == "" {
+		return runKey{}, fmt.Errorf("runtime is required")
+	}
+	if key.conversationKey == "" {
+		return runKey{}, fmt.Errorf("conversation key is required")
+	}
+	return key, nil
+}
+
+func snapshotFor(entry *activeRun) string {
+	if entry == nil || entry.Snapshot == nil {
+		return ""
+	}
+	return strings.TrimSpace(entry.Snapshot())
+}
+
+func emitControlEvent(entry *activeRun, kind string, reason string, text string) {
+	if entry == nil || entry.EventSink == nil {
+		return
+	}
+	agent.EmitEvent(context.Background(), entry.EventSink, agent.Event{
+		Kind:            kind,
+		RunID:           entry.RunID,
+		TaskID:          entry.TaskID,
+		ConversationKey: entry.ConversationKey,
+		TopicID:         entry.TopicID,
+		Reason:          strings.TrimSpace(reason),
+		Text:            strings.TrimSpace(text),
+	})
+}
+
+func StopFeedback(found bool, progress string) string {
+	if !found {
+		return "当前没有正在运行的任务。"
+	}
+	progress = strings.TrimSpace(progress)
+	if progress == "" {
+		return "已请求停止当前任务。"
+	}
+	return "已请求停止当前任务。\n当前进展：" + progress
+}
+
+func SteerFeedback(found bool, queued bool) string {
+	if !found {
+		return "当前没有正在运行的任务。"
+	}
+	if !queued {
+		return "当前任务正在运行，但暂时无法接收新的补充输入。"
+	}
+	return "已收到，会作为当前任务的补充输入处理。"
+}

--- a/internal/runtimecontrol/control.go
+++ b/internal/runtimecontrol/control.go
@@ -213,8 +213,11 @@ func (c *RunControl) Finish(runtime string, conversationKey string, taskID strin
 		c.mu.Unlock()
 		return false
 	}
-	delete(c.active, key)
 	wasStopped := entry.stopRequested
+	if entry.SteerQueue != nil {
+		entry.SteerQueue.Close()
+	}
+	delete(c.active, key)
 	c.mu.Unlock()
 
 	if wasStopped {
@@ -232,13 +235,15 @@ func (c *RunControl) Steer(runtime string, conversationKey string, input string)
 
 	c.mu.Lock()
 	entry := c.active[key]
-	c.mu.Unlock()
 	if entry == nil || entry.SteerQueue == nil {
+		c.mu.Unlock()
 		return SteerResult{}
 	}
 	if _, pushErr := entry.SteerQueue.Push(input); pushErr != nil {
+		c.mu.Unlock()
 		return SteerResult{Found: true}
 	}
+	c.mu.Unlock()
 	emitControlEvent(entry, agent.EventKindSteerQueued, "", input)
 	return SteerResult{Found: true, Queued: true}
 }

--- a/internal/runtimecontrol/control_test.go
+++ b/internal/runtimecontrol/control_test.go
@@ -355,7 +355,7 @@ func TestFeedbackHelpersUsePlainState(t *testing.T) {
 	if got := SteerFeedback(true, false); got != "当前任务正在运行，但暂时无法接收新的补充输入。" {
 		t.Fatalf("SteerFeedback(true, false) = %q", got)
 	}
-	if got := SteerFeedback(true, true); got != "已收到，会作为当前任务的补充输入处理。" {
+	if got := SteerFeedback(true, true); got != "👌" {
 		t.Fatalf("SteerFeedback(true, true) = %q", got)
 	}
 }

--- a/internal/runtimecontrol/control_test.go
+++ b/internal/runtimecontrol/control_test.go
@@ -255,6 +255,24 @@ func TestRunControlSteerReportsClosedQueue(t *testing.T) {
 	}
 }
 
+func TestSteerQueueDrainAndCloseRejectsLaterInput(t *testing.T) {
+	queue := NewSteerQueue(0)
+	if _, err := queue.Push("final note"); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+
+	items := queue.DrainAndClose()
+	if len(items) != 1 || items[0] != "final note" {
+		t.Fatalf("DrainAndClose() = %#v, want queued item", items)
+	}
+	if _, err := queue.Push("too late"); err == nil {
+		t.Fatal("Push() after DrainAndClose() error = nil")
+	}
+	if got := queue.Drain(); len(got) != 0 {
+		t.Fatalf("Drain() after DrainAndClose() = %#v, want empty", got)
+	}
+}
+
 func TestRunControlStartLeaseRegistersRunAndCleansUp(t *testing.T) {
 	control := New()
 	sink := &recordingSink{}

--- a/internal/runtimecontrol/control_test.go
+++ b/internal/runtimecontrol/control_test.go
@@ -206,6 +206,55 @@ func TestRunControlSteerQueuesAndDrainsInOrder(t *testing.T) {
 	}
 }
 
+func TestRunControlFinishClosesSteerQueue(t *testing.T) {
+	control := New()
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	queue := NewSteerQueue(0)
+	if err := control.Start(ActiveRun{
+		Runtime:         "console",
+		ConversationKey: "topic:1",
+		TaskID:          "task_1",
+		Cancel:          cancel,
+		SteerQueue:      queue,
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if !control.Finish("console", "topic:1", "task_1") {
+		t.Fatal("Finish() = false, want true")
+	}
+	if _, err := queue.Push("late input"); err == nil {
+		t.Fatal("Push() after Finish() error = nil")
+	}
+	if got := queue.Drain(); len(got) != 0 {
+		t.Fatalf("Drain() after Finish() = %#v, want empty", got)
+	}
+}
+
+func TestRunControlSteerReportsClosedQueue(t *testing.T) {
+	control := New()
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	queue := NewSteerQueue(0)
+	if err := control.Start(ActiveRun{
+		Runtime:         "console",
+		ConversationKey: "topic:1",
+		TaskID:          "task_1",
+		Cancel:          cancel,
+		SteerQueue:      queue,
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	queue.Close()
+
+	got := control.Steer("console", "topic:1", "late input")
+	if !got.Found || got.Queued {
+		t.Fatalf("Steer() = %#v, want found but not queued", got)
+	}
+}
+
 func TestRunControlStartLeaseRegistersRunAndCleansUp(t *testing.T) {
 	control := New()
 	sink := &recordingSink{}

--- a/internal/runtimecontrol/control_test.go
+++ b/internal/runtimecontrol/control_test.go
@@ -1,0 +1,294 @@
+package runtimecontrol
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/quailyquaily/mistermorph/agent"
+)
+
+type recordingSink struct {
+	mu     sync.Mutex
+	events []agent.Event
+}
+
+func (s *recordingSink) HandleEvent(_ context.Context, event agent.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+}
+
+func (s *recordingSink) all() []agent.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]agent.Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+func TestRunControlRejectsDuplicateActiveRun(t *testing.T) {
+	control := New()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	err := control.Start(ActiveRun{
+		Runtime:         "console",
+		ConversationKey: "topic:1",
+		TaskID:          "task_1",
+		RunID:           "run_1",
+		Cancel:          cancel,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	err = control.Start(ActiveRun{
+		Runtime:         "console",
+		ConversationKey: "topic:1",
+		TaskID:          "task_2",
+		RunID:           "run_2",
+		Cancel:          cancel,
+	})
+	if err == nil {
+		t.Fatal("Start() duplicate error = nil")
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("duplicate Start() canceled ctx: %v", ctx.Err())
+	}
+}
+
+func TestRunControlStopIsIdempotentAndEmitsEvents(t *testing.T) {
+	control := New()
+	sink := &recordingSink{}
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	err := control.Start(ActiveRun{
+		Runtime:         "console",
+		ConversationKey: "topic:1",
+		TopicID:         "topic-1",
+		TaskID:          "task_1",
+		RunID:           "run_1",
+		Cancel:          cancel,
+		EventSink:       sink,
+		Snapshot: func() string {
+			return "LLM 轮次 2，计划 1/3"
+		},
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	first := control.Stop("console", "topic:1", "user_stop")
+	if !first.Found {
+		t.Fatalf("first Stop() = %#v, want found", first)
+	}
+	if first.Progress != "LLM 轮次 2，计划 1/3" {
+		t.Fatalf("first progress = %q, want snapshot text", first.Progress)
+	}
+	if !errors.Is(context.Cause(ctx), ErrStoppedByUser) {
+		t.Fatalf("context cause = %v, want ErrStoppedByUser", context.Cause(ctx))
+	}
+
+	second := control.Stop("console", "topic:1", "again")
+	if !second.Found {
+		t.Fatalf("second Stop() = %#v, want same active run", second)
+	}
+	if !errors.Is(context.Cause(ctx), ErrStoppedByUser) {
+		t.Fatalf("second Stop() cause = %v, want original ErrStoppedByUser", context.Cause(ctx))
+	}
+
+	if !control.Finish("console", "topic:1", "task_1") {
+		t.Fatal("Finish() = false, want true")
+	}
+	missing := control.Stop("console", "topic:1", "after_finish")
+	if missing.Found {
+		t.Fatalf("Stop() after Finish() = %#v, want not found", missing)
+	}
+
+	events := sink.all()
+	if len(events) != 2 {
+		t.Fatalf("events = %#v, want stop requested and stopped", events)
+	}
+	if events[0].Kind != agent.EventKindRunStopRequested || events[1].Kind != agent.EventKindRunStopped {
+		t.Fatalf("event kinds = %q, %q", events[0].Kind, events[1].Kind)
+	}
+	if events[0].TaskID != "task_1" || events[0].ConversationKey != "topic:1" || events[0].Reason != "user_stop" {
+		t.Fatalf("stop event = %#v, want task/conversation/reason", events[0])
+	}
+}
+
+func TestRunControlStopTaskFindsActiveRunByTaskID(t *testing.T) {
+	control := New()
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	if err := control.Start(ActiveRun{
+		Runtime:         "console",
+		ConversationKey: "topic:1",
+		TaskID:          "task_1",
+		Cancel:          cancel,
+		Snapshot: func() string {
+			return "计划 2/4"
+		},
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	stop := control.StopTask("console", "task_1", "/stop")
+	if !stop.Found {
+		t.Fatalf("StopTask() = %#v, want found", stop)
+	}
+	if stop.Progress != "计划 2/4" {
+		t.Fatalf("StopTask().Progress = %q, want snapshot text", stop.Progress)
+	}
+	if !errors.Is(context.Cause(ctx), ErrStoppedByUser) {
+		t.Fatalf("context cause = %v, want ErrStoppedByUser", context.Cause(ctx))
+	}
+
+	missing := control.StopTask("console", "task_missing", "/stop")
+	if missing.Found {
+		t.Fatalf("StopTask(missing) = %#v, want not found", missing)
+	}
+}
+
+func TestRunControlSteerQueuesAndDrainsInOrder(t *testing.T) {
+	control := New()
+	sink := &recordingSink{}
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	queue := NewSteerQueue(0)
+	if err := control.Start(ActiveRun{
+		Runtime:         "console",
+		ConversationKey: "topic:1",
+		TaskID:          "task_1",
+		RunID:           "run_1",
+		Cancel:          cancel,
+		SteerQueue:      queue,
+		EventSink:       sink,
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	first := control.Steer("console", "topic:1", "prefer short answer")
+	second := control.Steer("console", "topic:1", "also mention risks")
+	if !first.Found || !first.Queued {
+		t.Fatalf("first Steer() = %#v, want queued", first)
+	}
+	if !second.Found || !second.Queued {
+		t.Fatalf("second Steer() = %#v, want queued", second)
+	}
+
+	items := queue.Drain()
+	if len(items) != 2 {
+		t.Fatalf("Drain() len = %d, want 2", len(items))
+	}
+	if items[0] != "prefer short answer" || items[1] != "also mention risks" {
+		t.Fatalf("Drain() = %#v, want input order", items)
+	}
+	if again := queue.Drain(); len(again) != 0 {
+		t.Fatalf("second Drain() = %#v, want empty", again)
+	}
+	missing := control.Steer("console", "topic:missing", "ignored")
+	if missing.Found || missing.Queued {
+		t.Fatalf("Steer() missing = %#v, want not found", missing)
+	}
+
+	events := sink.all()
+	if len(events) != 2 {
+		t.Fatalf("events len = %d, want 2", len(events))
+	}
+	for i, ev := range events {
+		if ev.Kind != agent.EventKindSteerQueued {
+			t.Fatalf("event %d kind = %q, want steer_queued", i, ev.Kind)
+		}
+	}
+}
+
+func TestRunControlStartLeaseRegistersRunAndCleansUp(t *testing.T) {
+	control := New()
+	sink := &recordingSink{}
+
+	lease, err := control.StartLease(context.Background(), time.Minute, ActiveRun{
+		Runtime:         "telegram",
+		ConversationKey: "chat:1",
+		TopicID:         "topic_1",
+		TaskID:          "task_1",
+		RunID:           "run_1",
+		EventSink:       sink,
+		Snapshot: func() string {
+			return "计划 1/2"
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartLease() error = %v", err)
+	}
+	if lease == nil || lease.Context == nil || lease.SteerQueue == nil {
+		t.Fatalf("lease = %#v, want context and steer queue", lease)
+	}
+
+	steer := control.Steer("telegram", "chat:1", "prefer concise")
+	if !steer.Found || !steer.Queued {
+		t.Fatalf("Steer() = %#v, want queued", steer)
+	}
+	if items := lease.SteerQueue.Drain(); len(items) != 1 || items[0] != "prefer concise" {
+		t.Fatalf("lease steer queue = %#v, want queued input", items)
+	}
+
+	stop := control.Stop("telegram", "chat:1", "/stop")
+	if !stop.Found {
+		t.Fatalf("Stop() = %#v, want found", stop)
+	}
+	if stop.Progress != "计划 1/2" {
+		t.Fatalf("Stop().Progress = %q, want snapshot text", stop.Progress)
+	}
+	if !lease.UserStopped() {
+		t.Fatalf("UserStopped() = false, cause=%v", context.Cause(lease.Context))
+	}
+	if !lease.Finish() {
+		t.Fatal("Finish() = false, want true")
+	}
+	if again := control.Stop("telegram", "chat:1", "again"); again.Found {
+		t.Fatalf("Stop() after Finish() = %#v, want not found", again)
+	}
+	if lease.Finish() {
+		t.Fatal("second Finish() = true, want false")
+	}
+
+	events := sink.all()
+	stopRequested := agent.Event{}
+	for _, event := range events {
+		if event.Kind == agent.EventKindRunStopRequested {
+			stopRequested = event
+			break
+		}
+	}
+	if stopRequested.Kind == "" {
+		t.Fatalf("events = %#v, want stop requested", events)
+	}
+	if stopRequested.TaskID != "task_1" || stopRequested.ConversationKey != "chat:1" || stopRequested.TopicID != "topic_1" {
+		t.Fatalf("event metadata = %#v, want lease metadata", stopRequested)
+	}
+}
+
+func TestFeedbackHelpersUsePlainState(t *testing.T) {
+	if got := StopFeedback(false, ""); got != "当前没有正在运行的任务。" {
+		t.Fatalf("StopFeedback(false, empty) = %q", got)
+	}
+	if got := StopFeedback(true, ""); got != "已请求停止当前任务。" {
+		t.Fatalf("StopFeedback(true, empty) = %q", got)
+	}
+	if got := StopFeedback(true, "计划 1/3"); got != "已请求停止当前任务。\n当前进展：计划 1/3" {
+		t.Fatalf("StopFeedback(true, progress) = %q", got)
+	}
+	if got := SteerFeedback(false, false); got != "当前没有正在运行的任务。" {
+		t.Fatalf("SteerFeedback(false, false) = %q", got)
+	}
+	if got := SteerFeedback(true, false); got != "当前任务正在运行，但暂时无法接收新的补充输入。" {
+		t.Fatalf("SteerFeedback(true, false) = %q", got)
+	}
+	if got := SteerFeedback(true, true); got != "已收到，会作为当前任务的补充输入处理。" {
+		t.Fatalf("SteerFeedback(true, true) = %q", got)
+	}
+}

--- a/internal/runtimecontrol/control_test.go
+++ b/internal/runtimecontrol/control_test.go
@@ -340,22 +340,19 @@ func TestRunControlStartLeaseRegistersRunAndCleansUp(t *testing.T) {
 }
 
 func TestFeedbackHelpersUsePlainState(t *testing.T) {
-	if got := StopFeedback(false, ""); got != "当前没有正在运行的任务。" {
-		t.Fatalf("StopFeedback(false, empty) = %q", got)
+	if got := StopFeedback(false); got != FeedbackNoActiveRun {
+		t.Fatalf("StopFeedback(false) = %q", got)
 	}
-	if got := StopFeedback(true, ""); got != "已请求停止当前任务。" {
-		t.Fatalf("StopFeedback(true, empty) = %q", got)
+	if got := StopFeedback(true); got != FeedbackStopped {
+		t.Fatalf("StopFeedback(true) = %q", got)
 	}
-	if got := StopFeedback(true, "计划 1/3"); got != "已请求停止当前任务。\n当前进展：计划 1/3" {
-		t.Fatalf("StopFeedback(true, progress) = %q", got)
-	}
-	if got := SteerFeedback(false, false); got != "当前没有正在运行的任务。" {
+	if got := SteerFeedback(false, false); got != FeedbackNoActiveRun {
 		t.Fatalf("SteerFeedback(false, false) = %q", got)
 	}
-	if got := SteerFeedback(true, false); got != "当前任务正在运行，但暂时无法接收新的补充输入。" {
+	if got := SteerFeedback(true, false); got != FeedbackSteerUnavailable {
 		t.Fatalf("SteerFeedback(true, false) = %q", got)
 	}
-	if got := SteerFeedback(true, true); got != "👌" {
+	if got := SteerFeedback(true, true); got != FeedbackSteerAccepted {
 		t.Fatalf("SteerFeedback(true, true) = %q", got)
 	}
 }

--- a/internal/runtimecontrol/steer_queue.go
+++ b/internal/runtimecontrol/steer_queue.go
@@ -1,0 +1,63 @@
+package runtimecontrol
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const defaultSteerQueueLimit = 32
+
+type SteerQueue struct {
+	mu    sync.Mutex
+	limit int
+	items []string
+}
+
+func NewSteerQueue(limit int) *SteerQueue {
+	if limit <= 0 {
+		limit = defaultSteerQueueLimit
+	}
+	return &SteerQueue{limit: limit}
+}
+
+func (q *SteerQueue) Push(input string) (int, error) {
+	if q == nil {
+		return 0, fmt.Errorf("steer queue is nil")
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return q.Len(), fmt.Errorf("steer input is empty")
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.limit > 0 && len(q.items) >= q.limit {
+		return len(q.items), fmt.Errorf("steer queue is full")
+	}
+	q.items = append(q.items, input)
+	return len(q.items), nil
+}
+
+func (q *SteerQueue) Drain() []string {
+	if q == nil {
+		return nil
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.items) == 0 {
+		return nil
+	}
+	out := make([]string, len(q.items))
+	copy(out, q.items)
+	q.items = nil
+	return out
+}
+
+func (q *SteerQueue) Len() int {
+	if q == nil {
+		return 0
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.items)
+}

--- a/internal/runtimecontrol/steer_queue.go
+++ b/internal/runtimecontrol/steer_queue.go
@@ -9,9 +9,10 @@ import (
 const defaultSteerQueueLimit = 32
 
 type SteerQueue struct {
-	mu    sync.Mutex
-	limit int
-	items []string
+	mu     sync.Mutex
+	limit  int
+	items  []string
+	closed bool
 }
 
 func NewSteerQueue(limit int) *SteerQueue {
@@ -31,11 +32,24 @@ func (q *SteerQueue) Push(input string) (int, error) {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	if q.closed {
+		return len(q.items), fmt.Errorf("steer queue is closed")
+	}
 	if q.limit > 0 && len(q.items) >= q.limit {
 		return len(q.items), fmt.Errorf("steer queue is full")
 	}
 	q.items = append(q.items, input)
 	return len(q.items), nil
+}
+
+func (q *SteerQueue) Close() {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.closed = true
+	q.items = nil
 }
 
 func (q *SteerQueue) Drain() []string {

--- a/internal/runtimecontrol/steer_queue.go
+++ b/internal/runtimecontrol/steer_queue.go
@@ -52,6 +52,22 @@ func (q *SteerQueue) Close() {
 	q.items = nil
 }
 
+func (q *SteerQueue) DrainAndClose() []string {
+	if q == nil {
+		return nil
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.closed = true
+	if len(q.items) == 0 {
+		return nil
+	}
+	out := make([]string, len(q.items))
+	copy(out, q.items)
+	q.items = nil
+	return out
+}
+
 func (q *SteerQueue) Drain() []string {
 	if q == nil {
 		return nil


### PR DESCRIPTION
## Summary

- Add runtime control for active runs, /stop, and in-flight steer input.
- Emit turn, stop, and steer events from the agent/runtime paths.
- Wire stop and steer through Console local, CLI chat, Telegram, Slack, Lark, and LINE runtimes.
- Add Console HTTP stop endpoints for POST /tasks/{id}/stop and POST /topics/{topic_id}/stop.
- Keep Slack stop/steer scoped to the thread to avoid cross-thread interference.
- Document the implementation plan and remaining validation checklist.

## Impact

Users can stop a running task without exiting the runtime, and normal input sent while a task is running is queued as steer input for that same turn. Console also gets explicit HTTP stop endpoints instead of requiring the UI to fake a slash command.

## Validation

- go test ./...
