### PR TITLE
feat(agent): add channel-based multi-agent collaboration

### DIFF
--- a/agent/engine_helpers.go
+++ b/agent/engine_helpers.go
@@ -154,7 +154,7 @@ func toolArgsSummary(toolName string, params map[string]any, opts LogOptions, de
 		if v, ok := params["path"].(string); ok && strings.TrimSpace(v) != "" {
 			out["path"] = truncateString(strings.TrimSpace(v), opts.MaxStringValueChars)
 		}
-	case "contacts_send":
+	case "contacts_send", "agent_send":
 		if v, ok := params["contact_id"].(string); ok && strings.TrimSpace(v) != "" {
 			out["contact_id"] = truncateString(strings.TrimSpace(v), opts.MaxStringValueChars)
 		}

--- a/agent/engine_helpers_test.go
+++ b/agent/engine_helpers_test.go
@@ -28,6 +28,29 @@ func TestToolArgsSummary_ContactsSendSafeSummary(t *testing.T) {
 	}
 }
 
+func TestToolArgsSummary_AgentSendSafeSummary(t *testing.T) {
+	opts := DefaultLogOptions()
+	params := map[string]any{
+		"contact_id":   "tg:@smith_bot",
+		"content_type": "application/json",
+		"message_text": "private handoff should not be logged",
+	}
+
+	got := toolArgsSummary("agent_send", params, opts, false)
+	if got == nil {
+		t.Fatal("summary should not be nil")
+	}
+	if got["contact_id"] != "tg:@smith_bot" {
+		t.Fatalf("unexpected contact_id summary: %#v", got["contact_id"])
+	}
+	if v, ok := got["has_message_text"].(bool); !ok || !v {
+		t.Fatalf("expected has_message_text=true, got %#v", got["has_message_text"])
+	}
+	if _, exists := got["message_text"]; exists {
+		t.Fatal("must not log raw message_text")
+	}
+}
+
 func TestToolArgsSummary_URLFetchDetailsOnlyInDebug(t *testing.T) {
 	opts := DefaultLogOptions()
 	params := map[string]any{

--- a/agent/engine_hooks_test.go
+++ b/agent/engine_hooks_test.go
@@ -202,6 +202,87 @@ func TestRun_ReplaysProviderAssistantMessagesForToolCalls(t *testing.T) {
 	}
 }
 
+func TestRun_BashTerminationCommandStopsTask(t *testing.T) {
+	for _, command := range []string{
+		"echo end",
+		"echo final",
+		"echo stop",
+		"  echo final\n",
+	} {
+		t.Run(command, func(t *testing.T) {
+			calls := 0
+			client := newMockClient(llm.Result{ToolCalls: []llm.ToolCall{{
+				ID:        "bash-stop",
+				Name:      "bash",
+				Arguments: map[string]any{"cmd": command},
+			}}})
+			registry := tools.NewRegistry()
+			registry.Register(&countingTool{name: "bash", result: "ok", count: &calls})
+			engine := New(client, registry, baseCfg(), DefaultPromptSpec())
+
+			final, _, err := engine.Run(context.Background(), "stop through bash", RunOptions{})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if final == nil || final.Output != "" {
+				t.Fatalf("final = %#v, want empty successful final", final)
+			}
+			if calls != 1 {
+				t.Fatalf("bash calls = %d, want 1", calls)
+			}
+			if got := len(client.allCalls()); got != 1 {
+				t.Fatalf("LLM calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestRun_BashTerminationCommandMustBeExactAndSuccessful(t *testing.T) {
+	t.Run("near miss", func(t *testing.T) {
+		client := newMockClient(
+			llm.Result{ToolCalls: []llm.ToolCall{{
+				ID:        "bash-near-miss",
+				Name:      "bash",
+				Arguments: map[string]any{"cmd": "echo final answer"},
+			}}},
+			finalResponse("continued"),
+		)
+		registry := tools.NewRegistry()
+		registry.Register(&mockTool{name: "bash", result: "ok"})
+		engine := New(client, registry, baseCfg(), DefaultPromptSpec())
+
+		final, _, err := engine.Run(context.Background(), "do not stop", RunOptions{})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if final == nil || final.Output != "continued" {
+			t.Fatalf("final = %#v, want continued", final)
+		}
+	})
+
+	t.Run("failed command", func(t *testing.T) {
+		client := newMockClient(
+			llm.Result{ToolCalls: []llm.ToolCall{{
+				ID:        "bash-failed-stop",
+				Name:      "bash",
+				Arguments: map[string]any{"cmd": "echo stop"},
+			}}},
+			finalResponse("continued"),
+		)
+		registry := tools.NewRegistry()
+		registry.Register(&mockTool{name: "bash", err: fmt.Errorf("bash failed")})
+		engine := New(client, registry, baseCfg(), DefaultPromptSpec())
+
+		final, _, err := engine.Run(context.Background(), "failed stop", RunOptions{})
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if final == nil || final.Output != "continued" {
+			t.Fatalf("final = %#v, want continued", final)
+		}
+	})
+}
+
 // ============================================================
 // Tests for Option functions and Engine field assignments
 // ============================================================

--- a/agent/engine_loop.go
+++ b/agent/engine_loop.go
@@ -381,6 +381,7 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (final *Final
 			type toolExecItem struct {
 				tc          ToolCall
 				toolNameKey string
+				terminates  bool
 				skip        bool
 				observation string
 				err         error
@@ -396,7 +397,12 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (final *Final
 			for i := range toolCalls {
 				tc := toolCalls[i]
 				toolNameKey := normalizedToolName(tc.Name)
-				items[i] = toolExecItem{tc: tc, toolNameKey: toolNameKey, stepStart: time.Now()}
+				items[i] = toolExecItem{
+					tc:          tc,
+					toolNameKey: toolNameKey,
+					terminates:  isBashTerminationCall(tc),
+					stepStart:   time.Now(),
+				}
 
 				debugMode := toolLog.Enabled(ctx, slog.LevelDebug)
 				fields := []any{"step", step, "tool", tc.Name, "args", toolArgsSummary(tc.Name, tc.Params, e.logOpts, debugMode)}
@@ -487,6 +493,10 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (final *Final
 					if items[i].skip {
 						continue
 					}
+					if items[i].terminates {
+						parallelBatch = false
+						break
+					}
 					runnableCount++
 					tool, ok := e.registry.Get(items[i].tc.Name)
 					capability, safe := tool.(tools.ParallelSafe)
@@ -540,6 +550,10 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (final *Final
 					item.executed = true
 					item.duration = time.Since(item.stepStart)
 					if item.err == nil {
+						if item.terminates {
+							items = items[:i+1]
+							break
+						}
 						if tool, ok := e.registry.Get(item.tc.Name); ok {
 							if stopper, ok := tool.(interface{ StopAfterSuccess() bool }); ok && stopper.StopAfterSuccess() {
 								items = items[:i+1]
@@ -664,6 +678,9 @@ func (e *Engine) runLoop(ctx context.Context, st *engineLoopState) (final *Final
 				})
 
 				if item.err == nil {
+					if item.terminates {
+						earlyStop = true
+					}
 					if t, ok := e.registry.Get(tc.Name); ok {
 						if stopper, ok := t.(interface{ StopAfterSuccess() bool }); ok && stopper.StopAfterSuccess() {
 							earlyStop = true
@@ -952,6 +969,22 @@ func toolActivityID(step int, tc *ToolCall) string {
 
 func normalizedToolName(name string) string {
 	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func isBashTerminationCall(call ToolCall) bool {
+	if normalizedToolName(call.Name) != "bash" {
+		return false
+	}
+	command, ok := call.Params["cmd"].(string)
+	if !ok {
+		return false
+	}
+	switch strings.TrimSpace(command) {
+	case "echo end", "echo final", "echo stop":
+		return true
+	default:
+		return false
+	}
 }
 
 func toolEventStatus(err error) string {

--- a/agent/prompt_template_test.go
+++ b/agent/prompt_template_test.go
@@ -66,6 +66,23 @@ func TestBuildSystemPrompt_DefaultIncludesSelfObservationBlock(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPrompt_DefaultIncludesAgentHandoffRules(t *testing.T) {
+	prompt := BuildSystemPrompt(nil, DefaultPromptSpec())
+
+	for _, want := range []string{
+		"## Agent Handoff",
+		"Only call `agent_send`",
+		"explicitly referenced in the current task",
+		"exact `contact_id`",
+		"Do not discover or choose another Agent",
+		"asynchronous",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q: %s", want, prompt)
+		}
+	}
+}
+
 func TestBuildSystemPrompt_FinalOnlyResponseOmitsPlanAndResponseRules(t *testing.T) {
 	reg := tools.NewRegistry()
 	reg.Register(&mockTool{name: "plan_create"})

--- a/agent/prompts/system.md
+++ b/agent/prompts/system.md
@@ -36,6 +36,7 @@ ENDIF
 ## Reference Format
 
 ### People Reference Format
+- You can find contacts at `${file_state_dir}/contacts/ACTIVE.md` or `${file_state_dir}/contacts/INACTIVE.md`.
 - Use canonical reference Markdown-like syntax: `[name](protocol:id)` for internal references to people, person, or agents.
 - Example references: `[John Wick](tg:@johnwick)`, `[Alice](aqua:123Dfjvjkdkd000s)`.
 
@@ -48,6 +49,13 @@ ENDIF
 - Only use the reference in internal storage or files, like memory, cron, HEARTBEAT files, etc.
 - `protocol` is extensible; not a fixed protocol list.
 - By default, only use the `name` or `id` in daily conversation expression.
+
+## Agent Handoff
+
+- Only call `agent_send` for an Agent explicitly referenced in the current task. Do not discover or choose another Agent on your own.
+- Pass the exact `contact_id` from that reference. A `[name](protocol:id)` reference requires the same `protocol:id`; do not replace it with another Channel.
+- Include enough context in `message_text` for the next Agent to continue without shared history.
+- Handoff is asynchronous. Do not wait for a remote task result.
 
 ## Additional Policies
 {{if .Blocks}}

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -160,7 +160,7 @@ logging:
   include_thoughts: true
   # If true, logs tool_call parameters (redacted and truncated).
   include_tool_params: true
-  # Even if include_tool_params=false, logs a small per-tool args summary (for example url_fetch.url, web_search.q, contacts_send.contact_id).
+  # Even if include_tool_params=false, logs a small per-tool args summary (for example url_fetch.url, web_search.q, contacts_send/agent_send.contact_id).
   # For bash, the full command is only logged when include_tool_params=true.
   # If true, logs loaded SKILL.md contents (truncated).
   include_skill_contents: false
@@ -454,6 +454,12 @@ memory:
 bus:
   # In-process bus (M1).
   max_inflight: 1024
+
+# Platform identities allowed to start Agent pairing in a private chat.
+# Telegram usernames must already exist in Contacts.
+admins:
+  - tg:@admin
+  - slack:T123:U234
 
 # Contacts business state (proactive sharing profiles/candidates/audit).
 contacts:

--- a/cmd/mistermorph/consolecmd/runtime_mount_test.go
+++ b/cmd/mistermorph/consolecmd/runtime_mount_test.go
@@ -143,6 +143,8 @@ func TestConsoleRuntimeMountExposesConsoleOwnedSettings(t *testing.T) {
 		{method: http.MethodDelete, path: "/runtime/auth/pro/login/start"},
 		{method: http.MethodDelete, path: "/runtime/auth/pro/login/poll"},
 		{method: http.MethodDelete, path: "/runtime/auth/pro/logout"},
+		{method: http.MethodDelete, path: "/runtime/setup/integrity"},
+		{method: http.MethodDelete, path: "/runtime/setup/file?key=config"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/mistermorph/consolecmd/serve.go
+++ b/cmd/mistermorph/consolecmd/serve.go
@@ -557,6 +557,8 @@ func (s *server) handler() http.Handler {
 		register("/settings/console", s.handleConsoleSettings)
 		register("/settings/auto-update", s.handleAutoUpdateSettings)
 		register("/settings/auto-update/check", s.handleAutoUpdateCheck)
+		register("/setup/integrity", s.handleSetupIntegrity)
+		register("/setup/file", s.handleSetupRepairFile)
 	}
 
 	mux.HandleFunc("/health", s.handleHealth)
@@ -567,8 +569,6 @@ func (s *server) handler() http.Handler {
 	mux.HandleFunc(apiPrefix+"/auth/me", s.withAuth(s.handleAuthMe))
 	registerConsoleOwnedSettings(mux, apiPrefix, s.withAuth)
 	mux.HandleFunc(apiPrefix+"/endpoints", s.withAuth(s.handleEndpoints))
-	mux.HandleFunc(apiPrefix+"/setup/integrity", s.withAuth(s.handleSetupIntegrity))
-	mux.HandleFunc(apiPrefix+"/setup/file", s.withAuth(s.handleSetupRepairFile))
 	mux.HandleFunc(apiPrefix+"/commands", s.withAuth(s.handleRuntimeCommands))
 	mux.HandleFunc(apiPrefix+"/settings/credits", s.withAuth(s.handleCredits))
 	mux.HandleFunc(apiPrefix+"/proxy", s.withAuth(s.handleProxy))

--- a/contacts/bus_observe.go
+++ b/contacts/bus_observe.go
@@ -98,9 +98,13 @@ func (s *Service) observeTelegramInboundBusMessage(ctx context.Context, msg busr
 
 	candidates := make([]observedContactCandidate, 0, len(msg.Extensions.MentionUsers)+1)
 	if senderContactID := telegramContactIDFromUser(fromUsername, fromUserID); senderContactID != "" {
+		kind := KindHuman
+		if msg.Extensions.FromIsAgent {
+			kind = KindAgent
+		}
 		candidate := observedContactCandidate{
 			PrimaryContactID: senderContactID,
-			Kind:             KindHuman,
+			Kind:             kind,
 			Channel:          ChannelTelegram,
 			Nickname:         nickname,
 			TGUsername:       fromUsername,
@@ -153,9 +157,13 @@ func (s *Service) observeSlackInboundBusMessage(ctx context.Context, msg busrunt
 
 	candidates := make([]observedContactCandidate, 0, len(msg.Extensions.MentionUsers)+1)
 	if senderContactID := slackContactIDFromUser(teamID, fromUserID); senderContactID != "" {
+		kind := KindHuman
+		if msg.Extensions.FromIsAgent {
+			kind = KindAgent
+		}
 		candidate := observedContactCandidate{
 			PrimaryContactID: senderContactID,
-			Kind:             KindHuman,
+			Kind:             kind,
 			Channel:          ChannelSlack,
 			Nickname:         nickname,
 			SlackTeamID:      teamID,
@@ -364,19 +372,14 @@ func (s *Service) upsertObservedCandidate(ctx context.Context, candidate observe
 
 	lastInteraction := now.UTC()
 	if found {
-		existing.Kind = candidate.Kind
+		if existing.Kind != KindAgent || candidate.Kind == KindAgent {
+			existing.Kind = candidate.Kind
+		}
 		existing.Channel = strings.TrimSpace(candidate.Channel)
 		if nickname := strings.TrimSpace(candidate.Nickname); nickname != "" {
 			replaceNickname := existing.Channel != ChannelTelegram
 			if !replaceNickname {
-				currentNickname := strings.TrimSpace(existing.ContactNickname)
-				currentUsername := normalizeTelegramUsername(currentNickname)
-				existingUsername := normalizeTelegramUsername(existing.TGUsername)
-				observedUsername := normalizeTelegramUsername(candidate.TGUsername)
-				replaceNickname = currentNickname == "" ||
-					currentNickname == "Unnamed User" ||
-					existingUsername != "" && strings.EqualFold(currentUsername, existingUsername) ||
-					observedUsername != "" && strings.EqualFold(currentUsername, observedUsername)
+				replaceNickname = shouldReplaceTelegramNickname(existing.ContactNickname, existing.TGUsername, candidate.TGUsername)
 			}
 			if replaceNickname {
 				existing.ContactNickname = nickname

--- a/contacts/bus_observe_test.go
+++ b/contacts/bus_observe_test.go
@@ -78,6 +78,100 @@ func TestObserveInboundBusMessage_TelegramSenderAndMention(t *testing.T) {
 	}
 }
 
+func TestObserveInboundBusMessage_AgentSenderAndKindPreservation(t *testing.T) {
+	tests := []struct {
+		name         string
+		contactID    string
+		existing     *Contact
+		message      busruntime.BusMessage
+		wantNickname string
+	}{
+		{
+			name:      "telegram agent sender",
+			contactID: "tg:@smith_bot",
+			message: busruntime.BusMessage{
+				Direction:       busruntime.DirectionInbound,
+				Channel:         busruntime.ChannelTelegram,
+				ConversationKey: "tg:-100500",
+				Extensions: busruntime.MessageExtensions{
+					ChatType:        "supergroup",
+					FromUserID:      77,
+					FromUsername:    "smith_bot",
+					FromDisplayName: "Smith",
+					FromIsAgent:     true,
+				},
+			},
+			wantNickname: "Smith",
+		},
+		{
+			name:      "slack agent sender",
+			contactID: "slack:T111:U777",
+			message: busruntime.BusMessage{
+				Direction:       busruntime.DirectionInbound,
+				Channel:         busruntime.ChannelSlack,
+				ConversationKey: "slack:T111:C222",
+				Extensions: busruntime.MessageExtensions{
+					ChatType:        "channel",
+					FromUserRef:     "U777",
+					FromDisplayName: "Smith",
+					FromIsAgent:     true,
+				},
+			},
+			wantNickname: "Smith",
+		},
+		{
+			name:      "human observation does not downgrade agent",
+			contactID: "tg:@smith_bot",
+			existing: &Contact{
+				ContactID:       "tg:@smith_bot",
+				Kind:            KindAgent,
+				Channel:         ChannelTelegram,
+				ContactNickname: "Smith",
+				TGUsername:      "smith_bot",
+			},
+			message: busruntime.BusMessage{
+				Direction:       busruntime.DirectionInbound,
+				Channel:         busruntime.ChannelTelegram,
+				ConversationKey: "tg:-100500",
+				Extensions: busruntime.MessageExtensions{
+					ChatType:     "supergroup",
+					MentionUsers: []string{"smith_bot"},
+				},
+			},
+			wantNickname: "Smith",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			svc := NewService(NewFileStore(t.TempDir()))
+			now := time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)
+			if tt.existing != nil {
+				if _, err := svc.UpsertContact(ctx, *tt.existing, now.Add(-time.Hour)); err != nil {
+					t.Fatalf("UpsertContact(existing) error = %v", err)
+				}
+			}
+			if err := svc.ObserveInboundBusMessage(ctx, tt.message, now); err != nil {
+				t.Fatalf("ObserveInboundBusMessage() error = %v", err)
+			}
+			contact, ok, err := svc.GetContact(ctx, tt.contactID)
+			if err != nil {
+				t.Fatalf("GetContact() error = %v", err)
+			}
+			if !ok {
+				t.Fatal("GetContact() expected ok=true")
+			}
+			if contact.Kind != KindAgent {
+				t.Fatalf("kind = %q, want %q", contact.Kind, KindAgent)
+			}
+			if contact.ContactNickname != tt.wantNickname {
+				t.Fatalf("nickname = %q, want %q", contact.ContactNickname, tt.wantNickname)
+			}
+		})
+	}
+}
+
 func TestObserveInboundBusMessage_TelegramNicknameMerge(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/contacts/file_store.go
+++ b/contacts/file_store.go
@@ -330,6 +330,9 @@ func (s *FileStore) PutContact(ctx context.Context, contact Contact) error {
 		if err != nil {
 			return err
 		}
+		if !contact.Paired && (hasPairedContactID(active, contact.ContactID) || hasPairedContactID(inactive, contact.ContactID)) {
+			contact.Paired = true
+		}
 
 		targetStatus := StatusActive
 		if hasContactID(inactive, contact.ContactID) && !contact.Paired {
@@ -1224,6 +1227,19 @@ func hasContactID(items []Contact, contactID string) bool {
 	}
 	for _, item := range items {
 		if strings.TrimSpace(item.ContactID) == contactID {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPairedContactID(items []Contact, contactID string) bool {
+	contactID = strings.TrimSpace(contactID)
+	if contactID == "" {
+		return false
+	}
+	for _, item := range items {
+		if strings.TrimSpace(item.ContactID) == contactID && item.Paired {
 			return true
 		}
 	}

--- a/contacts/file_store.go
+++ b/contacts/file_store.go
@@ -332,7 +332,7 @@ func (s *FileStore) PutContact(ctx context.Context, contact Contact) error {
 		}
 
 		targetStatus := StatusActive
-		if hasContactID(inactive, contact.ContactID) {
+		if hasContactID(inactive, contact.ContactID) && !contact.Paired {
 			targetStatus = StatusInactive
 		}
 
@@ -572,6 +572,7 @@ type contactProfileSection struct {
 	ContactID         string   `yaml:"contact_id"`
 	Nickname          string   `yaml:"nickname"`
 	Kind              string   `yaml:"kind"`
+	Paired            bool     `yaml:"paired,omitempty"`
 	Channel           string   `yaml:"channel"`
 	TGUsername        string   `yaml:"tg_username"`
 	TGPrivateChatID   string   `yaml:"tg_private_chat_id"`
@@ -892,6 +893,7 @@ func contactFromProfileSection(title string, profile contactProfileSection, stat
 	contact := Contact{
 		ContactID:        strings.TrimSpace(profile.ContactID),
 		ContactNickname:  strings.TrimSpace(profile.Nickname),
+		Paired:           profile.Paired,
 		Channel:          strings.ToLower(strings.TrimSpace(profile.Channel)),
 		TGUsername:       normalizeTelegramUsername(profile.TGUsername),
 		LineUserID:       refid.NormalizeLineID(profile.LineUserID),
@@ -978,6 +980,7 @@ func profileSectionFromContact(contact Contact) (contactProfileSection, string) 
 		ContactID:        strings.TrimSpace(contact.ContactID),
 		Nickname:         strings.TrimSpace(contact.ContactNickname),
 		Kind:             string(normalizeKind(contact.Kind)),
+		Paired:           contact.Paired,
 		Channel:          strings.TrimSpace(contact.Channel),
 		TGUsername:       normalizeTelegramUsername(contact.TGUsername),
 		LineUserID:       refid.NormalizeLineID(contact.LineUserID),

--- a/contacts/invariants_test.go
+++ b/contacts/invariants_test.go
@@ -150,15 +150,15 @@ func TestSendDecisionResolvesTelegramUsernameToPrivateChatContact(t *testing.T) 
 	if sender.contact.ContactID != "tg:777" {
 		t.Fatalf("sender contact mismatch: got %q want %q", sender.contact.ContactID, "tg:777")
 	}
-	if sender.decision.ContactID != "tg:777" {
-		t.Fatalf("sender decision contact_id mismatch: got %q want %q", sender.decision.ContactID, "tg:777")
+	if sender.decision.ContactID != "tg:@trinity" {
+		t.Fatalf("sender decision contact_id mismatch: got %q want %q", sender.decision.ContactID, "tg:@trinity")
 	}
 	if outcome.ContactID != "tg:777" {
 		t.Fatalf("outcome contact_id mismatch: got %q want %q", outcome.ContactID, "tg:777")
 	}
 }
 
-func TestSendDecisionTelegramUsernameWithoutPrivateChatIDNotFound(t *testing.T) {
+func TestSendDecisionTelegramUsernameWithoutPrivateChatID(t *testing.T) {
 	ctx := context.Background()
 	root := filepath.Join(t.TempDir(), "contacts")
 	store := NewFileStore(root)
@@ -177,21 +177,24 @@ func TestSendDecisionTelegramUsernameWithoutPrivateChatIDNotFound(t *testing.T) 
 
 	sender := &mockSender{accepted: true}
 	payload := base64.RawURLEncoding.EncodeToString([]byte("hello"))
-	_, err := svc.SendDecision(ctx, now, ShareDecision{
+	outcome, err := svc.SendDecision(ctx, now, ShareDecision{
 		ContactID:      "tg:@trinity",
 		ItemID:         "manual_item_3",
 		ContentType:    "application/json",
 		PayloadBase64:  payload,
 		IdempotencyKey: "manual:key3",
 	}, sender)
-	if err == nil {
-		t.Fatalf("SendDecision() expected contact not found error")
+	if err != nil {
+		t.Fatalf("SendDecision() error = %v", err)
 	}
-	if got := err.Error(); got != "contact not found: tg:@trinity" {
-		t.Fatalf("SendDecision() error mismatch: got %q want %q", got, "contact not found: tg:@trinity")
+	if sender.calls != 1 {
+		t.Fatalf("sender calls = %d, want 1", sender.calls)
 	}
-	if sender.calls != 0 {
-		t.Fatalf("sender should not be called, got %d", sender.calls)
+	if sender.decision.ContactID != "tg:@trinity" {
+		t.Fatalf("sender decision contact_id = %q, want %q", sender.decision.ContactID, "tg:@trinity")
+	}
+	if outcome.ContactID != "contact:trinity" {
+		t.Fatalf("outcome contact_id = %q, want %q", outcome.ContactID, "contact:trinity")
 	}
 }
 

--- a/contacts/paired_test.go
+++ b/contacts/paired_test.go
@@ -151,6 +151,39 @@ func TestFileStorePairedRoundTrip(t *testing.T) {
 	}
 }
 
+func TestFileStorePutContactPreservesPairedAfterStaleRead(t *testing.T) {
+	ctx := context.Background()
+	store := NewFileStore(filepath.Join(t.TempDir(), "contacts"))
+	observed := Contact{
+		ContactID:       "tg:@peer_bot",
+		Kind:            KindAgent,
+		Channel:         ChannelTelegram,
+		ContactNickname: "Peer",
+		TGUsername:      "peer_bot",
+		TGPrivateChatID: 2002,
+	}
+	if err := store.PutContact(ctx, observed); err != nil {
+		t.Fatalf("PutContact(initial) error = %v", err)
+	}
+
+	paired := observed
+	paired.Paired = true
+	if err := store.PutContact(ctx, paired); err != nil {
+		t.Fatalf("PutContact(paired) error = %v", err)
+	}
+	if err := store.PutContact(ctx, observed); err != nil {
+		t.Fatalf("PutContact(stale observation) error = %v", err)
+	}
+
+	got, ok, err := store.GetContact(ctx, observed.ContactID)
+	if err != nil {
+		t.Fatalf("GetContact() error = %v", err)
+	}
+	if !ok || !got.Paired {
+		t.Fatalf("stale observation cleared paired state: %#v, found=%v", got, ok)
+	}
+}
+
 func TestPairAgentReactivatesInactiveContact(t *testing.T) {
 	ctx := context.Background()
 	root := filepath.Join(t.TempDir(), "contacts")

--- a/contacts/paired_test.go
+++ b/contacts/paired_test.go
@@ -1,0 +1,202 @@
+package contacts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPairAgentIsOnlyStructuredPathThatCanGrantPaired(t *testing.T) {
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "contacts")
+	store := NewFileStore(root)
+	service := NewService(store)
+	now := time.Date(2026, 8, 17, 7, 0, 0, 0, time.UTC)
+
+	ordinary, err := service.UpsertContact(ctx, Contact{
+		ContactID:       "tg:@peer_bot",
+		Kind:            KindAgent,
+		Channel:         ChannelTelegram,
+		ContactNickname: "Peer",
+		TGUsername:      "peer_bot",
+		Paired:          true,
+	}, now)
+	if err != nil {
+		t.Fatalf("UpsertContact() error = %v", err)
+	}
+	if ordinary.Paired {
+		t.Fatal("ordinary UpsertContact() granted paired")
+	}
+
+	paired, err := service.PairAgent(ctx, Contact{
+		ContactID:       "tg:2002",
+		Kind:            KindAgent,
+		Channel:         ChannelTelegram,
+		ContactNickname: "Peer Bot",
+		TGUsername:      "peer_bot",
+		TGPrivateChatID: 2002,
+	}, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("PairAgent() error = %v", err)
+	}
+	if !paired.Paired || paired.Kind != KindAgent {
+		t.Fatalf("PairAgent() result = %#v", paired)
+	}
+	if paired.ContactID != "tg:@peer_bot" {
+		t.Fatalf("PairAgent() created a duplicate contact: got %q", paired.ContactID)
+	}
+	if paired.TGPrivateChatID != 2002 {
+		t.Fatalf("PairAgent() private chat id = %d, want 2002", paired.TGPrivateChatID)
+	}
+	if paired.ContactNickname != "Peer" {
+		t.Fatalf("PairAgent() overwrote manual nickname: got %q", paired.ContactNickname)
+	}
+
+	observed, err := service.UpsertContact(ctx, Contact{
+		ContactID:       "tg:@peer_bot",
+		Kind:            KindAgent,
+		Channel:         ChannelTelegram,
+		ContactNickname: "Peer",
+		TGUsername:      "peer_bot",
+		TGPrivateChatID: 2002,
+		Paired:          false,
+	}, now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("UpsertContact(after pair) error = %v", err)
+	}
+	if !observed.Paired {
+		t.Fatal("ordinary UpsertContact() cleared paired")
+	}
+}
+
+func TestPairAgentReplacesOnlyPlaceholderTelegramNickname(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		current  string
+		username string
+		want     string
+	}{
+		{name: "empty", current: "", username: "peer_bot", want: "Peer Bot"},
+		{name: "unnamed", current: "Unnamed User", username: "peer_bot", want: "Peer Bot"},
+		{name: "username", current: "peer_bot", username: "peer_bot", want: "Peer Bot"},
+		{name: "manual", current: "博士的助手", username: "peer_bot", want: "博士的助手"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := NewFileStore(filepath.Join(t.TempDir(), "contacts"))
+			service := NewService(store)
+			now := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
+			if _, err := service.UpsertContact(ctx, Contact{
+				ContactID:       "tg:@" + test.username,
+				Kind:            KindAgent,
+				Channel:         ChannelTelegram,
+				ContactNickname: test.current,
+				TGUsername:      test.username,
+			}, now); err != nil {
+				t.Fatalf("UpsertContact() error = %v", err)
+			}
+			paired, err := service.PairAgent(ctx, Contact{
+				ContactID:       "tg:2002",
+				Kind:            KindAgent,
+				Channel:         ChannelTelegram,
+				ContactNickname: "Peer Bot",
+				TGUsername:      test.username,
+				TGPrivateChatID: 2002,
+			}, now.Add(time.Minute))
+			if err != nil {
+				t.Fatalf("PairAgent() error = %v", err)
+			}
+			if paired.ContactNickname != test.want {
+				t.Fatalf("nickname = %q, want %q", paired.ContactNickname, test.want)
+			}
+		})
+	}
+}
+
+func TestFileStorePairedRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "contacts")
+	store := NewFileStore(root)
+
+	if err := store.PutContact(ctx, Contact{
+		ContactID:       "slack:T100:U200",
+		Kind:            KindAgent,
+		Channel:         ChannelSlack,
+		ContactNickname: "Peer",
+		SlackTeamID:     "T100",
+		SlackUserID:     "U200",
+		Paired:          true,
+	}); err != nil {
+		t.Fatalf("PutContact() error = %v", err)
+	}
+
+	got, ok, err := store.GetContact(ctx, "slack:T100:U200")
+	if err != nil {
+		t.Fatalf("GetContact() error = %v", err)
+	}
+	if !ok || !got.Paired {
+		t.Fatalf("GetContact() = %#v, %v", got, ok)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, "ACTIVE.md"))
+	if err != nil {
+		t.Fatalf("ReadFile(ACTIVE.md) error = %v", err)
+	}
+	if !strings.Contains(string(raw), "paired: true") {
+		t.Fatalf("ACTIVE.md missing paired state:\n%s", raw)
+	}
+}
+
+func TestPairAgentReactivatesInactiveContact(t *testing.T) {
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "contacts")
+	store := NewFileStore(root)
+	service := NewService(store)
+	base := time.Date(2026, 8, 17, 11, 0, 0, 0, time.UTC)
+	for i := 1; i <= maxActiveContacts+1; i++ {
+		lastInteraction := base.Add(time.Duration(i) * time.Minute)
+		if err := store.PutContact(ctx, Contact{
+			ContactID:         fmt.Sprintf("tg:%d", i),
+			Kind:              KindAgent,
+			Channel:           ChannelTelegram,
+			TGPrivateChatID:   int64(i),
+			LastInteractionAt: &lastInteraction,
+		}); err != nil {
+			t.Fatalf("PutContact(%d) error = %v", i, err)
+		}
+	}
+	if _, ok, err := store.GetContact(ctx, "tg:1"); err != nil || !ok {
+		t.Fatalf("GetContact(tg:1) = %v, %v", ok, err)
+	}
+
+	paired, err := service.PairAgent(ctx, Contact{
+		ContactID:       "tg:1",
+		Kind:            KindAgent,
+		Channel:         ChannelTelegram,
+		TGPrivateChatID: 1,
+	}, base.Add(3*time.Hour))
+	if err != nil {
+		t.Fatalf("PairAgent() error = %v", err)
+	}
+	if !paired.Paired {
+		t.Fatalf("PairAgent() = %#v", paired)
+	}
+	active, err := store.ListContacts(ctx, StatusActive)
+	if err != nil {
+		t.Fatalf("ListContacts(active) error = %v", err)
+	}
+	found := false
+	for _, contact := range active {
+		if contact.ContactID == "tg:1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("paired contact remained inactive")
+	}
+}

--- a/contacts/service.go
+++ b/contacts/service.go
@@ -91,10 +91,58 @@ func normalizeServiceOptions(opts ServiceOptions) ServiceOptions {
 }
 
 func (s *Service) UpsertContact(ctx context.Context, contact Contact, now time.Time) (Contact, error) {
+	return s.upsertContact(ctx, contact, now, false)
+}
+
+// PairAgent creates or updates an Agent contact and grants the paired state.
+// Ordinary contact observation uses UpsertContact and cannot grant or clear it.
+func (s *Service) PairAgent(ctx context.Context, contact Contact, now time.Time) (Contact, error) {
+	if s == nil || !s.ready() {
+		return Contact{}, fmt.Errorf("nil contacts service")
+	}
+	contact.Kind = KindAgent
+	contact.Paired = true
+	now = normalizeNow(now)
+	if contact.LastInteractionAt == nil {
+		contact.LastInteractionAt = &now
+	}
+	existing, found, err := s.findPairContact(ctx, contact)
+	if err != nil {
+		return Contact{}, err
+	}
+	if found {
+		contact.ContactID = existing.ContactID
+		replaceNickname := normalizeContactChannel(contact.Channel) == ChannelTelegram && shouldReplaceTelegramNickname(
+			existing.ContactNickname,
+			existing.TGUsername,
+			contact.TGUsername,
+		)
+		if strings.TrimSpace(existing.ContactNickname) != "" && !replaceNickname {
+			contact.ContactNickname = existing.ContactNickname
+		}
+	}
+	return s.upsertContact(ctx, contact, now, true)
+}
+
+func shouldReplaceTelegramNickname(currentNickname, existingUsername, observedUsername string) bool {
+	currentNickname = strings.TrimSpace(currentNickname)
+	currentUsername := normalizeTelegramUsername(currentNickname)
+	existingUsername = normalizeTelegramUsername(existingUsername)
+	observedUsername = normalizeTelegramUsername(observedUsername)
+	return currentNickname == "" ||
+		currentNickname == "Unnamed User" ||
+		existingUsername != "" && strings.EqualFold(currentUsername, existingUsername) ||
+		observedUsername != "" && strings.EqualFold(currentUsername, observedUsername)
+}
+
+func (s *Service) upsertContact(ctx context.Context, contact Contact, now time.Time, grantPaired bool) (Contact, error) {
 	if s == nil || !s.ready() {
 		return Contact{}, fmt.Errorf("nil contacts service")
 	}
 	now = normalizeNow(now)
+	if !grantPaired {
+		contact.Paired = false
+	}
 	if err := s.ensureStore.Ensure(ctx); err != nil {
 		return Contact{}, err
 	}
@@ -113,6 +161,11 @@ func (s *Service) UpsertContact(ctx context.Context, contact Contact, now time.T
 		return Contact{}, err
 	}
 	if ok {
+		if grantPaired {
+			contact.Paired = true
+		} else {
+			contact.Paired = existing.Paired
+		}
 		if input.Kind == "" {
 			contact.Kind = existing.Kind
 		}
@@ -133,6 +186,30 @@ func (s *Service) UpsertContact(ctx context.Context, contact Contact, now time.T
 		}
 		if len(contact.TGGroupChatIDs) == 0 && len(existing.TGGroupChatIDs) > 0 {
 			contact.TGGroupChatIDs = append([]int64(nil), existing.TGGroupChatIDs...)
+		}
+		if strings.TrimSpace(contact.LineUserID) == "" && strings.TrimSpace(existing.LineUserID) != "" {
+			contact.LineUserID = existing.LineUserID
+		}
+		if len(contact.LineChatIDs) == 0 && len(existing.LineChatIDs) > 0 {
+			contact.LineChatIDs = append([]string(nil), existing.LineChatIDs...)
+		}
+		if strings.TrimSpace(contact.LarkOpenID) == "" && strings.TrimSpace(existing.LarkOpenID) != "" {
+			contact.LarkOpenID = existing.LarkOpenID
+		}
+		if len(contact.LarkChatIDs) == 0 && len(existing.LarkChatIDs) > 0 {
+			contact.LarkChatIDs = append([]string(nil), existing.LarkChatIDs...)
+		}
+		if strings.TrimSpace(contact.SlackTeamID) == "" && strings.TrimSpace(existing.SlackTeamID) != "" {
+			contact.SlackTeamID = existing.SlackTeamID
+		}
+		if strings.TrimSpace(contact.SlackUserID) == "" && strings.TrimSpace(existing.SlackUserID) != "" {
+			contact.SlackUserID = existing.SlackUserID
+		}
+		if strings.TrimSpace(contact.SlackDMChannelID) == "" && strings.TrimSpace(existing.SlackDMChannelID) != "" {
+			contact.SlackDMChannelID = existing.SlackDMChannelID
+		}
+		if len(contact.SlackChannelIDs) == 0 && len(existing.SlackChannelIDs) > 0 {
+			contact.SlackChannelIDs = append([]string(nil), existing.SlackChannelIDs...)
 		}
 		if len(contact.TopicPreferences) == 0 && len(existing.TopicPreferences) > 0 {
 			contact.TopicPreferences = append([]string(nil), existing.TopicPreferences...)
@@ -158,6 +235,58 @@ func (s *Service) UpsertContact(ctx context.Context, contact Contact, now time.T
 		return Contact{}, err
 	}
 	return contact, nil
+}
+
+func (s *Service) findPairContact(ctx context.Context, candidate Contact) (Contact, bool, error) {
+	if id := strings.TrimSpace(candidate.ContactID); id != "" {
+		contact, ok, err := s.contactStore.GetContact(ctx, id)
+		if err != nil || ok {
+			return contact, ok, err
+		}
+	}
+	records, err := s.contactStore.ListContacts(ctx, "")
+	if err != nil {
+		return Contact{}, false, err
+	}
+	matches := make([]Contact, 0, 1)
+	for _, contact := range records {
+		if pairContactIdentityMatches(contact, candidate) {
+			matches = append(matches, contact)
+		}
+	}
+	if len(matches) == 0 {
+		return Contact{}, false, nil
+	}
+	if len(matches) == 1 {
+		return matches[0], true, nil
+	}
+	ids := make([]string, 0, len(matches))
+	for _, contact := range matches {
+		ids = append(ids, strings.TrimSpace(contact.ContactID))
+	}
+	sort.Strings(ids)
+	return Contact{}, false, fmt.Errorf("Agent identity matches multiple contacts: %s", strings.Join(ids, ", "))
+}
+
+func pairContactIdentityMatches(a, b Contact) bool {
+	if a.TGPrivateChatID > 0 && a.TGPrivateChatID == b.TGPrivateChatID {
+		return true
+	}
+	if aUsername, bUsername := normalizeTelegramUsername(a.TGUsername), normalizeTelegramUsername(b.TGUsername); aUsername != "" && strings.EqualFold(aUsername, bUsername) {
+		return true
+	}
+	if aTeam, bTeam := normalizeSlackID(a.SlackTeamID), normalizeSlackID(b.SlackTeamID); aTeam != "" && strings.EqualFold(aTeam, bTeam) {
+		if aUser, bUser := normalizeSlackID(a.SlackUserID), normalizeSlackID(b.SlackUserID); aUser != "" && strings.EqualFold(aUser, bUser) {
+			return true
+		}
+	}
+	if aUser, bUser := refid.NormalizeLineID(a.LineUserID), refid.NormalizeLineID(b.LineUserID); aUser != "" && aUser == bUser {
+		return true
+	}
+	if aOpenID, bOpenID := refid.NormalizeLarkID(a.LarkOpenID), refid.NormalizeLarkID(b.LarkOpenID); aOpenID != "" && aOpenID == bOpenID {
+		return true
+	}
+	return false
 }
 
 func (s *Service) ListContacts(ctx context.Context, status Status) ([]Contact, error) {
@@ -218,7 +347,6 @@ func (s *Service) SendDecision(ctx context.Context, now time.Time, decision Shar
 	if !ok {
 		return ShareOutcome{}, contactNotFoundError(decision.ContactID)
 	}
-	decision.ContactID = contact.ContactID
 	decision.ContentType = strings.TrimSpace(decision.ContentType)
 	if decision.ContentType == "" {
 		decision.ContentType = "application/json"
@@ -335,9 +463,6 @@ func (s *Service) resolveSendContact(ctx context.Context, contactID string) (Con
 	}
 	matches := make([]Contact, 0, 1)
 	for _, candidate := range records {
-		if candidate.TGPrivateChatID == 0 {
-			continue
-		}
 		if !strings.EqualFold(telegramUsernameOfContact(candidate), username) {
 			continue
 		}
@@ -354,7 +479,7 @@ func (s *Service) resolveSendContact(ctx context.Context, contactID string) (Con
 			ids = append(ids, strings.TrimSpace(candidate.ContactID))
 		}
 		sort.Strings(ids)
-		return Contact{}, false, fmt.Errorf("telegram username %q matches multiple contacts with private chat id: %s", username, strings.Join(ids, ", "))
+		return Contact{}, false, fmt.Errorf("telegram username %q matches multiple contacts: %s", username, strings.Join(ids, ", "))
 	}
 }
 
@@ -457,6 +582,23 @@ func ResolveDecisionChannel(contact Contact, decision ShareDecision) (string, er
 	if channel, hasHint, err := resolveChannelFromChatIDHint(decision.ChatID); hasHint || err != nil {
 		return channel, err
 	}
+	if channel := contactReferenceChannel(decision.ContactID); channel != "" {
+		available := false
+		switch channel {
+		case ChannelTelegram:
+			available = hasTelegramTarget(contact)
+		case ChannelSlack:
+			available = hasSlackTarget(contact)
+		case ChannelLine:
+			available = hasLineTarget(contact)
+		case ChannelLark:
+			available = hasLarkTarget(contact)
+		}
+		if !available {
+			return "", fmt.Errorf("explicit %s target is unavailable for contact_id=%s", channel, decision.ContactID)
+		}
+		return channel, nil
+	}
 	switch normalizeContactChannel(contact.Channel) {
 	case ChannelSlack:
 		if hasSlackTarget(contact) {
@@ -490,6 +632,25 @@ func ResolveDecisionChannel(contact Contact, decision ShareDecision) (string, er
 	return "", fmt.Errorf("unable to resolve delivery channel for contact_id=%s", contact.ContactID)
 }
 
+func contactReferenceChannel(contactID string) string {
+	protocol, _, ok := refid.Parse(strings.TrimSpace(contactID))
+	if !ok {
+		return ""
+	}
+	switch protocol {
+	case "tg":
+		return ChannelTelegram
+	case "slack":
+		return ChannelSlack
+	case "line", "line_user":
+		return ChannelLine
+	case "lark", "lark_user":
+		return ChannelLark
+	default:
+		return ""
+	}
+}
+
 func (s *Service) sendWithBusOutbox(ctx context.Context, now time.Time, contact Contact, decision ShareDecision, sender Sender) (ShareOutcome, bool, error) {
 	if s == nil || s.outboxStore == nil {
 		return ShareOutcome{}, false, fmt.Errorf("outbox store is required")
@@ -503,7 +664,7 @@ func (s *Service) sendWithBusOutbox(ctx context.Context, now time.Time, contact 
 	}
 
 	outcome := ShareOutcome{
-		ContactID:      decision.ContactID,
+		ContactID:      contact.ContactID,
 		PeerID:         decision.PeerID,
 		ItemID:         decision.ItemID,
 		IdempotencyKey: decision.IdempotencyKey,
@@ -528,7 +689,7 @@ func (s *Service) sendWithBusOutbox(ctx context.Context, now time.Time, contact 
 	baseRecord := BusOutboxRecord{
 		Channel:        channel,
 		IdempotencyKey: decision.IdempotencyKey,
-		ContactID:      decision.ContactID,
+		ContactID:      contact.ContactID,
 		PeerID:         decision.PeerID,
 		ItemID:         decision.ItemID,
 		ContentType:    decision.ContentType,
@@ -581,6 +742,9 @@ func (s *Service) sendWithBusOutbox(ctx context.Context, now time.Time, contact 
 }
 
 func hasTelegramTarget(contact Contact) bool {
+	if normalizeTelegramUsername(contact.TGUsername) != "" {
+		return true
+	}
 	if contact.TGPrivateChatID != 0 {
 		return true
 	}

--- a/contacts/service_channel_test.go
+++ b/contacts/service_channel_test.go
@@ -108,3 +108,44 @@ func TestResolveDecisionChannel_MissingProtocolHint(t *testing.T) {
 		t.Fatalf("ResolveDecisionChannel() error mismatch: got %q", err.Error())
 	}
 }
+
+func TestResolveDecisionChannel_ExplicitContactReferenceIsStrict(t *testing.T) {
+	contact := Contact{
+		ContactID:        "contact:smith",
+		Channel:          ChannelSlack,
+		TGUsername:       "smith_bot",
+		SlackTeamID:      "T111",
+		SlackUserID:      "U222",
+		SlackDMChannelID: "D333",
+	}
+
+	channel, err := ResolveDecisionChannel(contact, ShareDecision{ContactID: "tg:@smith_bot"})
+	if err != nil {
+		t.Fatalf("ResolveDecisionChannel() error = %v", err)
+	}
+	if channel != ChannelTelegram {
+		t.Fatalf("channel = %q, want %q", channel, ChannelTelegram)
+	}
+
+	contact.TGUsername = ""
+	if _, err := ResolveDecisionChannel(contact, ShareDecision{ContactID: "tg:@smith_bot"}); err == nil {
+		t.Fatal("ResolveDecisionChannel() expected unavailable explicit channel error")
+	}
+}
+
+func TestResolveDecisionChannel_ContactReferenceUsesDefaultRouting(t *testing.T) {
+	channel, err := ResolveDecisionChannel(Contact{
+		ContactID:        "contact:smith",
+		Channel:          ChannelSlack,
+		TGUsername:       "smith_bot",
+		SlackTeamID:      "T111",
+		SlackUserID:      "U222",
+		SlackDMChannelID: "D333",
+	}, ShareDecision{ContactID: "contact:smith"})
+	if err != nil {
+		t.Fatalf("ResolveDecisionChannel() error = %v", err)
+	}
+	if channel != ChannelSlack {
+		t.Fatalf("channel = %q, want %q", channel, ChannelSlack)
+	}
+}

--- a/contacts/types.go
+++ b/contacts/types.go
@@ -33,6 +33,7 @@ type Contact struct {
 	ContactID         string     `json:"contact_id"`
 	Synthetic         bool       `json:"-" yaml:"-"`
 	Kind              Kind       `json:"kind"`
+	Paired            bool       `json:"paired,omitempty"`
 	Channel           string     `json:"channel"`
 	ContactNickname   string     `json:"nickname,omitempty"`
 	TGUsername        string     `json:"tg_username,omitempty"`

--- a/docs/feat/feat_20260816_multi_agent_shared_context.md
+++ b/docs/feat/feat_20260816_multi_agent_shared_context.md
@@ -1,0 +1,406 @@
+---
+date: 2026-08-16
+updated: 2026-08-17
+title: 基于 Channel 的多 Agent 协作
+status: in_progress
+---
+
+# 基于 Channel 的多 Agent 协作
+
+## 1. 目标
+
+让运行在不同 endpoint 上的 Morph Agent 可以按人的安排依次完成任务，同时复用现有通信能力。
+
+第一版不建立团队、共享状态或远端任务协议。最小模型是：
+
+```text
+Contact(kind: agent)
++ Contact reference
++ agent_send
++ Channel message
+```
+
+人通过任务中的 Agent 引用指定当前负责人和后续接收者。当前 Agent 完成自己的部分后，使用 `agent_send` 向下一位 Agent 发送普通消息。目标 Agent 把它作为普通 Channel task 处理。
+
+这是一种异步消息交接。发送方只获得现有工具的发送结果，不等待目标 Agent 返回结构化结果。
+
+## 2. 术语
+
+本文统一使用 **Agent** 表示参与协作的 Morph 实例。
+
+Telegram 和 Slack 的 API 仍会使用 `Bot`、`bot_id`、`is_bot`、`bot_message` 和 Bot-to-Bot Communication 等平台术语。Morph 收到这类平台身份后，将其表示为 `Contact(kind: agent)`。平台术语不进入 Morph 的协作模型。
+
+把平台账号识别为 Agent 只是在 Contacts 中记录身份和地址，不会让它自动参与任务。任务仍然必须由人或当前 Agent 明确引用目标 Agent。
+
+## 3. 复用现有能力
+
+协作只需要解决四件事：
+
+| 问题 | 现有能力 |
+| --- | --- |
+| 对方是谁 | Contact 的 `contact_id` |
+| 如何联系 | Contact 中已有的 Channel 地址 |
+| 何时执行 | 消息中的第一个 Contact 引用 |
+| 需要知道什么 | 当前消息和可见的 Channel history |
+
+不新增 Agent Card、Agent store、coordinator、共享 Scope 或 Agent RPC。
+
+### 3.1 Contact
+
+继续使用现有 Contact 数据。协作只关心：
+
+```text
+contact_id
+kind: agent
+channel
+现有平台地址
+```
+
+不增加：
+
+- `capabilities`；
+- `accepted_input`；
+- `produced_output`；
+- 组织关系；
+- 自动选人规则。
+
+平台明确标记发送者为 Agent 账号时，Contact observation 使用 `kind: agent`。已经记录为 `kind: agent` 的 Contact 不能被后续普通观察降级为 `human`。
+
+`persona_brief` 等现有字段可以继续存在，但不参与协作寻址和任务分配。
+
+### 3.2 Contact 引用
+
+`@name` 是给人看的输入或显示形式，不是稳定身份。真正的身份继续使用 Morph 已有的引用格式：
+
+```text
+[name](protocol:id)
+```
+
+例如：
+
+```text
+[John](tg:@john_bot)
+[Smith](slack:T123:U456)
+```
+
+同一平台的原生 mention 在进入 Morph 后归一化为 Contact 引用。Console 中的 Contact 选择器也应写入同一种引用。这样可以引用位于其他 endpoint 或其他 Channel 的 Agent，不需要增加 Agent alias 表。
+
+原生 mention 只能引用当前平台的账号。跨 Channel 任务必须携带带 `contact_id` 的 Contact 引用，不能只依赖可能重名的 `@nickname`。
+
+寻址分为两种：
+
+- 已由平台 mention 或 Contact 选择器解析的 `@name` 只指定 Agent，内部可以表示为 `[name](contact:id)`。`agent_send` 按现有规则选择可用 Connection，允许使用其他可用 Channel；
+- `[name](protocol:id)` 明确指定 Channel 和地址。该地址不可用时直接返回错误，不能静默改用其他 Channel。
+
+任务明确要求使用某个 Channel 时，必须使用第二种形式。
+
+## 4. 执行规则
+
+### 4.1 当前负责人
+
+一条群聊协作消息中的第一个 Contact 引用是当前负责人。私聊的接收者已经由 Channel 确定，不再要求正文重复引用自己。
+
+```text
+这个方案由 [John](tg:@john_bot) 设计，完成后交给 [Smith](slack:T123:U456) 实施。
+```
+
+群聊 runtime 只检查第一项是否指向自己：
+
+- 指向自己：按普通 Channel task 执行；
+- 不指向自己：不触发 task；
+- 后续引用：只作为任务内容，不立即触发对应 Agent。
+
+runtime 不需要加载全部 Agent Contacts，也不需要判断每个引用是不是 Agent。任务作者负责把当前负责人放在第一项。需要并行执行时，分别发送多条消息。
+
+没有正文 mention 的普通消息继续使用现有 Channel trigger 规则。群聊正文包含 mention 时，无论发送者是人还是 Agent，都按第一项判断负责人；当前 Morph 排在后面时不会触发。私聊消息直接由接收方处理。
+
+### 4.2 Handoff
+
+当前 Agent 只有在任务明确引用了下一位 Agent 时，才进行 handoff。
+
+Handoff 使用专用工具：
+
+```text
+agent_send(contact_id, message_text)
+```
+
+`message_text` 是普通文本，不定义 JSON schema 或固定模板。它只需让目标 Agent 成为第一项引用，并包含足够继续执行的上下文。
+
+`agent_send` 与 `contacts_send` 使用相同的参数 schema、路由、批量发送、消息封装和返回结构。两者只在工具名称、说明和接收者限制上不同。
+
+运行时仅在 `contacts/ACTIVE.md` 至少存在一个 `kind: agent` 的 Contact 时注册 `agent_send`。每次执行仍须重新校验全部目标都来自 `ACTIVE.md` 且为 `kind: agent`。任一目标不符合时，整次调用失败，不发送部分消息。协议地址也必须映射到 active Agent，不能用任意 `tg:`、`slack:` 等地址绕过检查。
+
+`agent_send` 不增加配置项。`contacts_send` 继续使用原有注册规则；Telegram 和 Slack 群聊继续移除 `contacts_send`，但可以保留满足上述条件的 `agent_send`。
+
+示例：
+
+```text
+[Smith](slack:T123:U456)，设计已经完成。方案位于……，请按方案实施，重点检查……
+```
+
+发送结果直接沿用 `contacts_send` 的现有返回值，不增加 collaboration outcome。
+
+### 4.3 接收与继续
+
+目标 Agent 收到消息后，走现有 Channel task 流程，包括 history、memory、guard、approval、journal 和回复。
+
+完成后可以：
+
+- 在当前会话回复结果；
+- 把结果交给任务中明确引用的下一位 Agent；
+- 不再发送 handoff，结束任务。
+
+发送方不挂起原 task 等待目标 Agent，也不恢复远端 tool call。第一版不记录 call graph，不汇总远端 progress、approval 或 task status。
+
+### 4.4 上下文
+
+同一会话中的 Agent 可以读取现有 Channel history。不同 Channel 或不同私聊之间没有共同 history，目标 Agent 只能获得 handoff 正文中的上下文。
+
+因此第一版传递上下文，不建立共享上下文：
+
+- 不同步完整 history；
+- 不发送 reasoning、memory 或 journal；
+- 不创建共享可写文档；
+- 不处理 revision 或 merge；
+- 不同步 endpoint 配置和 Channel token。
+
+## 5. Channel 支持
+
+第一版只声明支持已经确认可以在 Agent 账号之间收发消息的 Telegram 和 Slack。其他 Channel 在确认平台能力后使用同一规则，不提前增加新的抽象。
+
+### 5.1 Telegram
+
+需要：
+
+- 在 BotFather 中开启平台所称的 Bot-to-Bot Communication Mode；
+- 允许 `tg:@username` 作为发送目标；
+- 保留入站消息中的 Agent user ID、username、display name 和 `is_bot`；
+- 群聊只让第一项 Contact 引用指向自己的 Agent 消息触发 task；
+- 私聊 Agent 消息不要求正文 mention；
+- 忽略自己发送的消息。
+
+### 5.2 Slack
+
+需要：
+
+- 接收来自其他 Agent 账号的 `bot_message`；
+- 通过 `bots.info` 把 sender bot ID 解析为可 mention 的 user ID，并缓存结果；
+- 允许 runtime 调用 `conversations.open` 和 `chat.postMessage` 建立并发送 Agent 私聊；
+- 继续忽略自己的 bot ID 和 bot user ID；
+- 保留 sender bot ID；
+- 按正文顺序提取 `<@USER_ID>`；
+- 群聊只让第一项 Contact 引用指向自己的 Agent 消息触发 task；
+- 私聊 Agent 消息不要求正文 mention。
+
+双方 Slack App 仍需位于有权读取和发送消息的同一 conversation。
+
+## 6. 循环保护
+
+任务分配和调用数量由人及 Agent 决定，不增加费用、并发、深度或时间预算。
+
+但 Agent 不能作为系统安全边界。运行时仍需保留最低限度的故障保护：
+
+- 忽略自己发送的消息；
+- 按平台 event 或 message ID 去重；
+- 群聊 Agent 消息只有在第一项引用指向自己时才触发；
+- 同一 conversation 的任意十分钟内，最多由 Agent 消息触发 8 次 task；
+- 继续使用现有 task timeout。
+
+`conversation` 直接使用现有 Channel history 的最小范围，不增加新的协作标识：
+
+- Telegram 使用 `chat_id + message_thread_id`，没有 topic 时只使用 `chat_id`；
+- Slack 使用 `team_id + channel_id + thread_ts`，没有 thread 时使用整个 channel；
+- 私聊使用对应的私聊 chat 或 channel；
+- endpoint 不进入 key，计数由各 runtime 本地维护。
+
+运行时只记录实际进入 task 队列的 Agent 消息。人工消息不计数，也不清除已有记录。第 9 条消息会被丢弃并写运行日志；最早记录超过十分钟后，新的 Agent 消息可以继续进入队列。切换 Channel、thread 或 Telegram topic 后进入另一个 conversation，使用独立的计数窗口。
+
+这个上限只用于中止同一 conversation 内的异常循环，不追踪跨 Channel 的完整任务链，也不建立 Scope、session ID 或持久化 collaboration state。
+
+## 7. Agent 配对
+
+静态 Channel allowlist 适合限制普通会话，但不适合要求用户手工复制两个 Agent 的平台 ID。Morph 使用双向配对为 Agent 私聊建立权限。
+
+可以发起配对的人由顶层配置声明：
+
+```yaml
+admins:
+  - tg:@owner
+  - slack:T123:U234
+```
+
+管理员可以使用平台稳定 ID。Telegram 也允许使用已有 Contact 的 `tg:@username` 引用；引用不存在于 Contacts 时不授权。`admins` 为空时，任何人都不能执行配对命令。管理员身份只允许在私聊中执行配对控制命令，不绕过普通消息的 Channel allowlist。
+
+配对不使用验证码。两个管理员须在五分钟内分别私聊自己的 Agent：
+
+```text
+Agent A 的管理员 -> Agent A: /pair @AgentB
+Agent B 的管理员 -> Agent B: /pair @AgentA
+```
+
+每个 runtime 为本地命令创建一个五分钟有效的临时意图，并向目标 Agent 发送带随机请求 ID 的内部 offer。两个方向的 Agent 身份和意图匹配后，双方确认配对。命令顺序不影响结果；重复的 offer 必须幂等。
+
+配对内部消息在普通 allowlist 判断前处理，但必须满足以下条件：
+
+- 消息来自平台确认的 Agent 账号；
+- 消息格式严格匹配 Morph 配对协议；
+- 本地存在对应的未过期配对意图，或者消息只用于保存等待本地管理员确认的 offer；
+- 内部消息不进入 LLM、普通 Channel history 或普通 task。
+
+配对完成后，每一侧创建或更新对方的 Contact：
+
+```yaml
+kind: agent
+paired: true
+```
+
+`paired` 是每个 Agent Contact 上的布尔值，不是数组。一个 Agent 与多个 Agent 配对时，会有多个分别标记 `paired: true` 的 Contact。平台返回的稳定身份和私聊地址写入 Contact；nickname 只在为空、`Unnamed User` 或等于平台 username 时自动补全，不能覆盖人工昵称。
+
+`paired` 是权限状态，只能由配对流程设置。普通 Contact observation 和面向 LLM 的写入路径不能设置或清除它。
+
+私聊授权规则为：
+
+```text
+普通消息：沿用 Channel allowlist
+管理员的 /pair：sender 位于 admins 时允许处理
+Agent 私聊：Channel allowlist 允许，或者 sender 对应 active、paired Agent Contact
+群聊：只使用原有 Channel allowlist 和 trigger 规则
+```
+
+配对协议本身不依赖 Channel。各 Channel 只负责解析管理员和目标 Agent 的平台身份、发送内部配对消息，以及把已认证的 sender 映射到 Contact。平台不支持 Agent-to-Agent 投递时，不能只靠该 Channel 完成配对。
+
+### 7.1 日志与 Journal
+
+运行日志记录配对状态转换，用于定位发送、匹配和超时问题：
+
+- `agent_pair_started`；
+- `agent_pair_offer_sent`；
+- `agent_pair_offer_received`；
+- `agent_pair_matched`；
+- `agent_pair_completed`；
+- `agent_pair_expired`；
+- `agent_pair_failed`。
+
+统一 Journal 使用 `contacts` domain，记录有业务意义的本地状态：
+
+- `agent_pair_requested`：本地管理员执行 `/pair`；
+- `agent_pair_completed`：Contact 已更新并标记为 paired；
+- `agent_pair_expired`：本地配对意图过期；
+- `agent_pair_failed`：已确认的本地配对流程终止失败。
+
+Journal payload 只保存 `pair_id`、管理员 ID 和双方 Agent ID；失败事件额外保存原因。Channel 和时间分别使用 Event Trace 与 Event Time，不在 payload 重复保存。没有本地管理员意图的远端 offer 只写运行日志，避免任意 Agent 污染 Journal。
+
+Contact 成功写入后即视为配对完成。此后的 Journal 写入失败只记录 `agent_pair_journal_error`，不能把已经生效的配对向调用方报告为失败。
+
+## 8. 权限
+
+- Channel token 继续只保存在对应 runtime；
+- Agent 只能使用本 runtime 已配置的 Channel sender；
+- Contacts 负责身份和寻址，不提供平台凭证；
+- 目标 Agent 的 guard 和 approval 不因发送者是 Agent 而放宽；
+- handoff 会进入对应 Channel history，按该 Channel 的权限和隐私范围处理；
+- 不自动把敏感内容发送到权限更宽的会话。
+- `admins` 和 `paired` 都属于权限状态，不能由 LLM 自行授予。
+
+## 9. 非目标
+
+第一版不做：
+
+- Agent 自主发现和选择未知协作者；
+- 固定团队、部门、职位或管理层级；
+- 按能力自动匹配 Agent；
+- 同步 Agent RPC；
+- 共享可写 Scope；
+- 自动合并多个 Agent 的结果；
+- 跨 Agent cancel、progress 或 approval 汇总；
+- 合并各 endpoint 的 memory、journal 或完整 history；
+- 为不支持 Agent-to-Agent 消息的 Channel 绕过平台限制建立中继服务。
+
+只有实际出现自主组织需求时，才考虑 capabilities、输入输出描述、可用性、费用和结构化 task protocol。
+
+## 10. 验收条件
+
+1. 人可以用 Contact 引用指定当前 Agent 和后续 Agent；
+2. 同一群聊消息只有第一项引用对应的 Agent 开始执行；私聊由接收方执行；
+3. Agent 只向当前任务明确引用的下一位 Agent handoff；
+4. handoff 通过仅允许 active Agent 的 `agent_send` 发送普通 Channel 消息；
+5. Telegram Agent 可以通过 username 收发消息；
+6. Slack Agent 可以接收其他 Agent 明确寻址的消息；
+7. 平台 Agent 身份在 Contacts 中表示为 `kind: agent`；
+8. 不建立共享 Scope、远端 task 或协作状态机；
+9. 自身消息、重复事件和异常循环不会反复触发 task；
+10. 没有正文 mention 的人类消息沿用现有 trigger；含 mention 的群聊消息只允许第一项指向的 Agent 触发。
+11. 只有 `admins` 中的平台身份，或能解析到现有 Contact 的 Telegram username 引用，可以在私聊中创建本地配对意图；
+12. 双方管理员在五分钟内分别执行 `/pair` 后，双方 Contact 都记录对方身份并标记 `paired: true`；
+13. 未配对、单向请求、过期请求和重放请求不能取得私聊权限；
+14. active、paired Agent 的私聊可以绕过 Channel allowlist，群聊不能；
+15. 配对控制消息不进入 LLM 或普通 task，配对状态转换有运行日志和 `contacts` Journal 事件。
+
+## 11. 参考
+
+- [Telegram Bot Features: Bot-to-Bot Communication](https://core.telegram.org/bots/features)
+- [Telegram Bot API](https://core.telegram.org/bots/api)
+- [Slack bot_message event](https://docs.slack.dev/reference/events/message/bot_message/)
+- [Slack app_mention event](https://docs.slack.dev/reference/events/app_mention/)
+- [Slack bots.info](https://docs.slack.dev/reference/methods/bots.info/)
+
+## 12. 实现路径与跟踪
+
+### Phase 1：通用身份与路由
+
+- [x] 在现有 Bus message extensions 中保留 `from_is_agent`，不增加新的消息类型。
+- [x] Telegram 和 Slack adapter 双向保留 Agent sender 标记。
+- [x] 平台明确标记的 Agent sender 写入 `Contact(kind: agent)`。
+- [x] 后续普通观察不能把已有 Agent Contact 降级为 human。
+- [x] `[name](protocol:id)` 使用指定 Channel；目标不可用时返回错误，不静默 fallback。
+- [x] `[name](contact:id)` 继续使用 Contact 的默认 Connection 选择规则。
+
+### Phase 2：Telegram
+
+- [x] Contact 发送流程支持 `tg:@username` 发送目标，供 `contacts_send` 和 `agent_send` 复用。
+- [x] 保留 Agent sender 的 user ID、username、display name 和 `is_bot`。
+- [x] 忽略当前 runtime 自己发送的消息。
+- [x] 群聊按正文或 caption 中的第一项 mention 判断当前负责人。
+- [x] 群聊 Agent 消息没有明确把当前 Agent 放在第一项时不触发 task；私聊不要求 mention。
+
+### Phase 3：Slack
+
+- [x] 接受其他 Agent 的 `bot_message`。
+- [x] 通过 `bots.info` 解析 sender user ID，并缓存 6 小时。
+- [x] 同时按 bot ID 和 bot user ID 忽略自身消息。
+- [x] 保留正文中 `<@USER_ID>` 的出现顺序。
+- [x] 群聊 Agent 消息没有明确把当前 Agent 放在第一项时不触发 task；私聊不要求 mention。
+
+### Phase 4：Handoff 与故障保护
+
+- [x] 新增与 `contacts_send` 参数一致的 `agent_send`，复用现有发送流程。
+- [x] 仅在存在 active Agent 时注册，并在发送前校验全部目标都是 active Agent。
+- [x] Telegram 和 Slack 群聊继续移除 `contacts_send`，允许注册 `agent_send`。
+- [x] system prompt 限制 Agent 只能通过 `agent_send` handoff 给当前任务明确引用的 Agent。
+- [x] handoff 保留引用中的准确 `contact_id`，并要求正文携带继续执行所需的上下文。
+- [x] Telegram topic 和 Slack thread 分别使用现有 history scope 计数。
+- [x] 同一 conversation 的滚动十分钟窗口最多允许 8 条 Agent 消息触发 task，第 9 条写日志并丢弃。
+- [x] 人工消息不参与 Agent 消息计数，也不重置窗口。
+
+### Phase 5：验证
+
+- [x] 覆盖 Bus adapter、Contacts observation、显式 Channel 路由和 Telegram username 发送测试。
+- [x] 覆盖 Telegram 与 Slack 第一项 mention、Agent history sender 和连续 handoff 限制测试。
+- [x] 覆盖 Slack `bot_message` 解析与 `bots.info` 测试。
+- [x] 覆盖 `agent_send` 参数复用、条件注册、active Agent 校验和批量拒绝测试。
+- [x] 运行 `go test ./...`，全仓回归通过。
+- [ ] 在真实 Telegram Bot-to-Bot Communication 环境验证一次 Agent A → Agent B handoff。
+- [ ] 在两个真实 Slack App 之间验证一次 Agent A → Agent B handoff。
+- [ ] 在真实 Channel 验证十分钟内第 9 条 Agent 消息被停止，窗口过期后可以恢复。
+
+### Phase 6：Agent 配对
+
+- [x] 解析顶层 `admins` 平台身份列表，并支持指向现有 Contact 的 Telegram username 引用。
+- [x] Contact 支持只由配对流程写入的 `paired` 状态。
+- [x] 实现五分钟有效、顺序无关且幂等的双向配对状态。
+- [x] Telegram 和 Slack 在 allowlist 前处理管理员 `/pair` 和内部配对消息。
+- [x] active、paired Agent 私聊绕过 Channel allowlist，群聊不绕过。
+- [x] 配对状态转换写入运行日志和 `contacts` Journal。
+- [x] 覆盖成功、单向、过期、重放、非管理员、群聊和 allowlist 回归测试。
+- [ ] 在真实 Telegram Bot-to-Bot Communication 环境验证一次双向配对。
+- [ ] 在两个真实 Slack App 之间验证一次双向配对。

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,9 +6,10 @@ This document describes the built-in and runtime-injected tool parameters curren
 
 ### 1) Tool classes in current code
 
-- `static` tools (fully constructable from config only):
-  - `read_file`, `write_file`, `bash`, `powershell`, `url_fetch`, `web_search`, `contacts_send`.
+- `static` tools (fully constructable from config and Contacts state):
+  - `read_file`, `write_file`, `bash`, `powershell`, `url_fetch`, `web_search`, `contacts_send`, `agent_send`.
   - `contacts_send` is static, but default exposure is limited to awareness runs when enabled, or to explicit `$contacts_send` opt-in.
+  - `agent_send` is exposed only while `contacts/ACTIVE.md` contains at least one `kind: agent` Contact.
 - `engine-scoped` tools:
   - `spawn`: registered when an agent engine is assembled for a run; depends on the current subtask runner, parent tool lookup, and default model.
   - `coder`: registered when an agent engine is assembled for a run; depends on the current subtask runner and starts the local Codex or Claude Code CLI.
@@ -320,6 +321,21 @@ Constraints:
 - `content_type` defaults to `application/json`, and must be `application/json` (parameters allowed, for example `application/json; charset=utf-8`).
 - If `message_base64` is provided, decoded payload must be envelope JSON containing `message_id` / `text` / `sent_at (RFC3339)` / `session_id (UUIDv7)`.
 - Sending to human contacts is allowed by default; actual deliverability still depends on sendable targets in contact profiles (private/group chat IDs).
+
+## `agent_send`
+
+Purpose: send a message to one or more active Agent contacts.
+
+Parameters and return values are identical to `contacts_send`. Both tools use the same parsing, routing, batch planning, message envelope, sender, and outbox implementation.
+
+Constraints:
+
+- Registered only when `contacts/ACTIVE.md` contains at least one `kind: agent` Contact. Availability is refreshed when preparing each task.
+- Every target is checked again immediately before planning the send. All targets must still be active and have `kind: agent`.
+- Protocol references such as `tg:@username` must resolve to an active Agent Contact. Arbitrary chat or user addresses cannot bypass the check.
+- A multi-target call is rejected before sending anything when any target is not an active Agent.
+- `agent_send` has no separate config key. Removing or deactivating all Agent Contacts makes it unavailable.
+- `contacts_send` registration and group-chat restrictions are unchanged.
 
 ## `plan_create`
 

--- a/internal/agentpair/admins.go
+++ b/internal/agentpair/admins.go
@@ -1,0 +1,94 @@
+package agentpair
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Admins contains platform identities and Contact references allowed to start Agent pairing.
+type Admins struct {
+	ids map[string]struct{}
+}
+
+func ParseAdmins(values []string) (Admins, error) {
+	admins := Admins{ids: make(map[string]struct{})}
+	for _, raw := range values {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		id, err := normalizeReference(raw)
+		if err != nil {
+			return Admins{}, fmt.Errorf("invalid admin %q: %w", strings.TrimSpace(raw), err)
+		}
+		admins.ids[referenceKey(id)] = struct{}{}
+	}
+	return admins, nil
+}
+
+func (a Admins) Contains(raw string) bool {
+	id, err := normalizeReference(raw)
+	if err != nil {
+		return false
+	}
+	_, ok := a.ids[referenceKey(id)]
+	return ok
+}
+
+func normalizeStableIdentity(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	lower := strings.ToLower(value)
+	switch {
+	case strings.HasPrefix(lower, "tg:"):
+		suffix := strings.TrimSpace(value[len("tg:"):])
+		id, err := strconv.ParseInt(suffix, 10, 64)
+		if err != nil || id <= 0 || suffix != strconv.FormatInt(id, 10) {
+			return "", fmt.Errorf("Telegram identity must be tg:<positive_user_id>")
+		}
+		return "tg:" + suffix, nil
+	case strings.HasPrefix(lower, "slack:"):
+		parts := strings.Split(value[len("slack:"):], ":")
+		if len(parts) != 2 {
+			return "", fmt.Errorf("Slack identity must be slack:<team_id>:<user_id>")
+		}
+		teamID := strings.ToUpper(strings.TrimSpace(parts[0]))
+		userID := strings.ToUpper(strings.TrimSpace(parts[1]))
+		if !isSlackStableID(teamID, 'T') || !(isSlackStableID(userID, 'U') || isSlackStableID(userID, 'W')) {
+			return "", fmt.Errorf("Slack identity must use stable team and user IDs")
+		}
+		return "slack:" + teamID + ":" + userID, nil
+	case strings.HasPrefix(lower, "line_user:"):
+		userID := strings.TrimSpace(value[len("line_user:"):])
+		if !isOpaqueStableID(userID) {
+			return "", fmt.Errorf("LINE identity must be line_user:<user_id>")
+		}
+		return "line_user:" + userID, nil
+	case strings.HasPrefix(lower, "lark_user:"):
+		openID := strings.TrimSpace(value[len("lark_user:"):])
+		if !isOpaqueStableID(openID) {
+			return "", fmt.Errorf("Lark identity must be lark_user:<open_id>")
+		}
+		return "lark_user:" + openID, nil
+	default:
+		return "", fmt.Errorf("unsupported platform identity")
+	}
+}
+
+func isSlackStableID(value string, prefix byte) bool {
+	if len(value) < 2 || value[0] != prefix {
+		return false
+	}
+	for i := 1; i < len(value); i++ {
+		c := value[i]
+		if c < 'A' || c > 'Z' {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isOpaqueStableID(value string) bool {
+	return value != "" && !strings.ContainsAny(value, " \t\r\n:()")
+}

--- a/internal/agentpair/admins_test.go
+++ b/internal/agentpair/admins_test.go
@@ -1,0 +1,53 @@
+package agentpair
+
+import "testing"
+
+func TestParseAdminsUsesStablePlatformIDs(t *testing.T) {
+	admins, err := ParseAdmins([]string{
+		" tg:1234 ",
+		"slack:T123:U234",
+		"line_user:U345",
+		"lark_user:ou_456",
+		"tg:1234",
+	})
+	if err != nil {
+		t.Fatalf("ParseAdmins() error = %v", err)
+	}
+	for _, id := range []string{"tg:1234", "slack:T123:U234", "line_user:U345", "lark_user:ou_456"} {
+		if !admins.Contains(id) {
+			t.Errorf("admins does not contain %q", id)
+		}
+	}
+	if admins.Contains("tg:9999") {
+		t.Fatal("admins contains an unconfigured id")
+	}
+}
+
+func TestParseAdminsAcceptsTelegramContactReference(t *testing.T) {
+	admins, err := ParseAdmins([]string{" tg:@BallCatCat "})
+	if err != nil {
+		t.Fatalf("ParseAdmins() error = %v", err)
+	}
+	if !admins.Contains("tg:@ballcatcat") {
+		t.Fatal("admins does not contain the Telegram contact reference")
+	}
+}
+
+func TestParseAdminsRejectsMalformedIDs(t *testing.T) {
+	for _, raw := range []string{
+		"tg:@",
+		"tg:@bad name",
+		"tg:-1001",
+		"slack:T123",
+		"slack:T123:C234",
+		"line:group-id",
+		"lark:chat-id",
+		"unknown:123",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParseAdmins([]string{raw}); err == nil {
+				t.Fatalf("ParseAdmins(%q) expected error", raw)
+			}
+		})
+	}
+}

--- a/internal/agentpair/manager.go
+++ b/internal/agentpair/manager.go
@@ -1,0 +1,563 @@
+package agentpair
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/quailyquaily/mistermorph/contacts"
+	"github.com/quailyquaily/mistermorph/internal/domainjournal"
+)
+
+const DefaultTTL = 5 * time.Minute
+
+type Status string
+
+const (
+	StatusWaiting       Status = "waiting"
+	StatusCompleted     Status = "completed"
+	StatusAlreadyPaired Status = "already_paired"
+)
+
+type Peer struct {
+	ID      string
+	Contact contacts.Contact
+}
+
+type SendFunc func(ctx context.Context, target Peer, body string) error
+
+type Options struct {
+	Context               context.Context
+	Self                  Peer
+	Admins                Admins
+	Contacts              *contacts.Service
+	JournalDir            string
+	JournalRotateMaxBytes int64
+	Logger                *slog.Logger
+	Now                   func() time.Time
+	TTL                   time.Duration
+	Send                  SendFunc
+}
+
+type localIntent struct {
+	PairID   string
+	AdminID  string
+	Target   Peer
+	Expires  time.Time
+	OfferRaw string
+}
+
+type remoteIntent struct {
+	Offer   pairOffer
+	Sender  Peer
+	Expires time.Time
+}
+
+type Manager struct {
+	self     Peer
+	admins   Admins
+	contacts *contacts.Service
+	journal  *domainjournal.Journal
+	logger   *slog.Logger
+	now      func() time.Time
+	ttl      time.Duration
+	send     SendFunc
+
+	mu     sync.Mutex
+	local  map[string]localIntent
+	remote map[string]remoteIntent
+}
+
+func New(opts Options) (*Manager, error) {
+	self, err := normalizePeer(opts.Self, true)
+	if err != nil {
+		return nil, fmt.Errorf("local Agent identity: %w", err)
+	}
+	if opts.Contacts == nil {
+		return nil, fmt.Errorf("contacts service is required")
+	}
+	if opts.Send == nil {
+		return nil, fmt.Errorf("Agent pair sender is required")
+	}
+	journal, err := domainjournal.New(domainjournal.JournalOptions{
+		Dir:            strings.TrimSpace(opts.JournalDir),
+		RotateMaxBytes: opts.JournalRotateMaxBytes,
+		SyncEachWrite:  true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open contacts journal: %w", err)
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	ttl := opts.TTL
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	manager := &Manager{
+		self:     self,
+		admins:   opts.Admins,
+		contacts: opts.Contacts,
+		journal:  journal,
+		logger:   logger,
+		now:      now,
+		ttl:      ttl,
+		send:     opts.Send,
+		local:    make(map[string]localIntent),
+		remote:   make(map[string]remoteIntent),
+	}
+	if opts.Context != nil {
+		go manager.runExpiry(opts.Context)
+	}
+	return manager, nil
+}
+
+func (m *Manager) Start(ctx context.Context, adminID string, target Peer, adminReference string) (Status, error) {
+	if m == nil {
+		return "", fmt.Errorf("Agent pair manager is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	now := m.currentTime()
+	m.expire(now)
+
+	normalizedAdmin, err := normalizeStableIdentity(adminID)
+	if err != nil {
+		m.logger.Warn("agent_pair_failed", "channel", channelForReference(m.self.ID), "admin_id", strings.TrimSpace(adminID), "reason", "unauthorized_admin")
+		return "", fmt.Errorf("not authorized to pair this Agent")
+	}
+	authorized, err := m.adminAuthorized(ctx, normalizedAdmin, adminReference)
+	if err != nil {
+		m.logger.Warn("agent_pair_failed", "channel", channelForReference(m.self.ID), "admin_id", normalizedAdmin, "reason", "admin_contact_lookup_failed", "error", err.Error())
+		return "", fmt.Errorf("resolve pairing administrator: %w", err)
+	}
+	if !authorized {
+		m.logger.Warn("agent_pair_failed", "channel", channelForReference(m.self.ID), "admin_id", normalizedAdmin, "reason", "unauthorized_admin")
+		return "", fmt.Errorf("not authorized to pair this Agent")
+	}
+	target, err = normalizePeer(target, false)
+	if err != nil {
+		m.logger.Warn("agent_pair_failed", "channel", channelForReference(m.self.ID), "admin_id", normalizedAdmin, "reason", "invalid_target", "error", err.Error())
+		return "", err
+	}
+	if channelForReference(target.ID) != channelForReference(m.self.ID) {
+		return "", fmt.Errorf("pair target must use the current Channel")
+	}
+	if peersMatch(target, m.self) {
+		m.logger.Warn("agent_pair_failed", "channel", channelForReference(m.self.ID), "admin_id", normalizedAdmin, "reason", "self_pair")
+		return "", fmt.Errorf("an Agent cannot pair with itself")
+	}
+	paired, err := m.IsPaired(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	if paired {
+		return StatusAlreadyPaired, nil
+	}
+
+	intent, created, err := m.prepareLocalIntent(normalizedAdmin, target, now)
+	if err != nil {
+		return "", err
+	}
+	m.logger.Info("agent_pair_started",
+		"pair_id", intent.PairID,
+		"channel", channelForReference(m.self.ID),
+		"admin_id", normalizedAdmin,
+		"local_agent_id", m.self.ID,
+		"peer_agent_id", target.ID,
+	)
+	if created {
+		if err := m.appendJournal("agent_pair_requested", intent, target.ID, "", now); err != nil {
+			m.removeLocal(intent.PairID)
+			m.logger.Warn("agent_pair_failed", "pair_id", intent.PairID, "channel", channelForReference(m.self.ID), "peer_agent_id", target.ID, "reason", "journal_append_failed", "error", err.Error())
+			return "", err
+		}
+	}
+	if err := m.send(ctx, target, intent.OfferRaw); err != nil {
+		m.removeLocal(intent.PairID)
+		m.logger.Warn("agent_pair_failed", "pair_id", intent.PairID, "channel", channelForReference(m.self.ID), "peer_agent_id", target.ID, "reason", "offer_send_failed", "error", err.Error())
+		_ = m.appendJournal("agent_pair_failed", intent, target.ID, "offer_send_failed", now)
+		return "", fmt.Errorf("send Agent pair offer: %w", err)
+	}
+	m.logger.Info("agent_pair_offer_sent", "pair_id", intent.PairID, "channel", channelForReference(m.self.ID), "peer_agent_id", target.ID)
+
+	completed, err := m.completeMatch(ctx, intent.PairID, now)
+	if err != nil {
+		return "", err
+	}
+	if completed {
+		return StatusCompleted, nil
+	}
+	return StatusWaiting, nil
+}
+
+func (m *Manager) adminAuthorized(ctx context.Context, stableID, authenticatedReference string) (bool, error) {
+	if m.admins.Contains(stableID) {
+		return true, nil
+	}
+	reference, err := normalizeReference(authenticatedReference)
+	if err != nil || !m.admins.Contains(reference) {
+		return false, nil
+	}
+
+	items, err := m.contacts.ListContacts(ctx, "")
+	if err != nil {
+		return false, err
+	}
+	for _, contact := range items {
+		if peerHasReference(Peer{Contact: contact}, reference) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *Manager) Handle(ctx context.Context, sender Peer, text string) (Status, bool, error) {
+	if m == nil {
+		return "", false, fmt.Errorf("Agent pair manager is nil")
+	}
+	offer, expiresAt, handled, err := decodeOffer(text)
+	if !handled || err != nil {
+		return "", handled, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	now := m.currentTime()
+	m.expire(now)
+	sender, err = normalizePeer(sender, true)
+	if err != nil {
+		return "", true, fmt.Errorf("authenticated Agent sender: %w", err)
+	}
+	if offer.From != sender.ID {
+		return "", true, fmt.Errorf("Agent pair sender does not match platform identity")
+	}
+	if !peerHasReference(m.self, offer.To) {
+		return "", true, fmt.Errorf("Agent pair offer targets another Agent")
+	}
+	if !expiresAt.After(now) {
+		m.logger.Info("agent_pair_expired", "pair_id", offer.PairID, "channel", channelForReference(m.self.ID), "peer_agent_id", sender.ID, "direction", "inbound")
+		return StatusWaiting, true, nil
+	}
+	m.logger.Info("agent_pair_offer_received", "pair_id", offer.PairID, "channel", channelForReference(m.self.ID), "peer_agent_id", sender.ID)
+
+	paired, err := m.IsPaired(ctx, sender)
+	if err != nil {
+		return "", true, err
+	}
+	if paired {
+		return StatusAlreadyPaired, true, nil
+	}
+	m.mu.Lock()
+	m.remote[sender.ID] = remoteIntent{Offer: offer, Sender: sender, Expires: expiresAt}
+	m.mu.Unlock()
+
+	localPairID := m.matchingLocalPairID(sender)
+	if localPairID == "" {
+		return StatusWaiting, true, nil
+	}
+	completed, err := m.completeMatch(ctx, localPairID, now)
+	if err != nil {
+		return "", true, err
+	}
+	if completed {
+		return StatusCompleted, true, nil
+	}
+	return StatusWaiting, true, nil
+}
+
+func (m *Manager) IsPaired(ctx context.Context, peer Peer) (bool, error) {
+	if m == nil || m.contacts == nil {
+		return false, fmt.Errorf("Agent pair manager is unavailable")
+	}
+	peer, err := normalizePeer(peer, false)
+	if err != nil {
+		return false, err
+	}
+	m.expire(m.currentTime())
+	items, err := m.contacts.ListContacts(ctx, contacts.StatusActive)
+	if err != nil {
+		return false, err
+	}
+	for _, contact := range items {
+		if contact.Kind != contacts.KindAgent || !contact.Paired {
+			continue
+		}
+		if peersMatch(peer, Peer{ID: contact.ContactID, Contact: contact}) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *Manager) prepareLocalIntent(adminID string, target Peer, now time.Time) (localIntent, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, intent := range m.local {
+		if intent.Expires.After(now) && peersMatch(intent.Target, target) {
+			return intent, false, nil
+		}
+	}
+	intent := localIntent{
+		PairID:  uuid.NewString(),
+		AdminID: adminID,
+		Target:  target,
+		Expires: now.Add(m.ttl),
+	}
+	offerRaw, err := encodeOffer(pairOffer{
+		PairID:    intent.PairID,
+		From:      m.self.ID,
+		To:        target.ID,
+		ExpiresAt: intent.Expires.Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return localIntent{}, false, err
+	}
+	intent.OfferRaw = offerRaw
+	m.local[intent.PairID] = intent
+	return intent, true, nil
+}
+
+func (m *Manager) completeMatch(ctx context.Context, localPairID string, now time.Time) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	intent, ok := m.local[localPairID]
+	if !ok || !intent.Expires.After(now) {
+		return false, nil
+	}
+	var remoteKey string
+	var remote remoteIntent
+	for key, candidate := range m.remote {
+		if candidate.Expires.After(now) && peersMatch(intent.Target, candidate.Sender) {
+			remoteKey = key
+			remote = candidate
+			break
+		}
+	}
+	if remoteKey == "" {
+		return false, nil
+	}
+	m.logger.Info("agent_pair_matched", "pair_id", intent.PairID, "remote_pair_id", remote.Offer.PairID, "channel", channelForReference(m.self.ID), "peer_agent_id", remote.Sender.ID)
+	contact := remote.Sender.Contact
+	pairedContact, err := m.contacts.PairAgent(ctx, contact, now)
+	if err != nil {
+		delete(m.local, localPairID)
+		delete(m.remote, remoteKey)
+		m.logger.Warn("agent_pair_failed", "pair_id", intent.PairID, "channel", channelForReference(m.self.ID), "peer_agent_id", remote.Sender.ID, "reason", "contact_update_failed", "error", err.Error())
+		_ = m.appendJournal("agent_pair_failed", intent, remote.Sender.ID, "contact_update_failed", now)
+		return false, err
+	}
+	delete(m.local, localPairID)
+	delete(m.remote, remoteKey)
+	if err := m.appendJournal("agent_pair_completed", intent, remote.Sender.ID, "", now); err != nil {
+		m.logger.Error("agent_pair_journal_error", "pair_id", intent.PairID, "event_type", "agent_pair_completed", "peer_agent_id", remote.Sender.ID, "error", err.Error())
+	}
+	m.logger.Info("agent_pair_completed", "pair_id", intent.PairID, "remote_pair_id", remote.Offer.PairID, "channel", channelForReference(m.self.ID), "peer_agent_id", remote.Sender.ID, "contact_id", pairedContact.ContactID)
+	return true, nil
+}
+
+func (m *Manager) expire(now time.Time) {
+	m.mu.Lock()
+	expired := make([]localIntent, 0)
+	for pairID, intent := range m.local {
+		if !intent.Expires.After(now) {
+			expired = append(expired, intent)
+			delete(m.local, pairID)
+		}
+	}
+	for key, intent := range m.remote {
+		if !intent.Expires.After(now) {
+			delete(m.remote, key)
+		}
+	}
+	m.mu.Unlock()
+	for _, intent := range expired {
+		m.logger.Info("agent_pair_expired", "pair_id", intent.PairID, "channel", channelForReference(m.self.ID), "admin_id", intent.AdminID, "peer_agent_id", intent.Target.ID, "direction", "outbound")
+		if err := m.appendJournal("agent_pair_expired", intent, intent.Target.ID, "", now); err != nil {
+			m.logger.Error("agent_pair_journal_error", "pair_id", intent.PairID, "event_type", "agent_pair_expired", "error", err.Error())
+		}
+	}
+}
+
+func (m *Manager) runExpiry(ctx context.Context) {
+	interval := m.ttl / 2
+	if interval > time.Minute {
+		interval = time.Minute
+	}
+	if interval < 10*time.Millisecond {
+		interval = 10 * time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.expire(m.currentTime())
+		}
+	}
+}
+
+func (m *Manager) appendJournal(eventType string, intent localIntent, peerID, reason string, now time.Time) error {
+	fields := map[string]any{
+		"pair_id":        intent.PairID,
+		"admin_id":       intent.AdminID,
+		"local_agent_id": m.self.ID,
+		"peer_agent_id":  strings.TrimSpace(peerID),
+	}
+	if reason = strings.TrimSpace(reason); reason != "" {
+		fields["reason"] = reason
+	}
+	payload, err := json.Marshal(fields)
+	if err != nil {
+		return err
+	}
+	_, err = m.journal.Append(domainjournal.Event{
+		ID:            uuid.NewString(),
+		Time:          now.UTC().Format(time.RFC3339Nano),
+		Domain:        "contacts",
+		Type:          eventType,
+		SchemaVersion: 1,
+		Trace:         domainjournal.Trace{Runtime: channelForReference(m.self.ID), Target: peerID},
+		Payload:       payload,
+	})
+	if err != nil {
+		return fmt.Errorf("append contacts journal: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) currentTime() time.Time {
+	return m.now().UTC()
+}
+
+func (m *Manager) removeLocal(pairID string) {
+	m.mu.Lock()
+	delete(m.local, strings.TrimSpace(pairID))
+	m.mu.Unlock()
+}
+
+func (m *Manager) matchingLocalPairID(sender Peer) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for pairID, intent := range m.local {
+		if peersMatch(intent.Target, sender) {
+			return pairID
+		}
+	}
+	return ""
+}
+
+func normalizePeer(peer Peer, stableID bool) (Peer, error) {
+	var err error
+	if stableID {
+		peer.ID, err = normalizeStableIdentity(peer.ID)
+	} else {
+		peer.ID, err = normalizeReference(peer.ID)
+	}
+	if err != nil {
+		return Peer{}, err
+	}
+	peer.Contact.Kind = contacts.KindAgent
+	return peer, nil
+}
+
+func normalizeReference(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	lower := strings.ToLower(value)
+	if strings.HasPrefix(lower, "tg:@") {
+		username := strings.TrimSpace(value[len("tg:@"):])
+		if username == "" || strings.ContainsAny(username, " \t\r\n:@()") {
+			return "", fmt.Errorf("invalid Telegram username reference")
+		}
+		return "tg:@" + username, nil
+	}
+	return normalizeStableIdentity(value)
+}
+
+func peersMatch(a, b Peer) bool {
+	aKeys := peerKeys(a)
+	for key := range peerKeys(b) {
+		if aKeys[key] {
+			return true
+		}
+	}
+	return false
+}
+
+func peerHasReference(peer Peer, raw string) bool {
+	ref, err := normalizeReference(raw)
+	if err != nil {
+		return false
+	}
+	return peerKeys(peer)[referenceKey(ref)]
+}
+
+func peerKeys(peer Peer) map[string]bool {
+	refs := []string{peer.ID}
+	refs = append(refs, contactReferences(peer.Contact)...)
+	out := make(map[string]bool, len(refs))
+	for _, raw := range refs {
+		ref, err := normalizeReference(raw)
+		if err == nil {
+			out[referenceKey(ref)] = true
+		}
+	}
+	return out
+}
+
+func contactReferences(contact contacts.Contact) []string {
+	refs := make([]string, 0, 6)
+	if id := strings.TrimSpace(contact.ContactID); id != "" {
+		refs = append(refs, id)
+	}
+	if contact.TGPrivateChatID > 0 {
+		refs = append(refs, "tg:"+strconv.FormatInt(contact.TGPrivateChatID, 10))
+	}
+	if username := strings.TrimSpace(strings.TrimPrefix(contact.TGUsername, "@")); username != "" {
+		refs = append(refs, "tg:@"+username)
+	}
+	if teamID, userID := strings.TrimSpace(contact.SlackTeamID), strings.TrimSpace(contact.SlackUserID); teamID != "" && userID != "" {
+		refs = append(refs, "slack:"+teamID+":"+userID)
+	}
+	if userID := strings.TrimSpace(contact.LineUserID); userID != "" {
+		refs = append(refs, "line_user:"+userID)
+	}
+	if openID := strings.TrimSpace(contact.LarkOpenID); openID != "" {
+		refs = append(refs, "lark_user:"+openID)
+	}
+	return refs
+}
+
+func referenceKey(ref string) string {
+	return strings.ToLower(strings.TrimSpace(ref))
+}
+
+func channelForReference(ref string) string {
+	lower := strings.ToLower(strings.TrimSpace(ref))
+	switch {
+	case strings.HasPrefix(lower, "tg:"):
+		return contacts.ChannelTelegram
+	case strings.HasPrefix(lower, "slack:"):
+		return contacts.ChannelSlack
+	case strings.HasPrefix(lower, "line_user:"):
+		return contacts.ChannelLine
+	case strings.HasPrefix(lower, "lark_user:"):
+		return contacts.ChannelLark
+	default:
+		return ""
+	}
+}

--- a/internal/agentpair/manager_test.go
+++ b/internal/agentpair/manager_test.go
@@ -1,0 +1,380 @@
+package agentpair
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/quailyquaily/mistermorph/contacts"
+	"github.com/quailyquaily/mistermorph/internal/domainjournal"
+)
+
+func TestManagersPairAfterReciprocalAdminRequests(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	peerA := telegramPeer(1001, "agent_a", "Agent A")
+	peerB := telegramPeer(2002, "agent_b", "Agent B")
+	var offerA, offerB string
+	managerA, storeA, journalA := newTestManager(t, peerA, []string{"tg:11"}, clock, func(_ context.Context, target Peer, body string) error {
+		if target.ID != "tg:@agent_b" {
+			t.Fatalf("A send target = %q", target.ID)
+		}
+		offerA = body
+		return nil
+	})
+	managerB, storeB, journalB := newTestManager(t, peerB, []string{"tg:22"}, clock, func(_ context.Context, target Peer, body string) error {
+		if target.ID != "tg:@agent_a" {
+			t.Fatalf("B send target = %q", target.ID)
+		}
+		offerB = body
+		return nil
+	})
+
+	status, err := managerA.Start(ctx, "tg:11", telegramAliasPeer("agent_b"), "")
+	if err != nil {
+		t.Fatalf("managerA.Start() error = %v", err)
+	}
+	if status != StatusWaiting || offerA == "" {
+		t.Fatalf("managerA.Start() = %q, offer=%q", status, offerA)
+	}
+
+	status, handled, err := managerB.Handle(ctx, peerA, offerA)
+	if err != nil {
+		t.Fatalf("managerB.Handle(A offer) error = %v", err)
+	}
+	if !handled || status != StatusWaiting {
+		t.Fatalf("managerB.Handle(A offer) = %q, handled=%v", status, handled)
+	}
+	if got := journalEventTypes(t, journalB); len(got) != 0 {
+		t.Fatalf("unsolicited offer wrote journal events: %v", got)
+	}
+
+	status, err = managerB.Start(ctx, "tg:22", telegramAliasPeer("agent_a"), "")
+	if err != nil {
+		t.Fatalf("managerB.Start() error = %v", err)
+	}
+	if status != StatusCompleted || offerB == "" {
+		t.Fatalf("managerB.Start() = %q, offer=%q", status, offerB)
+	}
+
+	status, handled, err = managerA.Handle(ctx, peerB, offerB)
+	if err != nil {
+		t.Fatalf("managerA.Handle(B offer) error = %v", err)
+	}
+	if !handled || status != StatusCompleted {
+		t.Fatalf("managerA.Handle(B offer) = %q, handled=%v", status, handled)
+	}
+
+	assertPairedTelegramContact(t, storeA, "agent_b", 2002)
+	assertPairedTelegramContact(t, storeB, "agent_a", 1001)
+	assertEventTypes(t, journalA, []string{"agent_pair_requested", "agent_pair_completed"})
+	assertEventTypes(t, journalB, []string{"agent_pair_requested", "agent_pair_completed"})
+
+	status, handled, err = managerA.Handle(ctx, peerB, offerB)
+	if err != nil {
+		t.Fatalf("managerA.Handle(replay) error = %v", err)
+	}
+	if !handled || status != StatusAlreadyPaired {
+		t.Fatalf("managerA.Handle(replay) = %q, handled=%v", status, handled)
+	}
+	assertEventTypes(t, journalA, []string{"agent_pair_requested", "agent_pair_completed"})
+}
+
+func TestManagerReportsCompletedWhenCompletionJournalFails(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 17, 8, 30, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	peerA := telegramPeer(1001, "agent_a", "Agent A")
+	peerB := telegramPeer(2002, "agent_b", "Agent B")
+	var offerA, offerB string
+	managerA, storeA, _ := newTestManager(t, peerA, []string{"tg:11"}, clock, func(_ context.Context, _ Peer, body string) error {
+		offerA = body
+		return nil
+	})
+	managerB, _, _ := newTestManager(t, peerB, []string{"tg:22"}, clock, func(_ context.Context, _ Peer, body string) error {
+		offerB = body
+		return nil
+	})
+
+	if _, err := managerA.Start(ctx, "tg:11", telegramAliasPeer("agent_b"), ""); err != nil {
+		t.Fatalf("managerA.Start() error = %v", err)
+	}
+	if _, handled, err := managerB.Handle(ctx, peerA, offerA); err != nil || !handled {
+		t.Fatalf("managerB.Handle(A offer) = handled %v, error %v", handled, err)
+	}
+	if _, err := managerB.Start(ctx, "tg:22", telegramAliasPeer("agent_a"), ""); err != nil {
+		t.Fatalf("managerB.Start() error = %v", err)
+	}
+	if err := managerA.journal.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	status, handled, err := managerA.Handle(ctx, peerB, offerB)
+	if err != nil {
+		t.Fatalf("managerA.Handle(B offer) error = %v", err)
+	}
+	if !handled || status != StatusCompleted {
+		t.Fatalf("managerA.Handle(B offer) = %q, handled=%v", status, handled)
+	}
+	assertPairedTelegramContact(t, storeA, "agent_b", 2002)
+}
+
+func TestManagerRejectsNonAdminWithoutJournal(t *testing.T) {
+	now := time.Date(2026, 8, 17, 9, 0, 0, 0, time.UTC)
+	sends := 0
+	manager, _, journalDir := newTestManager(t, telegramPeer(1001, "agent_a", "Agent A"), []string{"tg:11"}, func() time.Time { return now }, func(context.Context, Peer, string) error {
+		sends++
+		return nil
+	})
+
+	if _, err := manager.Start(context.Background(), "tg:12", telegramAliasPeer("agent_b"), ""); err == nil {
+		t.Fatal("Start(non-admin) expected error")
+	}
+	if sends != 0 {
+		t.Fatalf("send calls = %d, want 0", sends)
+	}
+	if got := journalEventTypes(t, journalDir); len(got) != 0 {
+		t.Fatalf("non-admin request wrote journal events: %v", got)
+	}
+}
+
+func TestManagerAuthorizesTelegramAdminContactReference(t *testing.T) {
+	now := time.Date(2026, 8, 17, 9, 15, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		contactUserID int64
+		addContact    bool
+		wantError     bool
+	}{
+		{name: "matching contact", contactUserID: 11, addContact: true},
+		{name: "contact without stored numeric id", addContact: true},
+		{name: "contact missing", wantError: true},
+		{name: "contact reference is sufficient", contactUserID: 12, addContact: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sends := 0
+			manager, store, journalDir := newTestManager(t, telegramPeer(1001, "agent_a", "Agent A"), []string{"tg:@ballcatcat"}, func() time.Time { return now }, func(context.Context, Peer, string) error {
+				sends++
+				return nil
+			})
+			if tt.addContact {
+				if err := store.PutContact(context.Background(), contacts.Contact{
+					ContactID:       "tg:@ballcatcat",
+					Kind:            contacts.KindHuman,
+					Channel:         contacts.ChannelTelegram,
+					ContactNickname: "Admin",
+					TGUsername:      "ballcatcat",
+					TGPrivateChatID: tt.contactUserID,
+				}); err != nil {
+					t.Fatalf("PutContact() error = %v", err)
+				}
+			}
+
+			_, err := manager.Start(context.Background(), "tg:11", telegramAliasPeer("agent_b"), "tg:@ballcatcat")
+			if (err != nil) != tt.wantError {
+				t.Fatalf("Start() error = %v, wantError %v", err, tt.wantError)
+			}
+			wantSends := 1
+			wantEvents := 1
+			if tt.wantError {
+				wantSends = 0
+				wantEvents = 0
+			}
+			if sends != wantSends {
+				t.Fatalf("send calls = %d, want %d", sends, wantSends)
+			}
+			if events := journalEventTypes(t, journalDir); len(events) != wantEvents {
+				t.Fatalf("journal events = %v, want %d", events, wantEvents)
+			}
+		})
+	}
+}
+
+func TestManagerRejectsPairingWithItself(t *testing.T) {
+	now := time.Date(2026, 8, 17, 9, 30, 0, 0, time.UTC)
+	sends := 0
+	manager, _, journalDir := newTestManager(t, telegramPeer(1001, "agent_a", "Agent A"), []string{"tg:11"}, func() time.Time { return now }, func(context.Context, Peer, string) error {
+		sends++
+		return nil
+	})
+	if _, err := manager.Start(context.Background(), "tg:11", telegramAliasPeer("agent_a"), ""); err == nil {
+		t.Fatal("Start(self) expected error")
+	}
+	if sends != 0 {
+		t.Fatalf("send calls = %d, want 0", sends)
+	}
+	if got := journalEventTypes(t, journalDir); len(got) != 0 {
+		t.Fatalf("self-pair request wrote journal events: %v", got)
+	}
+}
+
+func TestManagerExpiresLocalIntentBeforeLateOffer(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	peerA := telegramPeer(1001, "agent_a", "Agent A")
+	peerB := telegramPeer(2002, "agent_b", "Agent B")
+	var offerB string
+	managerA, storeA, journalA := newTestManager(t, peerA, []string{"tg:11"}, clock, func(context.Context, Peer, string) error { return nil })
+	managerB, _, _ := newTestManager(t, peerB, []string{"tg:22"}, clock, func(_ context.Context, _ Peer, body string) error {
+		offerB = body
+		return nil
+	})
+
+	if _, err := managerA.Start(ctx, "tg:11", telegramAliasPeer("agent_b"), ""); err != nil {
+		t.Fatalf("managerA.Start() error = %v", err)
+	}
+	now = now.Add(6 * time.Minute)
+	if _, err := managerB.Start(ctx, "tg:22", telegramAliasPeer("agent_a"), ""); err != nil {
+		t.Fatalf("managerB.Start() error = %v", err)
+	}
+	status, handled, err := managerA.Handle(ctx, peerB, offerB)
+	if err != nil {
+		t.Fatalf("managerA.Handle(late offer) error = %v", err)
+	}
+	if !handled || status != StatusWaiting {
+		t.Fatalf("managerA.Handle(late offer) = %q, handled=%v", status, handled)
+	}
+	if paired, err := managerA.IsPaired(ctx, peerB); err != nil || paired {
+		t.Fatalf("managerA.IsPaired() = %v, %v", paired, err)
+	}
+	if contactsList, err := storeA.ListContacts(ctx, contacts.StatusActive); err != nil {
+		t.Fatalf("ListContacts() error = %v", err)
+	} else if len(contactsList) != 0 {
+		t.Fatalf("late offer created contacts: %#v", contactsList)
+	}
+	assertEventTypes(t, journalA, []string{"agent_pair_requested", "agent_pair_expired"})
+}
+
+func TestManagerRecordsExpirationWithoutAnotherMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	root := t.TempDir()
+	store := contacts.NewFileStore(filepath.Join(root, "contacts"))
+	admins, err := ParseAdmins([]string{"tg:11"})
+	if err != nil {
+		t.Fatalf("ParseAdmins() error = %v", err)
+	}
+	journalDir := filepath.Join(root, "journal")
+	manager, err := New(Options{
+		Context:    ctx,
+		Self:       telegramPeer(1001, "agent_a", "Agent A"),
+		Admins:     admins,
+		Contacts:   contacts.NewService(store),
+		JournalDir: journalDir,
+		TTL:        30 * time.Millisecond,
+		Send:       func(context.Context, Peer, string) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if _, err := manager.Start(ctx, "tg:11", telegramAliasPeer("agent_b"), ""); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		got := journalEventTypes(t, journalDir)
+		if len(got) == 2 {
+			assertEventTypes(t, journalDir, []string{"agent_pair_requested", "agent_pair_expired"})
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expiration was not journaled: %v", journalEventTypes(t, journalDir))
+}
+
+func newTestManager(t *testing.T, self Peer, adminIDs []string, now func() time.Time, send SendFunc) (*Manager, *contacts.FileStore, string) {
+	t.Helper()
+	root := t.TempDir()
+	store := contacts.NewFileStore(filepath.Join(root, "contacts"))
+	admins, err := ParseAdmins(adminIDs)
+	if err != nil {
+		t.Fatalf("ParseAdmins() error = %v", err)
+	}
+	journalDir := filepath.Join(root, "journal")
+	manager, err := New(Options{
+		Self:       self,
+		Admins:     admins,
+		Contacts:   contacts.NewService(store),
+		JournalDir: journalDir,
+		Now:        now,
+		Send:       send,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return manager, store, journalDir
+}
+
+func telegramPeer(id int64, username, nickname string) Peer {
+	return Peer{
+		ID: "tg:" + strconv.FormatInt(id, 10),
+		Contact: contacts.Contact{
+			ContactID:       "tg:@" + username,
+			Kind:            contacts.KindAgent,
+			Channel:         contacts.ChannelTelegram,
+			ContactNickname: nickname,
+			TGUsername:      username,
+			TGPrivateChatID: id,
+		},
+	}
+}
+
+func telegramAliasPeer(username string) Peer {
+	return Peer{
+		ID: "tg:@" + username,
+		Contact: contacts.Contact{
+			ContactID:  "tg:@" + username,
+			Kind:       contacts.KindAgent,
+			Channel:    contacts.ChannelTelegram,
+			TGUsername: username,
+		},
+	}
+}
+
+func assertPairedTelegramContact(t *testing.T, store *contacts.FileStore, username string, privateChatID int64) {
+	t.Helper()
+	items, err := store.ListContacts(context.Background(), contacts.StatusActive)
+	if err != nil {
+		t.Fatalf("ListContacts() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("active contacts = %#v", items)
+	}
+	if !items[0].Paired || items[0].Kind != contacts.KindAgent || items[0].TGUsername != username || items[0].TGPrivateChatID != privateChatID {
+		t.Fatalf("paired contact = %#v", items[0])
+	}
+}
+
+func assertEventTypes(t *testing.T, dir string, want []string) {
+	t.Helper()
+	got := journalEventTypes(t, dir)
+	if len(got) != len(want) {
+		t.Fatalf("journal events = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("journal events = %v, want %v", got, want)
+		}
+	}
+}
+
+func journalEventTypes(t *testing.T, dir string) []string {
+	t.Helper()
+	var out []string
+	if err := domainjournal.ReplayDir(dir, func(record domainjournal.Record) error {
+		if record.Event.Domain == "contacts" {
+			out = append(out, record.Event.Type)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("ReplayDir() error = %v", err)
+	}
+	return out
+}

--- a/internal/agentpair/protocol.go
+++ b/internal/agentpair/protocol.go
@@ -1,0 +1,71 @@
+package agentpair
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const controlPrefix = "morph-agent-pair:v1:"
+
+type pairOffer struct {
+	PairID    string `json:"pair_id"`
+	From      string `json:"from"`
+	To        string `json:"to"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+func IsControlMessage(text string) bool {
+	return strings.HasPrefix(strings.TrimSpace(text), controlPrefix)
+}
+
+func encodeOffer(offer pairOffer) (string, error) {
+	raw, err := json.Marshal(offer)
+	if err != nil {
+		return "", err
+	}
+	return controlPrefix + base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func decodeOffer(text string) (pairOffer, time.Time, bool, error) {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, controlPrefix) {
+		return pairOffer{}, time.Time{}, false, nil
+	}
+	payload := strings.TrimPrefix(text, controlPrefix)
+	if payload == "" || strings.ContainsAny(payload, " \t\r\n") {
+		return pairOffer{}, time.Time{}, true, fmt.Errorf("invalid Agent pair control message")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		return pairOffer{}, time.Time{}, true, fmt.Errorf("decode Agent pair offer: %w", err)
+	}
+	var offer pairOffer
+	if err := json.Unmarshal(raw, &offer); err != nil {
+		return pairOffer{}, time.Time{}, true, fmt.Errorf("decode Agent pair offer: %w", err)
+	}
+	if _, err := uuid.Parse(strings.TrimSpace(offer.PairID)); err != nil {
+		return pairOffer{}, time.Time{}, true, fmt.Errorf("invalid Agent pair id")
+	}
+	from, err := normalizeStableIdentity(offer.From)
+	if err != nil {
+		return pairOffer{}, time.Time{}, true, fmt.Errorf("invalid Agent pair sender: %w", err)
+	}
+	to, err := normalizeReference(offer.To)
+	if err != nil {
+		return pairOffer{}, time.Time{}, true, fmt.Errorf("invalid Agent pair target: %w", err)
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(offer.ExpiresAt))
+	if err != nil {
+		return pairOffer{}, time.Time{}, true, fmt.Errorf("invalid Agent pair expiry")
+	}
+	offer.PairID = strings.TrimSpace(offer.PairID)
+	offer.From = from
+	offer.To = to
+	offer.ExpiresAt = expiresAt.UTC().Format(time.RFC3339Nano)
+	return offer, expiresAt.UTC(), true, nil
+}

--- a/internal/bus/adapters/slack/inbound.go
+++ b/internal/bus/adapters/slack/inbound.go
@@ -27,6 +27,7 @@ type InboundMessage struct {
 	UserID           string
 	Username         string
 	DisplayName      string
+	FromIsAgent      bool
 	Text             string
 	SentAt           time.Time
 	MentionUsers     []string
@@ -148,6 +149,7 @@ func (a *InboundAdapter) HandleInboundMessage(ctx context.Context, msg InboundMe
 			ChatType:          chatType,
 			FromUsername:      strings.TrimSpace(msg.Username),
 			FromDisplayName:   strings.TrimSpace(msg.DisplayName),
+			FromIsAgent:       msg.FromIsAgent,
 			TeamID:            teamID,
 			ChannelID:         channelID,
 			FromUserRef:       userID,
@@ -223,6 +225,7 @@ func InboundMessageFromBusMessage(msg busruntime.BusMessage) (InboundMessage, er
 		UserID:           userID,
 		Username:         strings.TrimSpace(msg.Extensions.FromUsername),
 		DisplayName:      strings.TrimSpace(msg.Extensions.FromDisplayName),
+		FromIsAgent:      msg.Extensions.FromIsAgent,
 		Text:             strings.TrimSpace(env.Text),
 		SentAt:           sentAt.UTC(),
 		MentionUsers:     mentionUsers,

--- a/internal/bus/adapters/slack/inbound_test.go
+++ b/internal/bus/adapters/slack/inbound_test.go
@@ -50,6 +50,7 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		UserID:       "U333",
 		Username:     "alice",
 		DisplayName:  "Alice W",
+		FromIsAgent:  true,
 		Text:         "hello from slack",
 		MentionUsers: []string{"@alice", "@bob"},
 		EventID:      "Ev01",
@@ -87,6 +88,9 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		}
 		if msg.Extensions.FromUserRef != "U333" {
 			t.Fatalf("from_user_ref mismatch: got %q want %q", msg.Extensions.FromUserRef, "U333")
+		}
+		if !msg.Extensions.FromIsAgent {
+			t.Fatal("from_is_agent mismatch: got false want true")
 		}
 		if msg.Extensions.ThreadTS != "1739667000.000050" {
 			t.Fatalf("thread_ts mismatch: got %q want %q", msg.Extensions.ThreadTS, "1739667000.000050")
@@ -166,6 +170,7 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 			FromUserRef:       "U333",
 			FromUsername:      "alice",
 			FromDisplayName:   "Alice W",
+			FromIsAgent:       true,
 			TeamID:            "T111",
 			ChannelID:         "C222",
 			ThreadTS:          "1739667000.000050",
@@ -198,6 +203,9 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 	}
 	if inbound.UserID != "U333" {
 		t.Fatalf("user_id mismatch: got %q want %q", inbound.UserID, "U333")
+	}
+	if !inbound.FromIsAgent {
+		t.Fatal("from_is_agent mismatch: got false want true")
 	}
 	if inbound.Text != "hello from slack" {
 		t.Fatalf("text mismatch: got %q want %q", inbound.Text, "hello from slack")

--- a/internal/bus/adapters/telegram/inbound.go
+++ b/internal/bus/adapters/telegram/inbound.go
@@ -31,6 +31,7 @@ type InboundMessage struct {
 	FromFirstName    string
 	FromLastName     string
 	FromDisplayName  string
+	FromIsAgent      bool
 	Text             string
 	MentionUsers     []string
 	ImagePaths       []string
@@ -159,6 +160,7 @@ func (a *InboundAdapter) HandleInboundMessage(ctx context.Context, msg InboundMe
 			FromFirstName:     strings.TrimSpace(msg.FromFirstName),
 			FromLastName:      strings.TrimSpace(msg.FromLastName),
 			FromDisplayName:   strings.TrimSpace(msg.FromDisplayName),
+			FromIsAgent:       msg.FromIsAgent,
 			MentionUsers:      mentionUsers,
 			ImagePaths:        imagePaths,
 			ImageAttachments:  imageAttachments,
@@ -223,6 +225,7 @@ func InboundMessageFromBusMessage(msg busruntime.BusMessage) (InboundMessage, er
 		FromFirstName:    strings.TrimSpace(msg.Extensions.FromFirstName),
 		FromLastName:     strings.TrimSpace(msg.Extensions.FromLastName),
 		FromDisplayName:  strings.TrimSpace(msg.Extensions.FromDisplayName),
+		FromIsAgent:      msg.Extensions.FromIsAgent,
 		Text:             strings.TrimSpace(envelope.Text),
 		MentionUsers:     mentionUsers,
 		ImagePaths:       imagePaths,

--- a/internal/bus/adapters/telegram/inbound_test.go
+++ b/internal/bus/adapters/telegram/inbound_test.go
@@ -53,6 +53,7 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		FromFirstName:    "Alice",
 		FromLastName:     "W",
 		FromDisplayName:  "Alice W",
+		FromIsAgent:      true,
 		Text:             "hello",
 		MentionUsers:     []string{"alice", "bob"},
 		ImagePaths:       []string{"/tmp/p1.jpg", "/tmp/p2.png"},
@@ -80,6 +81,9 @@ func TestInboundAdapterHandleInboundMessage(t *testing.T) {
 		}
 		if msg.Extensions.FromUserID != 777 {
 			t.Fatalf("from_user_id mismatch: got %d want 777", msg.Extensions.FromUserID)
+		}
+		if !msg.Extensions.FromIsAgent {
+			t.Fatal("from_is_agent mismatch: got false want true")
 		}
 		if msg.Extensions.ReplyTo != "677" {
 			t.Fatalf("reply_to mismatch: got %q want %q", msg.Extensions.ReplyTo, "677")
@@ -157,6 +161,7 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 			ChatType:          "group",
 			FromUserID:        9001,
 			FromUsername:      "neo",
+			FromIsAgent:       true,
 			MentionUsers:      []string{"neo", "morpheus"},
 			ImagePaths:        []string{"/tmp/p1.jpg", "/tmp/p2.jpg"},
 		},
@@ -182,6 +187,9 @@ func TestInboundMessageFromBusMessage(t *testing.T) {
 	}
 	if inbound.FromUserID != 9001 {
 		t.Fatalf("from_user_id mismatch: got %d want 9001", inbound.FromUserID)
+	}
+	if !inbound.FromIsAgent {
+		t.Fatal("from_is_agent mismatch: got false want true")
 	}
 	if inbound.Text != "hello" {
 		t.Fatalf("text mismatch: got %q want %q", inbound.Text, "hello")

--- a/internal/bus/message.go
+++ b/internal/bus/message.go
@@ -37,6 +37,7 @@ type MessageExtensions struct {
 	FromFirstName     string            `json:"from_first_name,omitempty"`
 	FromLastName      string            `json:"from_last_name,omitempty"`
 	FromDisplayName   string            `json:"from_display_name,omitempty"`
+	FromIsAgent       bool              `json:"from_is_agent,omitempty"`
 	TeamID            string            `json:"team_id,omitempty"`
 	ChannelID         string            `json:"channel_id,omitempty"`
 	FromUserRef       string            `json:"from_user_ref,omitempty"`

--- a/internal/channelruntime/awareness/chat_info.go
+++ b/internal/channelruntime/awareness/chat_info.go
@@ -27,9 +27,6 @@ func refreshChatInfoOnStart(ctx context.Context, store *chatinfo.Store, refreshe
 	if err := store.RefreshExpired(ctx, now, refresher); err != nil && logger != nil {
 		logger.Warn("chat_profile_refresh_expired_failed", "error", err.Error())
 	}
-	if !chatInfoStoreEmpty(ctx, store) {
-		return
-	}
 	candidates, err := chatinfo.ActiveContactCandidateIDs(ctx, contactsDir)
 	if err != nil {
 		if logger != nil {
@@ -56,11 +53,6 @@ func refreshChatInfoOnStart(ctx context.Context, store *chatinfo.Store, refreshe
 			)
 		}
 	}
-}
-
-func chatInfoStoreEmpty(ctx context.Context, store *chatinfo.Store) bool {
-	items, exists, err := store.Read(ctx)
-	return err == nil && (!exists || len(items) == 0)
 }
 
 func buildCronNotifyTargetForTask(ctx context.Context, task cronstore.Task, now time.Time, store *chatinfo.Store, refresher chatinfo.Refresher, logger *slog.Logger) map[string]any {

--- a/internal/channelruntime/awareness/cron_notify_test.go
+++ b/internal/channelruntime/awareness/cron_notify_test.go
@@ -109,7 +109,7 @@ func TestResolveChatInfoRuntimeDoesNotReadProcessGlobalConfiguration(t *testing.
 	}
 }
 
-func TestRefreshChatInfoOnStartSkipsMissingCandidatesWhenStoreHasItems(t *testing.T) {
+func TestRefreshChatInfoOnStartFetchesMissingCandidatesWhenStoreHasItems(t *testing.T) {
 	ctx := context.Background()
 	stateDir := t.TempDir()
 	contactsDir := filepath.Join(stateDir, "contacts")
@@ -134,21 +134,26 @@ func TestRefreshChatInfoOnStartSkipsMissingCandidatesWhenStoreHasItems(t *testin
 	}); err != nil {
 		t.Fatalf("seed chat profile: %v", err)
 	}
-	called := false
+	var fetchedChatIDs []string
 
-	refreshChatInfoOnStart(ctx, store, chatinfo.RefreshFunc(func(context.Context, string) (chatinfo.Info, error) {
-		called = true
-		return chatinfo.Info{}, errAwarenessTestBoom
+	refreshChatInfoOnStart(ctx, store, chatinfo.RefreshFunc(func(_ context.Context, chatID string) (chatinfo.Info, error) {
+		fetchedChatIDs = append(fetchedChatIDs, chatID)
+		return chatinfo.Info{
+			ChatID:   chatID,
+			Platform: "telegram",
+			Type:     "group",
+			Name:     "New Room",
+		}, nil
 	}), contactsDir, nil)
 
-	if called {
-		t.Fatalf("refresher should not be called when store already has items")
+	if len(fetchedChatIDs) != 1 || fetchedChatIDs[0] != "tg:-100456" {
+		t.Fatalf("fetched chat IDs = %#v, want [tg:-100456]", fetchedChatIDs)
 	}
 	items, _, err := store.Read(ctx)
 	if err != nil {
 		t.Fatalf("store.Read() error = %v", err)
 	}
-	if len(items) != 1 || items[0].ChatID != "tg:-100123" {
+	if len(items) != 2 || items[0].ChatID != "tg:-100123" || items[1].ChatID != "tg:-100456" {
 		t.Fatalf("unexpected items: %#v", items)
 	}
 }

--- a/internal/channelruntime/awareness/run.go
+++ b/internal/channelruntime/awareness/run.go
@@ -535,6 +535,13 @@ func runAwarenessTask(ctx context.Context, d Dependencies, opts awarenessTaskOpt
 	}
 
 	reg := opts.BaseRegistry.Clone()
+	if d.RegisterTriggeredStaticTools != nil {
+		reg.Remove(toolsutil.BuiltinAgentSend)
+		if toolTriggers == nil {
+			toolTriggers = make(map[string]bool)
+		}
+		toolTriggers[toolsutil.BuiltinAgentSend] = true
+	}
 	if d.RegisterTriggeredStaticTools != nil && len(toolTriggers) > 0 {
 		d.RegisterTriggeredStaticTools(reg, toolTriggers)
 	}

--- a/internal/channelruntime/core/agent_interaction_limiter.go
+++ b/internal/channelruntime/core/agent_interaction_limiter.go
@@ -12,8 +12,9 @@ const (
 )
 
 type AgentInteractionLimiter struct {
-	mu      sync.Mutex
-	history map[string][]time.Time
+	mu          sync.Mutex
+	history     map[string][]time.Time
+	nextCleanup time.Time
 }
 
 func (l *AgentInteractionLimiter) Allow(conversationKey string, now time.Time) bool {
@@ -29,16 +30,30 @@ func (l *AgentInteractionLimiter) Allow(conversationKey string, now time.Time) b
 	}
 
 	cutoff := now.Add(-AgentInteractionWindow)
-	history := l.history[conversationKey]
-	first := 0
-	for first < len(history) && !history[first].After(cutoff) {
-		first++
+	if l.nextCleanup.IsZero() || !now.Before(l.nextCleanup) {
+		for key, history := range l.history {
+			history = trimAgentInteractionHistory(history, cutoff)
+			if len(history) == 0 {
+				delete(l.history, key)
+				continue
+			}
+			l.history[key] = history
+		}
+		l.nextCleanup = now.Add(AgentInteractionWindow)
 	}
-	history = history[first:]
+	history := trimAgentInteractionHistory(l.history[conversationKey], cutoff)
 	if len(history) >= AgentInteractionLimit {
 		l.history[conversationKey] = history
 		return false
 	}
 	l.history[conversationKey] = append(history, now)
 	return true
+}
+
+func trimAgentInteractionHistory(history []time.Time, cutoff time.Time) []time.Time {
+	first := 0
+	for first < len(history) && !history[first].After(cutoff) {
+		first++
+	}
+	return history[first:]
 }

--- a/internal/channelruntime/core/agent_interaction_limiter.go
+++ b/internal/channelruntime/core/agent_interaction_limiter.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	AgentInteractionLimit  = 8
+	AgentInteractionWindow = 10 * time.Minute
+)
+
+type AgentInteractionLimiter struct {
+	mu      sync.Mutex
+	history map[string][]time.Time
+}
+
+func (l *AgentInteractionLimiter) Allow(conversationKey string, now time.Time) bool {
+	conversationKey = strings.TrimSpace(conversationKey)
+	if conversationKey == "" {
+		return false
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.history == nil {
+		l.history = make(map[string][]time.Time)
+	}
+
+	cutoff := now.Add(-AgentInteractionWindow)
+	history := l.history[conversationKey]
+	first := 0
+	for first < len(history) && !history[first].After(cutoff) {
+		first++
+	}
+	history = history[first:]
+	if len(history) >= AgentInteractionLimit {
+		l.history[conversationKey] = history
+		return false
+	}
+	l.history[conversationKey] = append(history, now)
+	return true
+}

--- a/internal/channelruntime/core/agent_interaction_limiter_test.go
+++ b/internal/channelruntime/core/agent_interaction_limiter_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -29,5 +30,26 @@ func TestAgentInteractionLimiterRejectsEmptyConversation(t *testing.T) {
 	var limiter AgentInteractionLimiter
 	if limiter.Allow("  ", time.Now()) {
 		t.Fatal("empty conversation accepted")
+	}
+}
+
+func TestAgentInteractionLimiterRemovesExpiredConversations(t *testing.T) {
+	var limiter AgentInteractionLimiter
+	start := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 100; i++ {
+		if !limiter.Allow(fmt.Sprintf("expired-%d", i), start) {
+			t.Fatalf("conversation %d rejected", i)
+		}
+	}
+	if !limiter.Allow("recent", start.Add(9*time.Minute)) {
+		t.Fatal("recent conversation rejected")
+	}
+	if !limiter.Allow("fresh", start.Add(AgentInteractionWindow)) {
+		t.Fatal("fresh conversation rejected")
+	}
+
+	if got := len(limiter.history); got != 2 {
+		t.Fatalf("retained conversation count = %d, want 2", got)
 	}
 }

--- a/internal/channelruntime/core/agent_interaction_limiter_test.go
+++ b/internal/channelruntime/core/agent_interaction_limiter_test.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAgentInteractionLimiterUsesRollingWindowPerConversation(t *testing.T) {
+	var limiter AgentInteractionLimiter
+	start := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+
+	for i := 0; i < AgentInteractionLimit; i++ {
+		if !limiter.Allow("conversation-a", start.Add(time.Duration(i)*time.Minute)) {
+			t.Fatalf("interaction %d rejected, want accepted", i+1)
+		}
+	}
+	if limiter.Allow("conversation-a", start.Add(9*time.Minute)) {
+		t.Fatal("ninth interaction within ten minutes accepted, want rejected")
+	}
+	if !limiter.Allow("conversation-b", start.Add(9*time.Minute)) {
+		t.Fatal("first interaction in another conversation rejected")
+	}
+	if !limiter.Allow("conversation-a", start.Add(10*time.Minute)) {
+		t.Fatal("interaction rejected after oldest entry left the rolling window")
+	}
+}
+
+func TestAgentInteractionLimiterRejectsEmptyConversation(t *testing.T) {
+	var limiter AgentInteractionLimiter
+	if limiter.Allow("  ", time.Now()) {
+		t.Fatal("empty conversation accepted")
+	}
+}

--- a/internal/channelruntime/slack/agent_pair.go
+++ b/internal/channelruntime/slack/agent_pair.go
@@ -1,0 +1,95 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/quailyquaily/mistermorph/contacts"
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
+)
+
+func slackPairTarget(args, teamID string) (agentpair.Peer, error) {
+	target := strings.TrimSpace(args)
+	match := slackMentionPattern.FindStringSubmatch(target)
+	if len(match) < 2 || match[0] != target {
+		return agentpair.Peer{}, fmt.Errorf("usage: /pair @Agent")
+	}
+	teamID = strings.ToUpper(strings.TrimSpace(teamID))
+	userID := strings.ToUpper(strings.TrimSpace(match[1]))
+	if !strings.HasPrefix(teamID, "T") || !(strings.HasPrefix(userID, "U") || strings.HasPrefix(userID, "W")) {
+		return agentpair.Peer{}, fmt.Errorf("pair target must be a Slack user")
+	}
+	stableID := "slack:" + teamID + ":" + userID
+	return agentpair.Peer{
+		ID: stableID,
+		Contact: contacts.Contact{
+			ContactID:   stableID,
+			Kind:        contacts.KindAgent,
+			Channel:     contacts.ChannelSlack,
+			SlackTeamID: teamID,
+			SlackUserID: userID,
+		},
+	}, nil
+}
+
+func slackInboundAgentPeer(teamID, userID, username, displayName, dmChannelID string) agentpair.Peer {
+	teamID = strings.ToUpper(strings.TrimSpace(teamID))
+	userID = strings.ToUpper(strings.TrimSpace(userID))
+	stableID := "slack:" + teamID + ":" + userID
+	nickname := strings.TrimSpace(displayName)
+	if nickname == "" {
+		nickname = strings.TrimSpace(username)
+	}
+	return agentpair.Peer{
+		ID: stableID,
+		Contact: contacts.Contact{
+			ContactID:        stableID,
+			Kind:             contacts.KindAgent,
+			Channel:          contacts.ChannelSlack,
+			ContactNickname:  nickname,
+			SlackTeamID:      teamID,
+			SlackUserID:      userID,
+			SlackDMChannelID: strings.TrimSpace(dmChannelID),
+		},
+	}
+}
+
+func slackChatAuthorized(allowedTeams, allowedChannels map[string]bool, teamID, channelID, chatType string, fromAgent, pairedAgent bool) bool {
+	teamAllowed := len(allowedTeams) == 0 || allowedTeams[strings.TrimSpace(teamID)]
+	channelAllowed := len(allowedChannels) == 0 || allowedChannels[strings.TrimSpace(channelID)]
+	if teamAllowed && channelAllowed {
+		return true
+	}
+	return !isSlackGroupChat(chatType) && fromAgent && pairedAgent
+}
+
+func slackPairSendUserID(peer agentpair.Peer) (string, error) {
+	parts := strings.Split(strings.TrimSpace(peer.ID), ":")
+	if len(parts) != 3 || !strings.EqualFold(parts[0], "slack") {
+		return "", fmt.Errorf("Slack pair target is invalid")
+	}
+	userID := strings.ToUpper(strings.TrimSpace(parts[2]))
+	if !(strings.HasPrefix(userID, "U") || strings.HasPrefix(userID, "W")) {
+		return "", fmt.Errorf("Slack pair target must be a user")
+	}
+	return userID, nil
+}
+
+func sendSlackPairReply(ctx context.Context, api *slackAPI, channelID string, status agentpair.Status, err error) {
+	if api == nil {
+		return
+	}
+	reply := "Pairing request sent. It expires in 5 minutes."
+	if err != nil {
+		reply = "Pairing failed: " + strings.TrimSpace(err.Error())
+	} else {
+		switch status {
+		case agentpair.StatusCompleted:
+			reply = "Agent pairing completed."
+		case agentpair.StatusAlreadyPaired:
+			reply = "This Agent is already paired."
+		}
+	}
+	_ = api.postMessage(ctx, channelID, reply, "")
+}

--- a/internal/channelruntime/slack/agent_pair_test.go
+++ b/internal/channelruntime/slack/agent_pair_test.go
@@ -1,0 +1,185 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/quailyquaily/mistermorph/contacts"
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
+	"github.com/quailyquaily/mistermorph/internal/domainjournal"
+	"github.com/quailyquaily/mistermorph/internal/testhttp"
+)
+
+func TestSlackPairTargetRequiresOneUserMention(t *testing.T) {
+	target, err := slackPairTarget("<@U234>", "T123")
+	if err != nil {
+		t.Fatalf("slackPairTarget() error = %v", err)
+	}
+	if target.ID != "slack:T123:U234" || target.Contact.SlackUserID != "U234" {
+		t.Fatalf("slackPairTarget() = %#v", target)
+	}
+
+	for _, raw := range []string{"", "@AgentB", "<@U234> extra", "<@C234>", "<@U234> <@U235>"} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := slackPairTarget(raw, "T123"); err == nil {
+				t.Fatalf("slackPairTarget(%q) expected error", raw)
+			}
+		})
+	}
+}
+
+func TestSlackPairedAgentBypassesAllowlistOnlyInPrivateChat(t *testing.T) {
+	allowedTeams := map[string]bool{"T100": true}
+	allowedChannels := map[string]bool{"C100": true}
+	tests := []struct {
+		name        string
+		teamID      string
+		channelID   string
+		chatType    string
+		fromAgent   bool
+		pairedAgent bool
+		want        bool
+	}{
+		{name: "configured channel", teamID: "T100", channelID: "C100", chatType: "channel", want: true},
+		{name: "unconfigured private human", teamID: "T100", channelID: "D200", chatType: "im"},
+		{name: "paired private Agent", teamID: "T200", channelID: "D200", chatType: "im", fromAgent: true, pairedAgent: true, want: true},
+		{name: "paired flag does not authorize human", teamID: "T200", channelID: "D200", chatType: "im", pairedAgent: true},
+		{name: "paired Agent does not bypass group", teamID: "T200", channelID: "C200", chatType: "channel", fromAgent: true, pairedAgent: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slackChatAuthorized(allowedTeams, allowedChannels, tt.teamID, tt.channelID, tt.chatType, tt.fromAgent, tt.pairedAgent)
+			if got != tt.want {
+				t.Fatalf("slackChatAuthorized() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+	if !slackChatAuthorized(nil, nil, "T200", "D200", "im", false, false) {
+		t.Fatal("empty allowlists should allow ordinary chats")
+	}
+}
+
+func TestSlackPostDirectMessageOpensConversation(t *testing.T) {
+	var openedUser string
+	var posted struct {
+		Channel string `json:"channel"`
+		Text    string `json:"text"`
+	}
+	server := testhttp.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.open":
+			var request struct {
+				Users string `json:"users"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode conversations.open: %v", err)
+			}
+			openedUser = request.Users
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D900"}}`))
+		case "/chat.postMessage":
+			if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+				t.Fatalf("decode chat.postMessage: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"D900","ts":"1.0"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	api := newSlackAPI(server.Client, server.URL, "bot-token", "app-token")
+	if err := api.postDirectMessage(context.Background(), "U234", "pair-control"); err != nil {
+		t.Fatalf("postDirectMessage() error = %v", err)
+	}
+	if openedUser != "U234" || posted.Channel != "D900" || posted.Text != "pair-control" {
+		t.Fatalf("opened=%q posted=%#v", openedUser, posted)
+	}
+}
+
+func TestSlackPrivateAdminPairCommandRunsBeforeAllowlist(t *testing.T) {
+	var postedChannels []string
+	server := testhttp.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.open":
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"D900"}}`))
+		case "/chat.postMessage":
+			var request struct {
+				Channel string `json:"channel"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode chat.postMessage: %v", err)
+			}
+			postedChannels = append(postedChannels, request.Channel)
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"` + request.Channel + `","ts":"1.0"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	api := newSlackAPI(server.Client, server.URL, "bot-token", "app-token")
+	root := t.TempDir()
+	store := contacts.NewFileStore(filepath.Join(root, "contacts"))
+	admins, err := agentpair.ParseAdmins([]string{"slack:T123:U11"})
+	if err != nil {
+		t.Fatalf("ParseAdmins() error = %v", err)
+	}
+	manager, err := agentpair.New(agentpair.Options{
+		Self:       slackInboundAgentPeer("T123", "U100", "agent_a", "Agent A", ""),
+		Admins:     admins,
+		Contacts:   contacts.NewService(store),
+		JournalDir: filepath.Join(root, "journal"),
+		Send: func(ctx context.Context, target agentpair.Peer, body string) error {
+			userID, targetErr := slackPairSendUserID(target)
+			if targetErr != nil {
+				return targetErr
+			}
+			return api.postDirectMessage(ctx, userID, body)
+		},
+	})
+	if err != nil {
+		t.Fatalf("agentpair.New() error = %v", err)
+	}
+	state := &slackRuntimeState{
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		api:             api,
+		pairManager:     manager,
+		botUserID:       "U100",
+		botID:           "B100",
+		allowedTeams:    map[string]bool{"T999": true},
+		allowedChannels: map[string]bool{"C999": true},
+	}
+	payload, err := json.Marshal(map[string]any{
+		"team_id":    "T123",
+		"event_id":   "Ev1",
+		"event_time": 1786932000,
+		"event": map[string]any{
+			"type":         "message",
+			"user":         "U11",
+			"text":         "/pair <@U234>",
+			"channel":      "D11",
+			"channel_type": "im",
+			"ts":           "1.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := state.handleSocketEnvelope(context.Background(), slackSocketEnvelope{Type: "events_api", Payload: payload}); err != nil {
+		t.Fatalf("handleSocketEnvelope() error = %v", err)
+	}
+	if len(postedChannels) != 2 || postedChannels[0] != "D900" || postedChannels[1] != "D11" {
+		t.Fatalf("posted channels = %v", postedChannels)
+	}
+	var eventTypes []string
+	if err := domainjournal.ReplayDir(filepath.Join(root, "journal"), func(record domainjournal.Record) error {
+		eventTypes = append(eventTypes, record.Event.Type)
+		return nil
+	}); err != nil {
+		t.Fatalf("ReplayDir() error = %v", err)
+	}
+	if len(eventTypes) != 1 || eventTypes[0] != "agent_pair_requested" {
+		t.Fatalf("journal events = %v", eventTypes)
+	}
+}

--- a/internal/channelruntime/slack/runtime.go
+++ b/internal/channelruntime/slack/runtime.go
@@ -12,6 +12,7 @@ import (
 	"github.com/quailyquaily/mistermorph/agent"
 	"github.com/quailyquaily/mistermorph/contacts"
 	"github.com/quailyquaily/mistermorph/guard"
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
 	busruntime "github.com/quailyquaily/mistermorph/internal/bus"
 	slackbus "github.com/quailyquaily/mistermorph/internal/bus/adapters/slack"
 	runtimecore "github.com/quailyquaily/mistermorph/internal/channelruntime/core"
@@ -70,6 +71,7 @@ type slackJob struct {
 	UserID           string
 	Username         string
 	DisplayName      string
+	FromIsAgent      bool
 	Text             string
 	ImagePaths       []string
 	Images           []chathistory.ChatHistoryImage
@@ -135,6 +137,7 @@ func slackRunControlConversationKey(fallback, teamID, channelID, threadTS string
 }
 
 type slackUserIdentityCacheEntry struct {
+	UserID      string
 	Username    string
 	DisplayName string
 	ExpiresAt   time.Time
@@ -255,6 +258,33 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts RunOptions) error {
 	if len(allowedTeams) == 0 && strings.TrimSpace(auth.TeamID) != "" {
 		allowedTeams[strings.TrimSpace(auth.TeamID)] = true
 	}
+	adminValues := []string(nil)
+	if d.AgentSettingsReader != nil {
+		adminValues = d.AgentSettingsReader.GetStringSlice("admins")
+	}
+	admins, err := agentpair.ParseAdmins(adminValues)
+	if err != nil {
+		return err
+	}
+	pairManager, err := agentpair.New(agentpair.Options{
+		Context:               ctx,
+		Self:                  slackInboundAgentPeer(auth.TeamID, botUserID, auth.User, auth.User, ""),
+		Admins:                admins,
+		Contacts:              contactsSvc,
+		JournalDir:            d.RuntimePaths.JournalDir,
+		JournalRotateMaxBytes: d.TaskRotateMaxBytes,
+		Logger:                logger,
+		Send: func(sendCtx context.Context, target agentpair.Peer, body string) error {
+			userID, targetErr := slackPairSendUserID(target)
+			if targetErr != nil {
+				return targetErr
+			}
+			return api.postDirectMessage(sendCtx, userID, body)
+		},
+	})
+	if err != nil {
+		return err
+	}
 	emojiLookupCtx, cancelEmojiLookup := context.WithTimeout(ctx, 8*time.Second)
 	availableEmojiNames, emojiErr := api.listEmojiNames(emojiLookupCtx)
 	cancelEmojiLookup()
@@ -312,11 +342,13 @@ func runSlackLoop(ctx context.Context, d Dependencies, opts RunOptions) error {
 		taskStore:           daemonStore,
 		api:                 api,
 		botUserID:           botUserID,
+		botID:               strings.TrimSpace(auth.BotID),
 		allowedTeams:        allowedTeams,
 		allowedChannels:     allowedChannels,
 		availableEmojiNames: availableEmojiNames,
 		inprocBus:           inprocBus,
 		contactsService:     contactsSvc,
+		pairManager:         pairManager,
 		workspaceStore:      workspaceStore,
 		inboundAdapter:      slackInboundAdapter,
 		deliveryAdapter:     slackDeliveryAdapter,

--- a/internal/channelruntime/slack/runtime_state.go
+++ b/internal/channelruntime/slack/runtime_state.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/quailyquaily/mistermorph/contacts"
 	"github.com/quailyquaily/mistermorph/guard"
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
 	busruntime "github.com/quailyquaily/mistermorph/internal/bus"
 	slackbus "github.com/quailyquaily/mistermorph/internal/bus/adapters/slack"
 	runtimecore "github.com/quailyquaily/mistermorph/internal/channelruntime/core"
@@ -29,11 +30,13 @@ type slackRuntimeStateConfig struct {
 	taskStore           daemonruntime.TaskView
 	api                 *slackAPI
 	botUserID           string
+	botID               string
 	allowedTeams        map[string]bool
 	allowedChannels     map[string]bool
 	availableEmojiNames []string
 	inprocBus           *busruntime.Inproc
 	contactsService     *contacts.Service
+	pairManager         *agentpair.Manager
 	workspaceStore      *workspace.Store
 	inboundAdapter      *slackbus.InboundAdapter
 	deliveryAdapter     *slackbus.DeliveryAdapter
@@ -66,11 +69,13 @@ type slackRuntimeState struct {
 	guard                         *guard.Guard
 	api                           *slackAPI
 	botUserID                     string
+	botID                         string
 	allowedTeams                  map[string]bool
 	allowedChannels               map[string]bool
 	availableEmojiNames           []string
 	availableEmojiList            string
 	contactsService               *contacts.Service
+	pairManager                   *agentpair.Manager
 	workspaceStore                *workspace.Store
 	inboundAdapter                *slackbus.InboundAdapter
 	deliveryAdapter               *slackbus.DeliveryAdapter
@@ -86,6 +91,7 @@ type slackRuntimeState struct {
 	history                       map[string][]chathistory.ChatHistoryItem
 	stickySkillsByConv            map[string][]string
 	userIdentityCache             map[string]slackUserIdentityCacheEntry
+	agentInteractions             runtimecore.AgentInteractionLimiter
 	pendingApprovals              *runtimecore.PendingApprovalRegistry[slackJob]
 	runner                        *runtimecore.ConversationRunner[string, slackJob]
 	inprocBus                     *busruntime.Inproc
@@ -138,11 +144,13 @@ func newSlackRuntimeState(config slackRuntimeStateConfig) (*slackRuntimeState, e
 		guard:                         sharedGuard,
 		api:                           config.api,
 		botUserID:                     strings.TrimSpace(config.botUserID),
+		botID:                         strings.TrimSpace(config.botID),
 		allowedTeams:                  config.allowedTeams,
 		allowedChannels:               config.allowedChannels,
 		availableEmojiNames:           append([]string(nil), config.availableEmojiNames...),
 		availableEmojiList:            strings.Join(config.availableEmojiNames, ","),
 		contactsService:               config.contactsService,
+		pairManager:                   config.pairManager,
 		workspaceStore:                config.workspaceStore,
 		inboundAdapter:                config.inboundAdapter,
 		deliveryAdapter:               config.deliveryAdapter,

--- a/internal/channelruntime/slack/runtime_state_events.go
+++ b/internal/channelruntime/slack/runtime_state_events.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
 	busruntime "github.com/quailyquaily/mistermorph/internal/bus"
 	slackbus "github.com/quailyquaily/mistermorph/internal/bus/adapters/slack"
 	runtimecore "github.com/quailyquaily/mistermorph/internal/channelruntime/core"
@@ -60,12 +61,52 @@ func (s *slackRuntimeState) resolveUserIdentity(ctx context.Context, teamID, use
 	}
 	s.mu.Lock()
 	s.userIdentityCache[cacheKey] = slackUserIdentityCacheEntry{
+		UserID:      userID,
 		Username:    username,
 		DisplayName: displayName,
 		ExpiresAt:   now.Add(slackUserIdentityCacheTTL),
 	}
 	s.mu.Unlock()
 	return username, displayName, nil
+}
+
+func (s *slackRuntimeState) resolveAgentIdentity(ctx context.Context, teamID, botID string) (slackUserIdentity, error) {
+	teamID = strings.TrimSpace(teamID)
+	botID = strings.TrimSpace(botID)
+	if teamID == "" || botID == "" {
+		return slackUserIdentity{}, fmt.Errorf("slack agent identity requires team_id and bot_id")
+	}
+	cacheKey := strings.ToUpper(teamID) + ":" + strings.ToUpper(botID)
+	now := time.Now().UTC()
+	s.mu.Lock()
+	if cached, ok := s.userIdentityCache[cacheKey]; ok && cached.ExpiresAt.After(now) {
+		s.mu.Unlock()
+		return slackUserIdentity{
+			UserID:      cached.UserID,
+			Username:    cached.Username,
+			DisplayName: cached.DisplayName,
+		}, nil
+	}
+	s.mu.Unlock()
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	identity, err := s.api.botIdentity(lookupCtx, botID)
+	if err != nil {
+		return slackUserIdentity{}, err
+	}
+	s.mu.Lock()
+	s.userIdentityCache[cacheKey] = slackUserIdentityCacheEntry{
+		UserID:      identity.UserID,
+		Username:    identity.Username,
+		DisplayName: identity.DisplayName,
+		ExpiresAt:   now.Add(slackUserIdentityCacheTTL),
+	}
+	s.mu.Unlock()
+	return identity, nil
 }
 
 func (s *slackRuntimeState) enqueueInbound(ctx context.Context, msg busruntime.BusMessage) error {
@@ -79,6 +120,19 @@ func (s *slackRuntimeState) enqueueInbound(ctx context.Context, msg busruntime.B
 	text := strings.TrimSpace(inbound.Text)
 	if text == "" {
 		return fmt.Errorf("slack inbound text is required")
+	}
+	historyScopeKey, err := buildSlackHistoryScopeKey(inbound.TeamID, inbound.ChannelID, inbound.ThreadTS)
+	if err != nil {
+		return err
+	}
+	if inbound.FromIsAgent && !s.agentInteractions.Allow(historyScopeKey, time.Now().UTC()) {
+		s.logger.Warn("agent_interaction_rate_limited",
+			"channel", "slack",
+			"conversation_key", historyScopeKey,
+			"limit", runtimecore.AgentInteractionLimit,
+			"window", runtimecore.AgentInteractionWindow,
+		)
+		return nil
 	}
 	contextCompactionOnly := chatcommands.IsContextCompactCommand(text)
 	if !contextCompactionOnly && len(inbound.ImageAttachments) == 0 {
@@ -127,6 +181,7 @@ func (s *slackRuntimeState) enqueueInbound(ctx context.Context, msg busruntime.B
 			UserID:          inbound.UserID,
 			Username:        inbound.Username,
 			DisplayName:     inbound.DisplayName,
+			FromIsAgent:     inbound.FromIsAgent,
 			Text:            text,
 			ImagePaths:      imagePaths,
 			Images:          append([]chathistory.ChatHistoryImage(nil), images...),
@@ -255,6 +310,7 @@ func (s *slackRuntimeState) appendIgnoredInboundHistory(event slackInboundEvent)
 		UserID:          event.UserID,
 		Username:        event.Username,
 		DisplayName:     event.DisplayName,
+		FromIsAgent:     event.IsAgent,
 		Text:            event.Text,
 		SentAt:          event.SentAt,
 		MentionUsers:    append([]string(nil), event.MentionUsers...),
@@ -280,6 +336,9 @@ func (s *slackRuntimeState) handleSocketEnvelope(ctx context.Context, envelope s
 	if err != nil || !ok {
 		return err
 	}
+	if event.IsAgent && strings.EqualFold(strings.TrimSpace(event.BotID), strings.TrimSpace(s.botID)) {
+		return nil
+	}
 	s.logger.Info("slack_inbound_event",
 		"event_type", event.EventType,
 		"event_subtype", event.EventSubtype,
@@ -288,16 +347,87 @@ func (s *slackRuntimeState) handleSocketEnvelope(ctx context.Context, envelope s
 		"channel_id", event.ChannelID,
 		"chat_type", event.ChatType,
 		"user_id", event.UserID,
+		"bot_id", event.BotID,
+		"from_is_agent", event.IsAgent,
 		"message_ts", event.MessageTS,
 		"thread_ts", event.ThreadTS,
 		"image_file_count", len(event.ImageFiles),
 		"is_app_mention", event.IsAppMention,
 		"is_thread_message", event.IsThreadMessage,
 	)
-	if len(s.allowedTeams) > 0 && !s.allowedTeams[event.TeamID] {
+	isGroup := isSlackGroupChat(event.ChatType)
+	normalizedCommandText := normalizeSlackCommandText(event.Text, s.botUserID)
+	commandWord, commandArgs := chatcommands.ParseCommand(normalizedCommandText)
+	normalizedCommand := chatcommands.NormalizeCommand(commandWord)
+	if agentpair.IsControlMessage(event.Text) {
+		if s.pairManager == nil || isGroup || !event.IsAgent {
+			s.logger.Warn("agent_pair_failed",
+				"channel", "slack",
+				"team_id", event.TeamID,
+				"channel_id", event.ChannelID,
+				"message_ts", event.MessageTS,
+				"reason", "invalid_control_sender_or_scope",
+			)
+			return nil
+		}
+		identity, resolveErr := s.resolveAgentIdentity(ctx, event.TeamID, event.BotID)
+		if resolveErr != nil {
+			s.logger.Warn("agent_pair_failed", "channel", "slack", "team_id", event.TeamID, "channel_id", event.ChannelID, "message_ts", event.MessageTS, "reason", "sender_identity_failed", "error", resolveErr.Error())
+			return nil
+		}
+		peer := slackInboundAgentPeer(event.TeamID, identity.UserID, identity.Username, identity.DisplayName, event.ChannelID)
+		_, handled, pairErr := s.pairManager.Handle(ctx, peer, event.Text)
+		if pairErr != nil {
+			s.logger.Warn("agent_pair_failed", "channel", "slack", "team_id", event.TeamID, "channel_id", event.ChannelID, "message_ts", event.MessageTS, "peer_agent_id", peer.ID, "reason", "offer_rejected", "error", pairErr.Error())
+		}
+		if handled {
+			return nil
+		}
+	}
+	if normalizedCommand == "/pair" {
+		if isGroup || event.IsAgent || s.pairManager == nil {
+			s.logger.Warn("agent_pair_failed",
+				"channel", "slack",
+				"team_id", event.TeamID,
+				"channel_id", event.ChannelID,
+				"message_ts", event.MessageTS,
+				"reason", "pair_command_requires_private_human_sender",
+			)
+			return nil
+		}
+		target, targetErr := slackPairTarget(commandArgs, event.TeamID)
+		var status agentpair.Status
+		if targetErr == nil {
+			adminID := "slack:" + strings.TrimSpace(event.TeamID) + ":" + strings.TrimSpace(event.UserID)
+			status, targetErr = s.pairManager.Start(ctx, adminID, target, "")
+		} else {
+			s.logger.Warn("agent_pair_failed", "channel", "slack", "team_id", event.TeamID, "channel_id", event.ChannelID, "message_ts", event.MessageTS, "reason", "invalid_target", "error", targetErr.Error())
+		}
+		sendSlackPairReply(ctx, s.api, event.ChannelID, status, targetErr)
 		return nil
 	}
-	if len(s.allowedChannels) > 0 && !s.allowedChannels[event.ChannelID] {
+	pairedAgent := false
+	agentIdentityResolved := false
+	agentUsername := ""
+	agentDisplayName := ""
+	if event.IsAgent && !isGroup && s.pairManager != nil {
+		identity, resolveErr := s.resolveAgentIdentity(ctx, event.TeamID, event.BotID)
+		if resolveErr != nil {
+			s.logger.Warn("slack_sender_identity_enrichment_failed", "team_id", event.TeamID, "channel_id", event.ChannelID, "bot_id", event.BotID, "error", resolveErr.Error())
+			return nil
+		}
+		event.UserID = identity.UserID
+		agentUsername = identity.Username
+		agentDisplayName = identity.DisplayName
+		agentIdentityResolved = true
+		peer := slackInboundAgentPeer(event.TeamID, identity.UserID, identity.Username, identity.DisplayName, event.ChannelID)
+		pairedAgent, err = s.pairManager.IsPaired(ctx, peer)
+		if err != nil {
+			s.logger.Warn("slack_agent_pair_lookup_failed", "team_id", event.TeamID, "channel_id", event.ChannelID, "message_ts", event.MessageTS, "peer_agent_id", peer.ID, "error", err.Error())
+			pairedAgent = false
+		}
+	}
+	if !slackChatAuthorized(s.allowedTeams, s.allowedChannels, event.TeamID, event.ChannelID, event.ChatType, event.IsAgent, pairedAgent) {
 		return nil
 	}
 	conversationKey, err := buildSlackConversationKey(event.TeamID, event.ChannelID)
@@ -308,9 +438,51 @@ func (s *slackRuntimeState) handleSocketEnvelope(ctx context.Context, envelope s
 	if err != nil {
 		return err
 	}
-	username, displayName, identityErr := s.resolveUserIdentity(ctx, event.TeamID, event.UserID)
+	firstMentionFound, firstMentionTargetsSelf := slackFirstBodyMentionTargetsSelf(event.MentionUsers, s.botUserID)
+	if shouldIgnoreSlackFirstMention(event.ChatType, event.IsAgent, firstMentionFound, firstMentionTargetsSelf) {
+		s.logger.Info("slack_message_ignored_first_mention",
+			"team_id", event.TeamID,
+			"channel_id", event.ChannelID,
+			"message_ts", event.MessageTS,
+			"from_is_agent", event.IsAgent,
+			"first_mention_found", firstMentionFound,
+		)
+		if strings.EqualFold(s.groupTriggerMode, "talkative") {
+			s.appendIgnoredInboundHistory(event)
+		}
+		if s.untriggeredRecorder != nil && !event.IsAgent {
+			if recordErr := s.untriggeredRecorder.Record(runtimecore.UntriggeredMessage{
+				Channel:         string(busruntime.ChannelSlack),
+				ConversationKey: historyScopeKey,
+				MessageID:       event.MessageTS,
+				SenderID:        event.UserID,
+				SentAt:          event.SentAt,
+				Text:            event.Text,
+				HasAttachment:   len(event.ImageFiles) > 0,
+			}); recordErr != nil {
+				s.logger.Error("slack_untriggered_journal_append_error", "channel_id", event.ChannelID, "message_ts", event.MessageTS, "error", recordErr.Error())
+			}
+		}
+		return nil
+	}
+	var username, displayName string
+	var identityErr error
+	if agentIdentityResolved {
+		username = agentUsername
+		displayName = agentDisplayName
+	} else if event.IsAgent {
+		identity, resolveErr := s.resolveAgentIdentity(ctx, event.TeamID, event.BotID)
+		identityErr = resolveErr
+		if resolveErr == nil {
+			event.UserID = identity.UserID
+			username = identity.Username
+			displayName = identity.DisplayName
+		}
+	} else {
+		username, displayName, identityErr = s.resolveUserIdentity(ctx, event.TeamID, event.UserID)
+	}
 	if identityErr != nil {
-		s.logger.Warn("slack_user_identity_enrichment_failed",
+		s.logger.Warn("slack_sender_identity_enrichment_failed",
 			"conversation_key", conversationKey,
 			"team_id", event.TeamID,
 			"channel_id", event.ChannelID,
@@ -336,7 +508,6 @@ func (s *slackRuntimeState) handleSocketEnvelope(ctx context.Context, envelope s
 	s.mu.Lock()
 	currentSkills := append([]string(nil), s.stickySkillsByConv[historyScopeKey]...)
 	s.mu.Unlock()
-	normalizedCommandText := normalizeSlackCommandText(event.Text, s.botUserID)
 	contextCompactionOnly := chatcommands.IsContextCompactCommand(normalizedCommandText)
 	if contextCompactionOnly && isSlackGroupChat(event.ChatType) && !slackCommandExplicitlyAddressed(event.Text, s.botUserID) {
 		return nil
@@ -379,7 +550,6 @@ func (s *slackRuntimeState) handleSocketEnvelope(ctx context.Context, envelope s
 		event.Text = normalizedCommandText
 	}
 
-	isGroup := isSlackGroupChat(event.ChatType)
 	if isGroup && !contextCompactionOnly {
 		s.mu.Lock()
 		historySnapshot := append([]chathistory.ChatHistoryItem(nil), s.history[historyScopeKey]...)
@@ -524,6 +694,7 @@ func (s *slackRuntimeState) handleSocketEnvelope(ctx context.Context, envelope s
 		UserID:           event.UserID,
 		Username:         event.Username,
 		DisplayName:      event.DisplayName,
+		FromIsAgent:      event.IsAgent,
 		Text:             event.Text,
 		SentAt:           event.SentAt,
 		MentionUsers:     append([]string(nil), event.MentionUsers...),

--- a/internal/channelruntime/slack/runtime_task.go
+++ b/internal/channelruntime/slack/runtime_task.go
@@ -294,6 +294,9 @@ func todoResolveContextForSlack(job slackJob) todo.AddResolveContext {
 }
 
 func contactsSendRuntimeContextForSlack(job slackJob) builtin.ContactsSendRuntimeContext {
+	if job.FromIsAgent {
+		return builtin.ContactsSendRuntimeContext{}
+	}
 	ids := make([]string, 0, 2)
 	teamID := strings.TrimSpace(job.TeamID)
 	if teamID != "" {
@@ -331,7 +334,7 @@ func newSlackInboundHistoryItem(job slackJob) chathistory.ChatHistoryItem {
 		MessageID:        strings.TrimSpace(job.MessageTS),
 		ReplyToMessageID: strings.TrimSpace(job.ThreadTS),
 		SentAt:           job.SentAt.UTC(),
-		Sender:           slackSenderFromJob(job, false, ""),
+		Sender:           slackSenderFromJob(job, job.FromIsAgent, ""),
 		Text:             slackHistoryText(job.Text, len(job.ImagePaths)),
 		Images:           append([]chathistory.ChatHistoryImage(nil), job.Images...),
 	}
@@ -471,7 +474,7 @@ func escapeSlackMRKDWN(text string) string {
 }
 
 func slackSenderFromJob(job slackJob, isBot bool, botUserID string) chathistory.ChatHistorySender {
-	if isBot {
+	if isBot && strings.TrimSpace(botUserID) != "" {
 		return chathistory.ChatHistorySender{
 			UserID:     strings.TrimSpace(botUserID),
 			Username:   "slack-bot",
@@ -485,6 +488,9 @@ func slackSenderFromJob(job slackJob, isBot bool, botUserID string) chathistory.
 		mentionRef = "<@" + mentionRef + ">"
 	}
 	nickname := strings.TrimSpace(job.DisplayName)
+	if nickname == "" {
+		nickname = strings.TrimSpace(job.Username)
+	}
 	if nickname == "" {
 		nickname = mentionRef
 	}
@@ -502,7 +508,7 @@ func slackSenderFromJob(job slackJob, isBot bool, botUserID string) chathistory.
 		UserID:     strings.TrimSpace(job.UserID),
 		Username:   username,
 		Nickname:   nickname,
-		IsBot:      false,
+		IsBot:      isBot,
 		DisplayRef: displayRef,
 	}
 }

--- a/internal/channelruntime/slack/runtime_task.go
+++ b/internal/channelruntime/slack/runtime_task.go
@@ -209,6 +209,9 @@ func runSlackTask(
 		HistoryBoundaries:      historyBoundaries,
 		CurrentMessageBoundary: checkpointHistory.CurrentMessageBoundary,
 	}
+	if job.FromIsAgent && strings.EqualFold(strings.TrimSpace(job.ChatType), "im") {
+		runReq.ToolTriggers = map[string]bool{toolsutil.BuiltinContactsSend: true}
+	}
 	var result taskruntime.RunResult
 	if approvalID := strings.TrimSpace(job.ResumeApprovalID); approvalID != "" {
 		result, err = rt.Resume(ctx, approvalID, runReq)

--- a/internal/channelruntime/slack/runtime_task_test.go
+++ b/internal/channelruntime/slack/runtime_task_test.go
@@ -75,6 +75,37 @@ func TestContactsSendRuntimeContextForSlackDirectMessage(t *testing.T) {
 	}
 }
 
+func TestContactsSendRuntimeContextForSlackAgentSender(t *testing.T) {
+	ctx := contactsSendRuntimeContextForSlack(slackJob{
+		TeamID:      "T1",
+		ChannelID:   "D1",
+		ChatType:    "im",
+		UserID:      "U1",
+		FromIsAgent: true,
+	})
+	if len(ctx.ForbiddenTargetIDs) != 0 {
+		t.Fatalf("forbidden_target_ids = %#v, want empty", ctx.ForbiddenTargetIDs)
+	}
+}
+
+func TestNewSlackInboundHistoryItemMarksAgentSender(t *testing.T) {
+	item := newSlackInboundHistoryItem(slackJob{
+		TeamID:      "T1",
+		ChannelID:   "C1",
+		ChatType:    "channel",
+		MessageTS:   "1739667600.000100",
+		UserID:      "U1",
+		Username:    "smith",
+		DisplayName: "Smith",
+		FromIsAgent: true,
+		Text:        "<@UBOT> continue",
+		SentAt:      time.Now().UTC(),
+	})
+	if !item.Sender.IsBot {
+		t.Fatal("sender IsBot = false, want true")
+	}
+}
+
 func TestNewSlackOutboundReactionHistoryItem(t *testing.T) {
 	job := slackJob{
 		TeamID:      "T1",

--- a/internal/channelruntime/slack/runtime_test.go
+++ b/internal/channelruntime/slack/runtime_test.go
@@ -123,6 +123,92 @@ func TestParseSlackInboundEvent_IgnoresSelfMessage(t *testing.T) {
 	}
 }
 
+func TestParseSlackInboundEvent_BotMessage(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"team_id":  "T111",
+		"event_id": "EvBot",
+		"event": map[string]any{
+			"type":         "message",
+			"subtype":      "bot_message",
+			"bot_id":       "B222",
+			"text":         "<@U999> continue after <@U888>",
+			"channel":      "C222",
+			"channel_type": "channel",
+			"ts":           "1739667600.000200",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	event, ok, err := parseSlackInboundEvent(slackSocketEnvelope{Type: "events_api", Payload: payload}, "U999")
+	if err != nil {
+		t.Fatalf("parseSlackInboundEvent() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("parseSlackInboundEvent() ok=false, want true")
+	}
+	if !event.IsAgent || event.BotID != "B222" {
+		t.Fatalf("agent identity = is_agent %v bot_id %q, want true B222", event.IsAgent, event.BotID)
+	}
+	if event.UserID != "" {
+		t.Fatalf("user_id = %q, want empty before bots.info", event.UserID)
+	}
+	if !reflect.DeepEqual(event.MentionUsers, []string{"U999", "U888"}) {
+		t.Fatalf("mention users = %#v, want [U999 U888]", event.MentionUsers)
+	}
+}
+
+func TestSlackFirstBodyMentionTargetsSelf(t *testing.T) {
+	tests := []struct {
+		name       string
+		mentions   []string
+		wantFound  bool
+		wantTarget bool
+	}{
+		{name: "self first", mentions: []string{"U999", "U888"}, wantFound: true, wantTarget: true},
+		{name: "other first", mentions: []string{"U888", "U999"}, wantFound: true},
+		{name: "no mention"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found, targetsSelf := slackFirstBodyMentionTargetsSelf(tt.mentions, "U999")
+			if found != tt.wantFound || targetsSelf != tt.wantTarget {
+				t.Fatalf("slackFirstBodyMentionTargetsSelf() = (%v, %v), want (%v, %v)", found, targetsSelf, tt.wantFound, tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestShouldIgnoreSlackFirstMention(t *testing.T) {
+	tests := []struct {
+		name        string
+		chatType    string
+		fromAgent   bool
+		found       bool
+		targetsSelf bool
+		want        bool
+	}{
+		{name: "direct agent without mention", chatType: "im", fromAgent: true},
+		{name: "direct agent mentioning another agent", chatType: "im", fromAgent: true, found: true},
+		{name: "channel agent without mention", chatType: "channel", fromAgent: true, want: true},
+		{name: "channel agent mentioning self", chatType: "channel", fromAgent: true, found: true, targetsSelf: true},
+		{name: "channel agent mentioning another agent", chatType: "channel", fromAgent: true, found: true, want: true},
+		{name: "channel human without mention", chatType: "channel"},
+		{name: "channel human mentioning another agent", chatType: "channel", found: true, want: true},
+		{name: "direct human mentioning another agent", chatType: "im", found: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldIgnoreSlackFirstMention(tt.chatType, tt.fromAgent, tt.found, tt.targetsSelf)
+			if got != tt.want {
+				t.Fatalf("shouldIgnoreSlackFirstMention() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseSlackInboundEventWithImageFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/channelruntime/slack/slack_api.go
+++ b/internal/channelruntime/slack/slack_api.go
@@ -71,6 +71,15 @@ type slackUserIdentity struct {
 	DisplayName string
 }
 
+type slackBotInfoResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+	Bot   struct {
+		Name   string `json:"name,omitempty"`
+		UserID string `json:"user_id,omitempty"`
+	} `json:"bot,omitempty"`
+}
+
 type slackUserInfoResponse struct {
 	OK    bool   `json:"ok"`
 	Error string `json:"error,omitempty"`
@@ -194,6 +203,49 @@ func (api *slackAPI) userIdentity(ctx context.Context, userID string) (slackUser
 		UserID:      resolvedUserID,
 		Username:    username,
 		DisplayName: displayName,
+	}, nil
+}
+
+func (api *slackAPI) botIdentity(ctx context.Context, botID string) (slackUserIdentity, error) {
+	if api == nil {
+		return slackUserIdentity{}, fmt.Errorf("slack api is not initialized")
+	}
+	botID = strings.TrimSpace(botID)
+	if botID == "" {
+		return slackUserIdentity{}, fmt.Errorf("slack bot id is required")
+	}
+	body, status, _, err := api.postAuthForm(ctx, api.botToken, "/bots.info", url.Values{
+		"bot": []string{botID},
+	})
+	if err != nil {
+		return slackUserIdentity{}, err
+	}
+	if status < 200 || status >= 300 {
+		return slackUserIdentity{}, fmt.Errorf("slack bots.info http %d", status)
+	}
+	var out slackBotInfoResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return slackUserIdentity{}, err
+	}
+	if !out.OK {
+		code := strings.TrimSpace(out.Error)
+		if code == "" {
+			code = "unknown_error"
+		}
+		return slackUserIdentity{}, fmt.Errorf("slack bots.info failed: %s", code)
+	}
+	userID := strings.TrimSpace(out.Bot.UserID)
+	if userID == "" {
+		return slackUserIdentity{}, fmt.Errorf("slack bots.info returned empty user_id")
+	}
+	name := strings.TrimSpace(out.Bot.Name)
+	if name == "" {
+		name = userID
+	}
+	return slackUserIdentity{
+		UserID:      userID,
+		Username:    name,
+		DisplayName: name,
 	}, nil
 }
 
@@ -338,6 +390,14 @@ type slackOpenConnectionResponse struct {
 	URL   string `json:"url,omitempty"`
 }
 
+type slackOpenConversationResponse struct {
+	OK      bool   `json:"ok"`
+	Error   string `json:"error,omitempty"`
+	Channel struct {
+		ID string `json:"id,omitempty"`
+	} `json:"channel,omitempty"`
+}
+
 type slackReactionResponse struct {
 	OK    bool   `json:"ok"`
 	Error string `json:"error,omitempty"`
@@ -402,6 +462,45 @@ func (api *slackAPI) connectSocket(ctx context.Context) (*websocket.Conn, error)
 func (api *slackAPI) postMessage(ctx context.Context, channelID, text, threadTS string) error {
 	client := slackclient.New(api.http, api.baseURL, api.botToken)
 	return client.PostMessage(ctx, channelID, text, threadTS)
+}
+
+func (api *slackAPI) postDirectMessage(ctx context.Context, userID, text string) error {
+	if api == nil {
+		return fmt.Errorf("slack api is not initialized")
+	}
+	userID = strings.TrimSpace(userID)
+	text = strings.TrimSpace(text)
+	if userID == "" {
+		return fmt.Errorf("slack user id is required")
+	}
+	if text == "" {
+		return fmt.Errorf("slack direct message is empty")
+	}
+	body, status, _, err := api.postAuthJSON(ctx, api.botToken, "/conversations.open", map[string]any{
+		"users": userID,
+	})
+	if err != nil {
+		return err
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("slack conversations.open http %d", status)
+	}
+	var out slackOpenConversationResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return err
+	}
+	if !out.OK {
+		code := strings.TrimSpace(out.Error)
+		if code == "" {
+			code = "unknown_error"
+		}
+		return fmt.Errorf("slack conversations.open failed: %s", code)
+	}
+	channelID := strings.TrimSpace(out.Channel.ID)
+	if channelID == "" {
+		return fmt.Errorf("slack conversations.open returned empty channel id")
+	}
+	return api.postMessage(ctx, channelID, text, "")
 }
 
 func (api *slackAPI) postMessageWithBlocks(ctx context.Context, channelID, text, threadTS string, blocks []slackclient.Block) error {

--- a/internal/channelruntime/slack/slack_api_test.go
+++ b/internal/channelruntime/slack/slack_api_test.go
@@ -66,6 +66,40 @@ func TestSlackAPIUserIdentity(t *testing.T) {
 	}
 }
 
+func TestSlackAPIBotIdentity(t *testing.T) {
+	server := testhttp.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/bots.info" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/bots.info")
+		}
+		rawBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read payload: %v", err)
+		}
+		payload, err := url.ParseQuery(string(rawBody))
+		if err != nil {
+			t.Fatalf("parse payload: %v", err)
+		}
+		if got := payload.Get("bot"); got != "B222" {
+			t.Fatalf("bot = %q, want %q", got, "B222")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"bot": map[string]any{
+				"name":    "Smith",
+				"user_id": "U222",
+			},
+		})
+	}))
+
+	identity, err := newSlackAPI(server.Client, server.URL, "xoxb-test", "xapp-test").botIdentity(context.Background(), "B222")
+	if err != nil {
+		t.Fatalf("botIdentity() error = %v", err)
+	}
+	if identity.UserID != "U222" || identity.Username != "Smith" || identity.DisplayName != "Smith" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
 func TestSlackAPIUserIdentityFallbackAndError(t *testing.T) {
 	t.Run("fallback to username for display name", func(t *testing.T) {
 		server := testhttp.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/channelruntime/slack/socket_events.go
+++ b/internal/channelruntime/slack/socket_events.go
@@ -113,6 +113,7 @@ type slackInboundEvent struct {
 	MessageTS        string
 	ThreadTS         string
 	UserID           string
+	BotID            string
 	Username         string
 	DisplayName      string
 	Text             string
@@ -123,6 +124,7 @@ type slackInboundEvent struct {
 	ImageAttachments []busruntime.ImageAttachment
 	IsAppMention     bool
 	IsThreadMessage  bool
+	IsAgent          bool
 }
 
 var slackMentionPattern = regexp.MustCompile(`<@([A-Z0-9]+)(?:\|[^>]+)?>`)
@@ -189,11 +191,10 @@ func parseSlackInboundEvent(envelope slackSocketEnvelope, botUserID string) (sla
 	if !acceptSlackMessageSubtype(subtype, imageFiles) {
 		return slackInboundEvent{}, false, nil
 	}
-	if strings.TrimSpace(event.BotID) != "" {
-		return slackInboundEvent{}, false, nil
-	}
+	botID := strings.TrimSpace(event.BotID)
+	isAgent := subtype == "bot_message" || botID != ""
 	userID := strings.TrimSpace(event.User)
-	if userID == "" {
+	if (isAgent && botID == "") || (!isAgent && userID == "") {
 		return slackInboundEvent{}, false, nil
 	}
 	if userID == strings.TrimSpace(botUserID) {
@@ -238,6 +239,7 @@ func parseSlackInboundEvent(envelope slackSocketEnvelope, botUserID string) (sla
 		MessageTS:       messageTS,
 		ThreadTS:        strings.TrimSpace(event.ThreadTS),
 		UserID:          userID,
+		BotID:           botID,
 		Text:            text,
 		EventID:         strings.TrimSpace(payload.EventID),
 		SentAt:          sentAt,
@@ -245,7 +247,26 @@ func parseSlackInboundEvent(envelope slackSocketEnvelope, botUserID string) (sla
 		ImageFiles:      imageFiles,
 		IsAppMention:    isAppMention,
 		IsThreadMessage: strings.TrimSpace(event.ThreadTS) != "",
+		IsAgent:         isAgent,
 	}, true, nil
+}
+
+func slackFirstBodyMentionTargetsSelf(mentionUsers []string, botUserID string) (bool, bool) {
+	if len(mentionUsers) == 0 {
+		return false, false
+	}
+	first := strings.TrimSpace(mentionUsers[0])
+	return true, first != "" && strings.EqualFold(first, strings.TrimSpace(botUserID))
+}
+
+func shouldIgnoreSlackFirstMention(chatType string, fromIsAgent bool, firstMentionFound bool, firstMentionTargetsSelf bool) bool {
+	if !isSlackGroupChat(chatType) {
+		return false
+	}
+	if fromIsAgent && !firstMentionFound {
+		return true
+	}
+	return firstMentionFound && !firstMentionTargetsSelf
 }
 
 func parseSlackApprovalAction(envelope slackSocketEnvelope) (slackApprovalActionEvent, bool, error) {
@@ -291,7 +312,7 @@ func acceptSlackMessageSubtype(subtype string, imageFiles []slackEventFile) bool
 	if subtype == "" {
 		return true
 	}
-	return subtype == "file_share" && len(imageFiles) > 0
+	return subtype == "bot_message" || (subtype == "file_share" && len(imageFiles) > 0)
 }
 
 func slackImageFilesFromEvent(files []slackEventFile) []slackEventFile {

--- a/internal/channelruntime/taskruntime/runtime.go
+++ b/internal/channelruntime/taskruntime/runtime.go
@@ -597,6 +597,13 @@ func (rt *Runtime) prepareRun(ctx context.Context, req RunRequest) (preparedRunt
 		if len(rt.ACPAgents) == 0 {
 			delete(toolTriggers, toolsutil.BuiltinACPSpawn)
 		}
+		if rt.commonDeps.RegisterTriggeredStaticTools != nil {
+			reg.Remove(toolsutil.BuiltinAgentSend)
+			if toolTriggers == nil {
+				toolTriggers = make(map[string]bool)
+			}
+			toolTriggers[toolsutil.BuiltinAgentSend] = true
+		}
 		if rt.commonDeps.RegisterTriggeredStaticTools != nil && len(toolTriggers) > 0 {
 			rt.commonDeps.RegisterTriggeredStaticTools(reg, toolTriggers)
 		}

--- a/internal/channelruntime/taskruntime/runtime.go
+++ b/internal/channelruntime/taskruntime/runtime.go
@@ -147,6 +147,7 @@ type RunRequest struct {
 	CurrentMessage           *llm.Message
 	Meta                     map[string]any
 	Registry                 *tools.Registry
+	ToolTriggers             map[string]bool
 	DisableRuntimeTools      bool
 	DisableTodoWorkflow      bool
 	Hook                     agent.Hook
@@ -593,6 +594,15 @@ func (rt *Runtime) prepareRun(ctx context.Context, req RunRequest) (preparedRunt
 	if !req.DisableRuntimeTools {
 		if rt.commonDeps.ToolTriggers != nil {
 			toolTriggers = rt.commonDeps.ToolTriggers(task)
+		}
+		for name, triggered := range req.ToolTriggers {
+			if !triggered {
+				continue
+			}
+			if toolTriggers == nil {
+				toolTriggers = make(map[string]bool)
+			}
+			toolTriggers[name] = true
 		}
 		if len(rt.ACPAgents) == 0 {
 			delete(toolTriggers, toolsutil.BuiltinACPSpawn)

--- a/internal/channelruntime/taskruntime/runtime_test.go
+++ b/internal/channelruntime/taskruntime/runtime_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/quailyquaily/mistermorph/internal/toolsutil"
 	"github.com/quailyquaily/mistermorph/llm"
 	"github.com/quailyquaily/mistermorph/tools"
+	"github.com/quailyquaily/mistermorph/tools/builtin"
 )
 
 type stubTaskRuntimeClient struct {
@@ -300,6 +301,43 @@ func TestPreparedEngineExposesLoadedSkills(t *testing.T) {
 	defer func() { _ = prepared.Cleanup() }()
 	if got := strings.Join(prepared.LoadedSkills, ","); got != "repo-skill" {
 		t.Fatalf("LoadedSkills = %q, want repo-skill", got)
+	}
+}
+
+func TestPrepareRunRefreshesAgentSendRegistration(t *testing.T) {
+	deps := lifecycleTaskRuntimeDeps(func(llmutil.ResolvedRoute) (llm.Client, error) {
+		return &lifecycleTaskRuntimeClient{}, nil
+	})
+	deps.Registry = func() *tools.Registry {
+		reg := tools.NewRegistry()
+		if err := reg.Register(builtin.NewAgentSendTool(builtin.ContactsSendToolOptions{Enabled: true})); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		return reg
+	}
+	var refreshCalled bool
+	deps.RegisterTriggeredStaticTools = func(reg *tools.Registry, triggers map[string]bool) {
+		refreshCalled = true
+		if !triggers[toolsutil.BuiltinAgentSend] {
+			t.Fatal("agent_send availability trigger is missing")
+		}
+		if _, ok := reg.Get(toolsutil.BuiltinAgentSend); ok {
+			t.Fatal("stale agent_send remained before availability refresh")
+		}
+	}
+	rt, err := NewRunPreparer(deps, BootstrapOptions{})
+	if err != nil {
+		t.Fatalf("NewRunPreparer() error = %v", err)
+	}
+	defer func() { _ = rt.Close() }()
+
+	prepared, err := rt.PrepareEngine(context.Background(), RunRequest{Task: "ping"})
+	if err != nil {
+		t.Fatalf("PrepareEngine() error = %v", err)
+	}
+	defer func() { _ = prepared.Cleanup() }()
+	if !refreshCalled {
+		t.Fatal("agent_send availability was not refreshed")
 	}
 }
 

--- a/internal/channelruntime/taskruntime/runtime_test.go
+++ b/internal/channelruntime/taskruntime/runtime_test.go
@@ -341,6 +341,41 @@ func TestPrepareRunRefreshesAgentSendRegistration(t *testing.T) {
 	}
 }
 
+func TestPrepareRunMergesPerRunToolTriggers(t *testing.T) {
+	deps := lifecycleTaskRuntimeDeps(func(llmutil.ResolvedRoute) (llm.Client, error) {
+		return &lifecycleTaskRuntimeClient{}, nil
+	})
+	deps.ToolTriggers = func(string) map[string]bool {
+		return map[string]bool{toolsutil.BuiltinBash: true}
+	}
+	var gotTriggers map[string]bool
+	deps.RegisterTriggeredStaticTools = func(_ *tools.Registry, triggers map[string]bool) {
+		gotTriggers = make(map[string]bool, len(triggers))
+		for name, triggered := range triggers {
+			gotTriggers[name] = triggered
+		}
+	}
+	rt, err := NewRunPreparer(deps, BootstrapOptions{})
+	if err != nil {
+		t.Fatalf("NewRunPreparer() error = %v", err)
+	}
+	defer func() { _ = rt.Close() }()
+
+	prepared, err := rt.PrepareEngine(context.Background(), RunRequest{
+		Task:         "ping",
+		ToolTriggers: map[string]bool{toolsutil.BuiltinContactsSend: true},
+	})
+	if err != nil {
+		t.Fatalf("PrepareEngine() error = %v", err)
+	}
+	defer func() { _ = prepared.Cleanup() }()
+	for _, name := range []string{toolsutil.BuiltinBash, toolsutil.BuiltinContactsSend, toolsutil.BuiltinAgentSend} {
+		if !gotTriggers[name] {
+			t.Fatalf("tool trigger %q missing from %#v", name, gotTriggers)
+		}
+	}
+}
+
 func TestRunRequestForwardsToolCallbacksToPreparedEngine(t *testing.T) {
 	client := &approvalResumeClient{}
 	tool := &approvalResumeTool{}

--- a/internal/channelruntime/telegram/agent_pair.go
+++ b/internal/channelruntime/telegram/agent_pair.go
@@ -1,0 +1,90 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/quailyquaily/mistermorph/contacts"
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
+)
+
+func telegramPairTarget(args string) (agentpair.Peer, error) {
+	target := strings.TrimSpace(args)
+	if !strings.HasPrefix(target, "@") || strings.Count(target, "@") != 1 || strings.ContainsAny(target, " \t\r\n:") || len(target) == 1 {
+		return agentpair.Peer{}, fmt.Errorf("usage: /pair @Agent")
+	}
+	username := strings.TrimPrefix(target, "@")
+	return agentpair.Peer{
+		ID: "tg:@" + username,
+		Contact: contacts.Contact{
+			ContactID:  "tg:@" + username,
+			Kind:       contacts.KindAgent,
+			Channel:    contacts.ChannelTelegram,
+			TGUsername: username,
+		},
+	}, nil
+}
+
+func telegramInboundAgentPeer(userID int64, username, displayName string, privateChatID int64) agentpair.Peer {
+	stableID := "tg:" + strconv.FormatInt(userID, 10)
+	username = strings.TrimSpace(strings.TrimPrefix(username, "@"))
+	contactID := stableID
+	if username != "" {
+		contactID = "tg:@" + username
+	}
+	return agentpair.Peer{
+		ID: stableID,
+		Contact: contacts.Contact{
+			ContactID:       contactID,
+			Kind:            contacts.KindAgent,
+			Channel:         contacts.ChannelTelegram,
+			ContactNickname: strings.TrimSpace(displayName),
+			TGUsername:      username,
+			TGPrivateChatID: privateChatID,
+		},
+	}
+}
+
+func telegramChatAuthorized(allowedChatIDs map[int64]bool, chatID int64, isGroup, fromAgent, pairedAgent bool) bool {
+	if len(allowedChatIDs) == 0 || allowedChatIDs[chatID] {
+		return true
+	}
+	return !isGroup && fromAgent && pairedAgent
+}
+
+func telegramPairSendTarget(peer agentpair.Peer) (string, error) {
+	refs := []string{peer.ID}
+	if username := strings.TrimSpace(strings.TrimPrefix(peer.Contact.TGUsername, "@")); username != "" {
+		refs = append(refs, "tg:@"+username)
+	}
+	for _, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		if strings.HasPrefix(strings.ToLower(ref), "tg:@") {
+			username := strings.TrimSpace(ref[len("tg:"):])
+			if len(username) > 1 {
+				return username, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("Telegram pair target requires a username")
+}
+
+func sendTelegramPairReply(ctx context.Context, api *telegramAPI, chatID, messageThreadID int64, status agentpair.Status, err error) {
+	if api == nil {
+		return
+	}
+	reply := "Pairing request sent. It expires in 5 minutes."
+	if err != nil {
+		reply = "Pairing failed: " + strings.TrimSpace(err.Error())
+	} else {
+		switch status {
+		case agentpair.StatusCompleted:
+			reply = "Agent pairing completed."
+		case agentpair.StatusAlreadyPaired:
+			reply = "This Agent is already paired."
+		}
+	}
+	_ = api.sendMessageHTMLInThread(ctx, chatID, messageThreadID, reply, true)
+}

--- a/internal/channelruntime/telegram/agent_pair_test.go
+++ b/internal/channelruntime/telegram/agent_pair_test.go
@@ -151,3 +151,30 @@ func TestTelegramPrivateAdminPairCommandRunsBeforeAllowlist(t *testing.T) {
 		t.Fatalf("journal events = %v", eventTypes)
 	}
 }
+
+func TestTelegramUnpairedPrivateAgentDoesNotReceiveUnauthorizedReply(t *testing.T) {
+	requestCount := 0
+	server := testhttp.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	state := &telegramRuntimeState{
+		logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		api:              newTelegramAPI(server.Client, server.URL, "token"),
+		allowedChatIDs:   map[int64]bool{99: true},
+		botUser:          "agent_a",
+		botID:            1001,
+		groupTriggerMode: "strict",
+	}
+
+	state.handleUpdate(telegramUpdate{Message: &telegramMessage{
+		MessageID: 1,
+		Chat:      &telegramChat{ID: 2002, Type: "private"},
+		From:      &telegramUser{ID: 2002, IsBot: true, Username: "agent_b"},
+		Text:      "hello",
+	}})
+
+	if requestCount != 0 {
+		t.Fatalf("Telegram API request count = %d, want 0", requestCount)
+	}
+}

--- a/internal/channelruntime/telegram/agent_pair_test.go
+++ b/internal/channelruntime/telegram/agent_pair_test.go
@@ -1,0 +1,153 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/quailyquaily/mistermorph/contacts"
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
+	"github.com/quailyquaily/mistermorph/internal/domainjournal"
+	"github.com/quailyquaily/mistermorph/internal/testhttp"
+)
+
+func TestTelegramPairTargetRequiresOneUsername(t *testing.T) {
+	target, err := telegramPairTarget("@AgentB")
+	if err != nil {
+		t.Fatalf("telegramPairTarget() error = %v", err)
+	}
+	if target.ID != "tg:@AgentB" || target.Contact.TGUsername != "AgentB" {
+		t.Fatalf("telegramPairTarget() = %#v", target)
+	}
+
+	for _, raw := range []string{"", "AgentB", "@AgentB extra", "@Agent:B", "@@AgentB"} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := telegramPairTarget(raw); err == nil {
+				t.Fatalf("telegramPairTarget(%q) expected error", raw)
+			}
+		})
+	}
+}
+
+func TestTelegramPairedAgentBypassesAllowlistOnlyInPrivateChat(t *testing.T) {
+	allowed := map[int64]bool{100: true}
+	tests := []struct {
+		name        string
+		chatID      int64
+		isGroup     bool
+		fromAgent   bool
+		pairedAgent bool
+		want        bool
+	}{
+		{name: "configured chat", chatID: 100, isGroup: true, want: true},
+		{name: "unconfigured private human", chatID: 200},
+		{name: "paired private Agent", chatID: 200, fromAgent: true, pairedAgent: true, want: true},
+		{name: "paired flag does not authorize human", chatID: 200, pairedAgent: true},
+		{name: "paired Agent does not bypass group allowlist", chatID: -200, isGroup: true, fromAgent: true, pairedAgent: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := telegramChatAuthorized(allowed, tt.chatID, tt.isGroup, tt.fromAgent, tt.pairedAgent); got != tt.want {
+				t.Fatalf("telegramChatAuthorized() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+	if !telegramChatAuthorized(nil, 200, false, false, false) {
+		t.Fatal("empty allowlist should allow ordinary chats")
+	}
+}
+
+func TestTelegramSendDirectTextSupportsUsernameTarget(t *testing.T) {
+	var request telegramDirectMessageRequest
+	server := testhttp.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	api := newTelegramAPI(server.Client, server.URL, "token")
+	if err := api.sendDirectText(context.Background(), "@AgentB", "pair-control"); err != nil {
+		t.Fatalf("sendDirectText() error = %v", err)
+	}
+	if request.ChatID != "@AgentB" || request.Text != "pair-control" {
+		t.Fatalf("request = %#v", request)
+	}
+}
+
+func TestTelegramPrivateAdminPairCommandRunsBeforeAllowlist(t *testing.T) {
+	var chatTargets []any
+	server := testhttp.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		chatTargets = append(chatTargets, request["chat_id"])
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	api := newTelegramAPI(server.Client, server.URL, "token")
+	root := t.TempDir()
+	store := contacts.NewFileStore(filepath.Join(root, "contacts"))
+	admins, err := agentpair.ParseAdmins([]string{"tg:@admin"})
+	if err != nil {
+		t.Fatalf("ParseAdmins() error = %v", err)
+	}
+	if err := store.PutContact(context.Background(), contacts.Contact{
+		ContactID:       "tg:@admin",
+		Kind:            contacts.KindHuman,
+		Channel:         contacts.ChannelTelegram,
+		ContactNickname: "Admin",
+		TGUsername:      "admin",
+		TGPrivateChatID: 11,
+	}); err != nil {
+		t.Fatalf("PutContact() error = %v", err)
+	}
+	manager, err := agentpair.New(agentpair.Options{
+		Self:       telegramInboundAgentPeer(1001, "agent_a", "Agent A", 0),
+		Admins:     admins,
+		Contacts:   contacts.NewService(store),
+		JournalDir: filepath.Join(root, "journal"),
+		Send: func(ctx context.Context, target agentpair.Peer, body string) error {
+			chatTarget, targetErr := telegramPairSendTarget(target)
+			if targetErr != nil {
+				return targetErr
+			}
+			return api.sendDirectText(ctx, chatTarget, body)
+		},
+	})
+	if err != nil {
+		t.Fatalf("agentpair.New() error = %v", err)
+	}
+	state := &telegramRuntimeState{
+		logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		api:              api,
+		pairManager:      manager,
+		allowedChatIDs:   map[int64]bool{99: true},
+		botUser:          "agent_a",
+		botID:            1001,
+		groupTriggerMode: "strict",
+	}
+	state.handleUpdate(telegramUpdate{Message: &telegramMessage{
+		MessageID: 1,
+		Chat:      &telegramChat{ID: 11, Type: "private"},
+		From:      &telegramUser{ID: 11, Username: "admin"},
+		Text:      "/pair @AgentB",
+	}})
+
+	if len(chatTargets) != 2 || chatTargets[0] != "@AgentB" || chatTargets[1] != float64(11) {
+		t.Fatalf("chat targets = %#v", chatTargets)
+	}
+	var eventTypes []string
+	if err := domainjournal.ReplayDir(filepath.Join(root, "journal"), func(record domainjournal.Record) error {
+		eventTypes = append(eventTypes, record.Event.Type)
+		return nil
+	}); err != nil {
+		t.Fatalf("ReplayDir() error = %v", err)
+	}
+	if len(eventTypes) != 1 || eventTypes[0] != "agent_pair_requested" {
+		t.Fatalf("journal events = %v", eventTypes)
+	}
+}

--- a/internal/channelruntime/telegram/history_context_test.go
+++ b/internal/channelruntime/telegram/history_context_test.go
@@ -61,6 +61,24 @@ func TestNewTelegramInboundHistoryItem_StructuredFields(t *testing.T) {
 	}
 }
 
+func TestNewTelegramInboundHistoryItem_MarksAgentSender(t *testing.T) {
+	item := newTelegramInboundHistoryItem(telegramJob{
+		ChatID:          -100123,
+		MessageID:       88,
+		SentAt:          time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC),
+		ChatType:        "supergroup",
+		FromUserID:      77,
+		FromUsername:    "smith_bot",
+		FromDisplayName: "Smith",
+		FromIsAgent:     true,
+		Text:            "@morph_bot continue",
+	})
+
+	if !item.Sender.IsBot {
+		t.Fatal("sender IsBot = false, want true")
+	}
+}
+
 func TestTrimChatHistoryItems_ModeCaps(t *testing.T) {
 	items := make([]chathistory.ChatHistoryItem, 0, 20)
 	for i := 0; i < 20; i++ {

--- a/internal/channelruntime/telegram/runtime.go
+++ b/internal/channelruntime/telegram/runtime.go
@@ -36,6 +36,7 @@ type telegramJob struct {
 	FromFirstName    string
 	FromLastName     string
 	FromDisplayName  string
+	FromIsAgent      bool
 	Text             string
 	ImagePaths       []string
 	Images           []chathistory.ChatHistoryImage
@@ -242,7 +243,7 @@ func emojiForTelegramPlanStep(step string) string {
 		return "🧑‍💻"
 	case strings.Contains(lower, "todo_update"):
 		return "🗓️"
-	case strings.Contains(lower, "contacts_send"):
+	case strings.Contains(lower, "contacts_send"), strings.Contains(lower, "agent_send"):
 		return "✉️"
 	default:
 		if randv2.IntN(2) == 0 {

--- a/internal/channelruntime/telegram/runtime_helpers.go
+++ b/internal/channelruntime/telegram/runtime_helpers.go
@@ -72,6 +72,60 @@ func collectMentionCandidates(msg *telegramMessage, botUser string) []string {
 	return out
 }
 
+func telegramFirstBodyMentionTargetsSelf(msg *telegramMessage, botUser string, botID int64) (bool, bool) {
+	if msg == nil {
+		return false, false
+	}
+	botUser = strings.TrimPrefix(strings.TrimSpace(botUser), "@")
+	find := func(text string, entities []telegramEntity) (telegramEntity, bool) {
+		firstOffset := 0
+		var first telegramEntity
+		found := false
+		for _, entity := range entities {
+			typeName := strings.ToLower(strings.TrimSpace(entity.Type))
+			if (typeName != "mention" && typeName != "text_mention") || entity.Offset < 0 || entity.Length <= 0 {
+				continue
+			}
+			if !found || entity.Offset < firstOffset {
+				first = entity
+				firstOffset = entity.Offset
+				found = true
+			}
+		}
+		return first, found
+	}
+	text := msg.Text
+	entity, found := find(text, msg.Entities)
+	if !found {
+		text = msg.Caption
+		entity, found = find(text, msg.CaptionEntities)
+	}
+	if !found {
+		return false, false
+	}
+	if strings.EqualFold(strings.TrimSpace(entity.Type), "text_mention") {
+		if entity.User == nil {
+			return true, false
+		}
+		if botID != 0 && entity.User.ID == botID {
+			return true, true
+		}
+		return true, botUser != "" && strings.EqualFold(strings.TrimPrefix(strings.TrimSpace(entity.User.Username), "@"), botUser)
+	}
+	username := strings.TrimPrefix(strings.TrimSpace(sliceByUTF16(text, entity.Offset, entity.Length)), "@")
+	return true, botUser != "" && strings.EqualFold(username, botUser)
+}
+
+func shouldIgnoreTelegramFirstMention(isGroup bool, fromIsAgent bool, firstMentionFound bool, firstMentionTargetsSelf bool) bool {
+	if !isGroup {
+		return false
+	}
+	if fromIsAgent && !firstMentionFound {
+		return true
+	}
+	return firstMentionFound && !firstMentionTargetsSelf
+}
+
 func addKnownUsernames(known map[int64]map[string]string, chatID int64, usernames []string) {
 	if chatID == 0 || len(usernames) == 0 {
 		return
@@ -400,6 +454,7 @@ func telegramSenderFromJob(job telegramJob) chathistory.ChatHistorySender {
 		UserID:     strconv.FormatInt(job.FromUserID, 10),
 		Username:   username,
 		Nickname:   nickname,
+		IsBot:      job.FromIsAgent,
 		DisplayRef: formatTelegramPersonReference(nickname, username),
 	}
 }

--- a/internal/channelruntime/telegram/runtime_outbound_test.go
+++ b/internal/channelruntime/telegram/runtime_outbound_test.go
@@ -160,6 +160,7 @@ func TestEmojiForTelegramPlanStep(t *testing.T) {
 		{step: "run bash script", want: "🧑‍💻"},
 		{step: "todo_update next steps", want: "🗓️"},
 		{step: "use contacts_send", want: "✉️"},
+		{step: "use agent_send", want: "✉️"},
 	}
 	for _, tc := range tests {
 		if got := emojiForTelegramPlanStep(tc.step); got != tc.want {

--- a/internal/channelruntime/telegram/runtime_owner.go
+++ b/internal/channelruntime/telegram/runtime_owner.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/quailyquaily/mistermorph/agent"
 	"github.com/quailyquaily/mistermorph/contacts"
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
 	busruntime "github.com/quailyquaily/mistermorph/internal/bus"
 	telegrambus "github.com/quailyquaily/mistermorph/internal/bus/adapters/telegram"
 	runtimecore "github.com/quailyquaily/mistermorph/internal/channelruntime/core"
@@ -154,6 +155,33 @@ func bootstrapTelegramRuntimeState(ctx context.Context, d Dependencies, opts Run
 			allowedChatIDs[id] = true
 		}
 	}
+	adminValues := []string(nil)
+	if d.AgentSettingsReader != nil {
+		adminValues = d.AgentSettingsReader.GetStringSlice("admins")
+	}
+	admins, err := agentpair.ParseAdmins(adminValues)
+	if err != nil {
+		return nil, err
+	}
+	pairManager, err := agentpair.New(agentpair.Options{
+		Context:               ctx,
+		Self:                  telegramInboundAgentPeer(me.ID, me.Username, telegramDisplayName(me), 0),
+		Admins:                admins,
+		Contacts:              contactsService,
+		JournalDir:            d.RuntimePaths.JournalDir,
+		JournalRotateMaxBytes: d.TaskRotateMaxBytes,
+		Logger:                logger,
+		Send: func(sendCtx context.Context, target agentpair.Peer, body string) error {
+			chatTarget, targetErr := telegramPairSendTarget(target)
+			if targetErr != nil {
+				return targetErr
+			}
+			return api.sendDirectText(sendCtx, chatTarget, body)
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
 	state, err := newTelegramRuntimeState(telegramRuntimeStateConfig{
 		ctx:                ctx,
 		logger:             logger,
@@ -167,6 +195,7 @@ func bootstrapTelegramRuntimeState(ctx context.Context, d Dependencies, opts Run
 		inprocBus:          inprocBus,
 		runtimeGenerations: runtimeGenerations,
 		contactsService:    contactsService,
+		pairManager:        pairManager,
 		workspaceStore:     workspaceStore,
 		inboundAdapter:     inboundAdapter,
 	})
@@ -556,6 +585,15 @@ func (s *telegramRuntimeState) enqueueInbound(ctx context.Context, message busru
 	if text == "" {
 		return fmt.Errorf("telegram inbound text is required")
 	}
+	if inbound.FromIsAgent && !s.agentInteractions.Allow(message.ConversationKey, time.Now().UTC()) {
+		s.logger.Warn("agent_interaction_rate_limited",
+			"channel", "telegram",
+			"conversation_key", message.ConversationKey,
+			"limit", runtimecore.AgentInteractionLimit,
+			"window", runtimecore.AgentInteractionWindow,
+		)
+		return nil
+	}
 	s.stateMu.Lock()
 	s.lastActivity[inbound.ChatID] = time.Now()
 	if inbound.FromUserID > 0 {
@@ -626,6 +664,7 @@ func (s *telegramRuntimeState) enqueueInbound(ctx context.Context, message busru
 			FromFirstName:    inbound.FromFirstName,
 			FromLastName:     inbound.FromLastName,
 			FromDisplayName:  inbound.FromDisplayName,
+			FromIsAgent:      inbound.FromIsAgent,
 			Text:             text,
 			ImagePaths:       imagePaths,
 			Images:           append([]chathistory.ChatHistoryImage(nil), images...),
@@ -783,16 +822,83 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 	fromFirst := ""
 	fromLast := ""
 	fromDisplay := ""
-	if message.From != nil && !message.From.IsBot {
+	fromIsAgent := false
+	if message.From != nil {
 		fromUserID = message.From.ID
 		fromUsername = strings.TrimSpace(message.From.Username)
 		fromFirst = strings.TrimSpace(message.From.FirstName)
 		fromLast = strings.TrimSpace(message.From.LastName)
 		fromDisplay = telegramDisplayName(message.From)
+		fromIsAgent = message.From.IsBot
 	}
 	chatType := strings.ToLower(strings.TrimSpace(message.Chat.Type))
 	isGroup := chatType == "group" || chatType == "supergroup"
 	messageSentAt := telegramMessageSentAt(message)
+	if fromIsAgent && (fromUserID == s.botID || fromUsername != "" && strings.EqualFold(fromUsername, s.botUser)) {
+		return
+	}
+	commandWord, commandArgs := chatcommands.ParseCommand(text)
+	normalizedCommand := chatcommands.NormalizeCommand(commandWord)
+	if agentpair.IsControlMessage(rawText) {
+		if s.pairManager == nil || isGroup || !fromIsAgent {
+			s.logger.Warn("agent_pair_failed",
+				"channel", "telegram",
+				"chat_id", chatID,
+				"message_id", message.MessageID,
+				"reason", "invalid_control_sender_or_scope",
+			)
+			return
+		}
+		peer := telegramInboundAgentPeer(fromUserID, fromUsername, fromDisplay, chatID)
+		_, handled, pairErr := s.pairManager.Handle(context.Background(), peer, rawText)
+		if pairErr != nil {
+			s.logger.Warn("agent_pair_failed", "channel", "telegram", "chat_id", chatID, "message_id", message.MessageID, "peer_agent_id", peer.ID, "reason", "offer_rejected", "error", pairErr.Error())
+		}
+		if handled {
+			return
+		}
+	}
+	if normalizedCommand == "/pair" {
+		if isGroup || fromIsAgent || s.pairManager == nil {
+			s.logger.Warn("agent_pair_failed",
+				"channel", "telegram",
+				"chat_id", chatID,
+				"message_id", message.MessageID,
+				"reason", "pair_command_requires_private_human_sender",
+			)
+			return
+		}
+		target, targetErr := telegramPairTarget(commandArgs)
+		var status agentpair.Status
+		if targetErr == nil {
+			adminReference := ""
+			if fromUsername != "" {
+				adminReference = "tg:@" + fromUsername
+			}
+			status, targetErr = s.pairManager.Start(context.Background(), "tg:"+strconv.FormatInt(fromUserID, 10), target, adminReference)
+		} else {
+			s.logger.Warn("agent_pair_failed", "channel", "telegram", "chat_id", chatID, "message_id", message.MessageID, "reason", "invalid_target", "error", targetErr.Error())
+		}
+		sendTelegramPairReply(context.Background(), s.api, chatID, messageThreadID, status, targetErr)
+		return
+	}
+	pairedAgent := false
+	if fromIsAgent && !isGroup && s.pairManager != nil {
+		peer := telegramInboundAgentPeer(fromUserID, fromUsername, fromDisplay, chatID)
+		pairedAgent, err = s.pairManager.IsPaired(context.Background(), peer)
+		if err != nil {
+			s.logger.Warn("telegram_agent_pair_lookup_failed", "chat_id", chatID, "message_id", message.MessageID, "peer_agent_id", peer.ID, "error", err.Error())
+			pairedAgent = false
+		}
+	}
+	if fromIsAgent && !isGroup {
+		s.logger.Debug("telegram_private_agent_message_received",
+			"chat_id", chatID,
+			"message_id", message.MessageID,
+			"text", rawText,
+		)
+	}
+	chatAuthorized := telegramChatAuthorized(s.allowedChatIDs, chatID, isGroup, fromIsAgent, pairedAgent)
 	s.sendSystemWarnings(chatID, messageThreadID)
 
 	var mentionCandidates []string
@@ -830,6 +936,7 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 			FromFirstName:   fromFirst,
 			FromLastName:    fromLast,
 			FromDisplayName: fromDisplay,
+			FromIsAgent:     fromIsAgent,
 			Text:            ignoredText,
 		}))
 		s.history[conversationKey] = trimChatHistoryItems(current, s.historyCap)
@@ -855,14 +962,26 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 			s.logger.Error("telegram_untriggered_journal_append_error", "chat_id", chatID, "message_id", message.MessageID, "error", err.Error())
 		}
 	}
+	firstMentionFound, firstMentionTargetsSelf := telegramFirstBodyMentionTargetsSelf(message, s.botUser, s.botID)
+	if shouldIgnoreTelegramFirstMention(isGroup, fromIsAgent, firstMentionFound, firstMentionTargetsSelf) {
+		s.logger.Info("telegram_message_ignored_first_mention",
+			"chat_id", chatID,
+			"message_id", message.MessageID,
+			"from_is_agent", fromIsAgent,
+			"first_mention_found", firstMentionFound,
+		)
+		if strings.EqualFold(s.groupTriggerMode, "talkative") {
+			appendIgnoredInboundHistory(rawText)
+		}
+		recordUntriggered()
+		return
+	}
 
-	commandWord, commandArgs := chatcommands.ParseCommand(text)
-	normalizedCommand := chatcommands.NormalizeCommand(commandWord)
 	contextCompactionOnly := chatcommands.IsContextCompactCommand(text)
 	replyToMessageID := int64(0)
 	switch normalizedCommand {
 	case "/stop":
-		if len(s.allowedChatIDs) > 0 && !s.allowedChatIDs[chatID] {
+		if !chatAuthorized {
 			s.logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
 			sendTelegramUnauthorizedMessage(s.api, chatID, messageThreadID, chatType)
 			return
@@ -879,7 +998,7 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 		_ = s.api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, help, true)
 		return
 	case "/models":
-		if len(s.allowedChatIDs) > 0 && !s.allowedChatIDs[chatID] {
+		if !chatAuthorized {
 			s.logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
 			sendTelegramUnauthorizedMessage(s.api, chatID, messageThreadID, chatType)
 			return
@@ -890,7 +1009,7 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 		_ = s.api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, "error: "+htmlstd.EscapeString("missing llm profile command handler"), true)
 		return
 	case "/skills":
-		if len(s.allowedChatIDs) > 0 && !s.allowedChatIDs[chatID] {
+		if !chatAuthorized {
 			s.logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
 			sendTelegramUnauthorizedMessage(s.api, chatID, messageThreadID, chatType)
 			return
@@ -904,7 +1023,7 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 		_ = s.api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, "error: "+htmlstd.EscapeString("missing skill command handler"), true)
 		return
 	case "/ctx":
-		if len(s.allowedChatIDs) > 0 && !s.allowedChatIDs[chatID] {
+		if !chatAuthorized {
 			s.logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
 			sendTelegramUnauthorizedMessage(s.api, chatID, messageThreadID, chatType)
 			return
@@ -926,7 +1045,7 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 		_ = s.api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, idText, true)
 		return
 	case "/workspace":
-		if len(s.allowedChatIDs) > 0 && !s.allowedChatIDs[chatID] {
+		if !chatAuthorized {
 			s.logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
 			sendTelegramUnauthorizedMessage(s.api, chatID, messageThreadID, chatType)
 			return
@@ -939,13 +1058,13 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 		_ = s.api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, htmlstd.EscapeString(reply), true)
 		return
 	case "/think":
-		if len(s.allowedChatIDs) > 0 && !s.allowedChatIDs[chatID] {
+		if !chatAuthorized {
 			s.logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
 			sendTelegramUnauthorizedMessage(s.api, chatID, messageThreadID, chatType)
 			return
 		}
 	case "/reset":
-		if len(s.allowedChatIDs) > 0 && !s.allowedChatIDs[chatID] {
+		if !chatAuthorized {
 			s.logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
 			sendTelegramUnauthorizedMessage(s.api, chatID, messageThreadID, chatType)
 			return
@@ -976,7 +1095,7 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 		_ = s.api.sendMessageHTMLInThread(context.Background(), chatID, messageThreadID, "ok (reset)", true)
 		return
 	default:
-		if len(s.allowedChatIDs) > 0 && !s.allowedChatIDs[chatID] {
+		if !chatAuthorized {
 			s.logger.Warn("telegram_unauthorized_chat", "chat_id", chatID)
 			sendTelegramUnauthorizedMessage(s.api, chatID, messageThreadID, chatType)
 			return
@@ -1130,7 +1249,7 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 			text = "Quoted message:\n> " + quoted + "\n\nUser request:\n" + strings.TrimSpace(text)
 		}
 	}
-	if fromUserID > 0 {
+	if fromUserID > 0 && !fromIsAgent {
 		if err := applyTelegramInboundFeedback(context.Background(), s.contactsService, chatID, chatType, fromUserID, fromUsername, time.Now().UTC()); err != nil {
 			s.logger.Warn("contacts_feedback_telegram_error", "chat_id", chatID, "user_id", fromUserID, "error", err.Error())
 		}
@@ -1160,6 +1279,7 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 		FromFirstName:    fromFirst,
 		FromLastName:     fromLast,
 		FromDisplayName:  fromDisplay,
+		FromIsAgent:      fromIsAgent,
 		Text:             text,
 		MentionUsers:     mentionUsers,
 		ImageAttachments: imageAttachments,

--- a/internal/channelruntime/telegram/runtime_owner.go
+++ b/internal/channelruntime/telegram/runtime_owner.go
@@ -899,6 +899,14 @@ func (s *telegramRuntimeState) handleUpdate(update telegramUpdate) {
 		)
 	}
 	chatAuthorized := telegramChatAuthorized(s.allowedChatIDs, chatID, isGroup, fromIsAgent, pairedAgent)
+	if fromIsAgent && !chatAuthorized {
+		s.logger.Warn("telegram_unauthorized_chat",
+			"chat_id", chatID,
+			"message_id", message.MessageID,
+			"from_is_agent", true,
+		)
+		return
+	}
 	s.sendSystemWarnings(chatID, messageThreadID)
 
 	var mentionCandidates []string

--- a/internal/channelruntime/telegram/runtime_state.go
+++ b/internal/channelruntime/telegram/runtime_state.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/quailyquaily/mistermorph/contacts"
 	"github.com/quailyquaily/mistermorph/guard"
+	"github.com/quailyquaily/mistermorph/internal/agentpair"
 	busruntime "github.com/quailyquaily/mistermorph/internal/bus"
 	telegrambus "github.com/quailyquaily/mistermorph/internal/bus/adapters/telegram"
 	runtimecore "github.com/quailyquaily/mistermorph/internal/channelruntime/core"
@@ -36,6 +37,7 @@ type telegramRuntimeStateConfig struct {
 	runtimeBundle      runtimecore.ChannelRuntimeBundle
 	runtimeGenerations *runtimecore.RuntimeGenerationManager
 	contactsService    *contacts.Service
+	pairManager        *agentpair.Manager
 	workspaceStore     *workspace.Store
 	inboundAdapter     *telegrambus.InboundAdapter
 }
@@ -74,6 +76,7 @@ type telegramRuntimeState struct {
 	inboundAdapter      *telegrambus.InboundAdapter
 	deliveryAdapter     *telegrambus.DeliveryAdapter
 	contactsService     *contacts.Service
+	pairManager         *agentpair.Manager
 	workspaceStore      *workspace.Store
 	runControl          *runtimecontrol.RunControl
 	untriggeredRecorder *runtimecore.UntriggeredRecorder
@@ -94,6 +97,7 @@ type telegramRuntimeState struct {
 	lastFromLast        map[int64]string
 	lastChatType        map[int64]string
 	knownMentions       map[int64]map[string]string
+	agentInteractions   runtimecore.AgentInteractionLimiter
 	offset              int64
 	planProgressMu      sync.Mutex
 	planProgressByID    map[string]telegramPlanProgressEditState
@@ -153,6 +157,7 @@ func newTelegramRuntimeState(config telegramRuntimeStateConfig) (*telegramRuntim
 		runtimeGenerations:  config.runtimeGenerations,
 		inboundAdapter:      config.inboundAdapter,
 		contactsService:     config.contactsService,
+		pairManager:         config.pairManager,
 		workspaceStore:      config.workspaceStore,
 		runControl:          runtimecontrol.New(),
 		allowedChatIDs:      allowedChatIDs,

--- a/internal/channelruntime/telegram/runtime_task.go
+++ b/internal/channelruntime/telegram/runtime_task.go
@@ -227,6 +227,9 @@ func runTelegramTask(ctx context.Context, rt *taskruntime.Runtime, api *telegram
 		HistoryBoundaries:      historyBoundaries,
 		CurrentMessageBoundary: checkpointHistory.CurrentMessageBoundary,
 	}
+	if job.FromIsAgent && strings.EqualFold(strings.TrimSpace(job.ChatType), "private") {
+		runReq.ToolTriggers = map[string]bool{toolsutil.BuiltinContactsSend: true}
+	}
 	var result taskruntime.RunResult
 	if approvalID := strings.TrimSpace(job.ResumeApprovalID); approvalID != "" {
 		result, err = rt.Resume(ctx, approvalID, runReq)

--- a/internal/channelruntime/telegram/runtime_task.go
+++ b/internal/channelruntime/telegram/runtime_task.go
@@ -349,6 +349,9 @@ func shouldWriteMemory(publishText bool, memoryEnabled bool, orchestrator *memor
 }
 
 func contactsSendRuntimeContextForTelegram(job telegramJob) builtin.ContactsSendRuntimeContext {
+	if job.FromIsAgent {
+		return builtin.ContactsSendRuntimeContext{}
+	}
 	ids := make([]string, 0, 3)
 	if username := strings.TrimPrefix(strings.TrimSpace(job.FromUsername), "@"); username != "" {
 		ids = append(ids, "tg:@"+username)

--- a/internal/channelruntime/telegram/runtime_task_test.go
+++ b/internal/channelruntime/telegram/runtime_task_test.go
@@ -98,6 +98,19 @@ func TestContactsSendRuntimeContextForTelegramPrivateChat(t *testing.T) {
 	}
 }
 
+func TestContactsSendRuntimeContextForTelegramAgentSender(t *testing.T) {
+	ctx := contactsSendRuntimeContextForTelegram(telegramJob{
+		ChatID:       28036192,
+		ChatType:     "private",
+		FromUserID:   42,
+		FromUsername: "smith_bot",
+		FromIsAgent:  true,
+	})
+	if len(ctx.ForbiddenTargetIDs) != 0 {
+		t.Fatalf("forbidden_target_ids = %#v, want empty", ctx.ForbiddenTargetIDs)
+	}
+}
+
 func TestTelegramPlanProgressLineProgrammaticFormat(t *testing.T) {
 	plan := &agent.Plan{
 		Steps: []agent.PlanStep{

--- a/internal/channelruntime/telegram/telegram_api.go
+++ b/internal/channelruntime/telegram/telegram_api.go
@@ -254,6 +254,11 @@ type telegramSendMessageRequest struct {
 	ReplyMarkup           *telegramInlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
+type telegramDirectMessageRequest struct {
+	ChatID string `json:"chat_id"`
+	Text   string `json:"text"`
+}
+
 type telegramEditMessageTextRequest struct {
 	ChatID                int64  `json:"chat_id"`
 	MessageID             int64  `json:"message_id"`
@@ -588,6 +593,23 @@ func (api *telegramAPI) sendMessageWithParseModeReplyAndMessageIDAndMarkup(ctx c
 		ReplyToMessageID:      replyToMessageID,
 		ReplyMarkup:           replyMarkup,
 	}
+	return api.postSendMessage(ctx, reqBody)
+}
+
+func (api *telegramAPI) sendDirectText(ctx context.Context, chatTarget, text string) error {
+	chatTarget = strings.TrimSpace(chatTarget)
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(chatTarget, "@") || len(chatTarget) == 1 {
+		return fmt.Errorf("Telegram direct target must be a username")
+	}
+	if text == "" {
+		return fmt.Errorf("Telegram direct message is empty")
+	}
+	_, err := api.postSendMessage(ctx, telegramDirectMessageRequest{ChatID: chatTarget, Text: text})
+	return err
+}
+
+func (api *telegramAPI) postSendMessage(ctx context.Context, reqBody any) (int64, error) {
 	b, _ := json.Marshal(reqBody)
 	url := fmt.Sprintf("%s/bot%s/sendMessage", api.baseURL, api.token)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))

--- a/internal/channelruntime/telegram/trigger_addressing_test.go
+++ b/internal/channelruntime/telegram/trigger_addressing_test.go
@@ -144,6 +144,93 @@ func TestCollectMentionCandidates_IgnoresForumTopicRootReplySender(t *testing.T)
 	}
 }
 
+func TestTelegramFirstBodyMentionTargetsSelf(t *testing.T) {
+	tests := []struct {
+		name       string
+		message    *telegramMessage
+		wantFound  bool
+		wantTarget bool
+	}{
+		{
+			name: "username mention targets self",
+			message: &telegramMessage{
+				Text:     "@morph_bot please continue",
+				Entities: []telegramEntity{{Type: "mention", Offset: 0, Length: 10}},
+			},
+			wantFound:  true,
+			wantTarget: true,
+		},
+		{
+			name: "first mention targets another agent",
+			message: &telegramMessage{
+				Text: "@smith_bot then @morph_bot",
+				Entities: []telegramEntity{
+					{Type: "mention", Offset: 16, Length: 10},
+					{Type: "mention", Offset: 0, Length: 10},
+				},
+			},
+			wantFound: true,
+		},
+		{
+			name: "text mention user id targets self",
+			message: &telegramMessage{
+				Text:     "Morph please continue",
+				Entities: []telegramEntity{{Type: "text_mention", Offset: 0, Length: 5, User: &telegramUser{ID: 99}}},
+			},
+			wantFound:  true,
+			wantTarget: true,
+		},
+		{
+			name: "caption mention",
+			message: &telegramMessage{
+				Caption:         "@morph_bot inspect this",
+				CaptionEntities: []telegramEntity{{Type: "mention", Offset: 0, Length: 10}},
+			},
+			wantFound:  true,
+			wantTarget: true,
+		},
+		{name: "no mention", message: &telegramMessage{Text: "plain task"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			found, targetsSelf := telegramFirstBodyMentionTargetsSelf(tt.message, "morph_bot", 99)
+			if found != tt.wantFound || targetsSelf != tt.wantTarget {
+				t.Fatalf("telegramFirstBodyMentionTargetsSelf() = (%v, %v), want (%v, %v)", found, targetsSelf, tt.wantFound, tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestShouldIgnoreTelegramFirstMention(t *testing.T) {
+	tests := []struct {
+		name        string
+		isGroup     bool
+		fromAgent   bool
+		found       bool
+		targetsSelf bool
+		want        bool
+	}{
+		{name: "private agent without mention", fromAgent: true},
+		{name: "private agent mentioning another agent", fromAgent: true, found: true},
+		{name: "group agent without mention", isGroup: true, fromAgent: true, want: true},
+		{name: "group agent mentioning self", isGroup: true, fromAgent: true, found: true, targetsSelf: true},
+		{name: "group agent mentioning another agent", isGroup: true, fromAgent: true, found: true, want: true},
+		{name: "group human without mention", isGroup: true},
+		{name: "group human mentioning another agent", isGroup: true, found: true, want: true},
+		{name: "private human mentioning another agent", found: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldIgnoreTelegramFirstMention(tt.isGroup, tt.fromAgent, tt.found, tt.targetsSelf)
+			if got != tt.want {
+				t.Fatalf("shouldIgnoreTelegramFirstMention() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAddressingDecisionViaLLM_EnforceLightweightReactionReturnsErrorOnToolFailure(t *testing.T) {
 	client := &stubAddressingLLMClient{
 		results: []llm.Result{

--- a/internal/configdefaults/defaults.go
+++ b/internal/configdefaults/defaults.go
@@ -95,6 +95,7 @@ func Apply(v *viper.Viper) {
 	v.SetDefault("journal.dir_name", "journal")
 
 	v.SetDefault("bus.max_inflight", DefaultBusMaxInFlight)
+	v.SetDefault("admins", []string{})
 
 	v.SetDefault("contacts.dir_name", "contacts")
 	v.SetDefault("contacts.proactive.max_turns_per_session", 6)

--- a/internal/contactsruntime/sender.go
+++ b/internal/contactsruntime/sender.go
@@ -257,9 +257,20 @@ func (s *RoutingSender) Send(ctx context.Context, contact contacts.Contact, deci
 		}
 		return s.publishSlack(ctx, target, decision)
 	case contacts.ChannelTelegram:
-		target, _, resolveErr := ResolveTelegramTargetWithChatID(contact, decision.ChatID)
-		if resolveErr != nil {
-			return false, false, resolveErr
+		var target any
+		decisionContactID := strings.TrimSpace(decision.ContactID)
+		if strings.TrimSpace(decision.ChatID) == "" && strings.HasPrefix(strings.ToLower(decisionContactID), "tg:@") {
+			username := strings.TrimSpace(decisionContactID[len("tg:@"):])
+			if username == "" {
+				return false, false, fmt.Errorf("telegram username is required")
+			}
+			target = "@" + username
+		} else {
+			var resolveErr error
+			target, _, resolveErr = ResolveTelegramTargetWithChatID(contact, decision.ChatID)
+			if resolveErr != nil {
+				return false, false, resolveErr
+			}
 		}
 		return s.publishTelegram(ctx, target, decision)
 	case contacts.ChannelLine:
@@ -292,6 +303,21 @@ func (s *RoutingSender) publishTelegram(ctx context.Context, target any, decisio
 	payloadRaw, err := buildEnvelopePayload(decision, decision.ContentType, decision.PayloadBase64, now)
 	if err != nil {
 		return false, false, err
+	}
+	if username, ok, err := parseTelegramUsernameTarget(target); err != nil {
+		return false, false, err
+	} else if ok {
+		var envelope busruntime.MessageEnvelope
+		if decodeErr := json.Unmarshal(payloadRaw, &envelope); decodeErr != nil {
+			return false, false, decodeErr
+		}
+		if sendErr := s.sendTelegramTarget(ctx, username, envelope.Text, telegrambus.SendTextOptions{
+			ReplyTo:       envelope.ReplyTo,
+			CorrelationID: "contactsruntime:telegram:" + idempotencyKey,
+		}); sendErr != nil {
+			return false, false, sendErr
+		}
+		return true, false, nil
 	}
 	payloadBase64 := base64.RawURLEncoding.EncodeToString(payloadRaw)
 	conversationKey, participantKey, err := telegramConversationFromTarget(target)
@@ -660,6 +686,22 @@ func normalizeTelegramSendTarget(target any) (telegrambus.DeliveryTarget, error)
 	}
 }
 
+func parseTelegramUsernameTarget(target any) (string, bool, error) {
+	raw, ok := target.(string)
+	if !ok {
+		return "", false, nil
+	}
+	raw = strings.TrimSpace(raw)
+	if !strings.HasPrefix(raw, "@") {
+		return "", false, nil
+	}
+	username := strings.TrimSpace(strings.TrimPrefix(raw, "@"))
+	if username == "" || strings.ContainsAny(username, " \t\r\n") {
+		return "", true, fmt.Errorf("telegram username target is invalid")
+	}
+	return "@" + username, true, nil
+}
+
 func normalizeSlackSendTarget(target any) (slackbus.DeliveryTarget, error) {
 	switch value := target.(type) {
 	case slackbus.DeliveryTarget:
@@ -767,18 +809,27 @@ func (s *RoutingSender) sendTelegramTarget(ctx context.Context, target any, text
 		return fmt.Errorf("telegram text is required")
 	}
 
-	resolvedTarget, err := normalizeTelegramSendTarget(target)
-	if err != nil {
+	chatID := any(nil)
+	messageThreadID := int64(0)
+	if username, ok, err := parseTelegramUsernameTarget(target); err != nil {
 		return err
+	} else if ok {
+		chatID = username
+	} else {
+		resolvedTarget, resolveErr := normalizeTelegramSendTarget(target)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		chatID = resolvedTarget.ChatID
+		messageThreadID = resolvedTarget.MessageThreadID
 	}
-
 	body := map[string]any{
-		"chat_id":                  resolvedTarget.ChatID,
+		"chat_id":                  chatID,
 		"text":                     text,
 		"disable_web_page_preview": true,
 	}
-	if resolvedTarget.MessageThreadID > 0 {
-		body["message_thread_id"] = resolvedTarget.MessageThreadID
+	if messageThreadID > 0 {
+		body["message_thread_id"] = messageThreadID
 	}
 	replyToRaw := strings.TrimSpace(opts.ReplyTo)
 	if replyToRaw != "" {
@@ -1002,10 +1053,17 @@ func ResolveTelegramTarget(contact contacts.Contact) (any, string, error) {
 	if chatID, chatType, ok := preferredChat(contact); ok {
 		return chatID, chatType, nil
 	}
+	if username := strings.TrimPrefix(strings.TrimSpace(contact.TGUsername), "@"); username != "" {
+		return "@" + username, "private", nil
+	}
 	value := strings.TrimSpace(contact.ContactID)
 	lower := strings.ToLower(value)
 	if strings.HasPrefix(lower, "tg:@") {
-		return nil, "", fmt.Errorf("telegram username target is not sendable: %s", value)
+		username := strings.TrimSpace(value[len("tg:@"):])
+		if username == "" {
+			return nil, "", fmt.Errorf("telegram username is required")
+		}
+		return "@" + username, "private", nil
 	}
 	if strings.HasPrefix(lower, "tg:") {
 		idText := strings.TrimSpace(value[len("tg:"):])

--- a/internal/contactsruntime/sender.go
+++ b/internal/contactsruntime/sender.go
@@ -259,7 +259,7 @@ func (s *RoutingSender) Send(ctx context.Context, contact contacts.Contact, deci
 	case contacts.ChannelTelegram:
 		var target any
 		decisionContactID := strings.TrimSpace(decision.ContactID)
-		if strings.TrimSpace(decision.ChatID) == "" && strings.HasPrefix(strings.ToLower(decisionContactID), "tg:@") {
+		if strings.TrimSpace(decision.ChatID) == "" && contact.TGPrivateChatID == 0 && strings.HasPrefix(strings.ToLower(decisionContactID), "tg:@") {
 			username := strings.TrimSpace(decisionContactID[len("tg:@"):])
 			if username == "" {
 				return false, false, fmt.Errorf("telegram username is required")

--- a/internal/contactsruntime/sender_bus_test.go
+++ b/internal/contactsruntime/sender_bus_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -486,18 +488,32 @@ func TestRoutingSenderSendFailsWithoutIdempotencyKey(t *testing.T) {
 	}
 }
 
-func TestRoutingSenderSendHumanWithUsernameTargetFails(t *testing.T) {
+func TestRoutingSenderSendAgentWithUsernameTarget(t *testing.T) {
 	ctx := context.Background()
+	var gotPath string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("Decode() error = %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":1}}`))
+	}))
+	defer server.Close()
 
-	calls := 0
-	sender := newRoutingSenderForBusTest(t, func(ctx context.Context, target any, text string, opts telegrambus.SendTextOptions) error {
-		calls++
-		return nil
+	sender, err := NewRoutingSender(ctx, SenderOptions{
+		TelegramBotToken: "token",
+		TelegramBaseURL:  server.URL,
 	})
+	if err != nil {
+		t.Fatalf("NewRoutingSender() error = %v", err)
+	}
+	defer sender.Close()
 	contentType, payloadBase64 := testEnvelopePayload(t, "hello")
-	_, _, err := sender.Send(ctx, contacts.Contact{
+	accepted, deduped, err := sender.Send(ctx, contacts.Contact{
 		ContactID:  "tg:@alice",
-		Kind:       contacts.KindHuman,
+		Kind:       contacts.KindAgent,
 		Channel:    contacts.ChannelTelegram,
 		TGUsername: "alice",
 	}, contacts.ShareDecision{
@@ -507,14 +523,20 @@ func TestRoutingSenderSendHumanWithUsernameTargetFails(t *testing.T) {
 		PayloadBase64:  payloadBase64,
 		IdempotencyKey: "manual:tg:@alice",
 	})
-	if err == nil {
-		t.Fatalf("Send() expected error for tg:@ fallback")
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "telegram username target is not sendable") {
-		t.Fatalf("Send() error mismatch: got %q", err.Error())
+	if !accepted || deduped {
+		t.Fatalf("Send() = accepted %v, deduped %v; want true, false", accepted, deduped)
 	}
-	if calls != 0 {
-		t.Fatalf("send calls mismatch: got %d want 0", calls)
+	if gotPath != "/bottoken/sendMessage" {
+		t.Fatalf("request path = %q, want %q", gotPath, "/bottoken/sendMessage")
+	}
+	if gotBody["chat_id"] != "@alice" {
+		t.Fatalf("chat_id = %#v, want %q", gotBody["chat_id"], "@alice")
+	}
+	if gotBody["text"] != "hello" {
+		t.Fatalf("text = %#v, want %q", gotBody["text"], "hello")
 	}
 }
 

--- a/internal/contactsruntime/sender_bus_test.go
+++ b/internal/contactsruntime/sender_bus_test.go
@@ -71,6 +71,37 @@ func TestRoutingSenderSendTelegramViaBus(t *testing.T) {
 	}
 }
 
+func TestRoutingSenderSendTelegramUsernameAliasPrefersPrivateChatID(t *testing.T) {
+	ctx := context.Background()
+	var gotTarget any
+	sender := newRoutingSenderForBusTest(t, func(_ context.Context, target any, _ string, _ telegrambus.SendTextOptions) error {
+		gotTarget = target
+		return nil
+	})
+	contentType, payloadBase64 := testEnvelopePayload(t, "hello telegram")
+
+	_, _, err := sender.Send(ctx, contacts.Contact{
+		ContactID:       "tg:@alice",
+		Kind:            contacts.KindHuman,
+		Channel:         contacts.ChannelTelegram,
+		TGUsername:      "alice",
+		TGPrivateChatID: 12345,
+	}, contacts.ShareDecision{
+		ContactID:      "tg:@alice",
+		ItemID:         "cand_alias_private",
+		ContentType:    contentType,
+		PayloadBase64:  payloadBase64,
+		IdempotencyKey: "manual:tg:alias-private",
+	})
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	wantTarget := telegrambus.DeliveryTarget{ChatID: 12345}
+	if gotTarget != wantTarget {
+		t.Fatalf("target = %#v, want %#v", gotTarget, wantTarget)
+	}
+}
+
 func TestRoutingSenderSendTelegramViaBus_ChatIDHintMatchGroup(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/contactsruntime/sender_telegram_test.go
+++ b/internal/contactsruntime/sender_telegram_test.go
@@ -71,6 +71,31 @@ func TestResolveTelegramTargetFallsBackToPrivate(t *testing.T) {
 	}
 }
 
+func TestResolveTelegramTargetUsesUsername(t *testing.T) {
+	target, chatType, err := ResolveTelegramTarget(contacts.Contact{
+		ContactID:  "tg:@smith_bot",
+		Kind:       contacts.KindAgent,
+		Channel:    contacts.ChannelTelegram,
+		TGUsername: "smith_bot",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTelegramTarget() error = %v", err)
+	}
+	if target != "@smith_bot" {
+		t.Fatalf("target = %#v, want %q", target, "@smith_bot")
+	}
+	if chatType != "private" {
+		t.Fatalf("chat type = %q, want %q", chatType, "private")
+	}
+	username, ok, err := parseTelegramUsernameTarget(target)
+	if err != nil || !ok || username != "@smith_bot" {
+		t.Fatalf("parseTelegramUsernameTarget(%#v) = (%q, %v, %v)", target, username, ok, err)
+	}
+	if _, ok, err := parseTelegramUsernameTarget("tg:@smith_bot"); err != nil || ok {
+		t.Fatalf("raw contact reference accepted as delivery target: ok=%v err=%v", ok, err)
+	}
+}
+
 func TestResolveTelegramTargetWithChatIDMatchGroup(t *testing.T) {
 	contact := contacts.Contact{
 		ContactID:       "tg:@alice",

--- a/internal/toolsutil/static_register.go
+++ b/internal/toolsutil/static_register.go
@@ -1,6 +1,7 @@
 package toolsutil
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -27,6 +28,7 @@ const (
 	BuiltinImageGenerate = "image_generate"
 	BuiltinImageEdit     = "image_edit"
 	BuiltinContactsSend  = "contacts_send"
+	BuiltinAgentSend     = "agent_send"
 	BuiltinSpawn         = "spawn"
 	BuiltinACPSpawn      = "acp_spawn"
 	BuiltinCoder         = "coder"
@@ -44,6 +46,7 @@ var builtinToolNameSet = map[string]struct{}{
 	BuiltinImageGenerate: {},
 	BuiltinImageEdit:     {},
 	BuiltinContactsSend:  {},
+	BuiltinAgentSend:     {},
 	BuiltinSpawn:         {},
 	BuiltinACPSpawn:      {},
 	BuiltinCoder:         {},
@@ -381,21 +384,29 @@ func RegisterStaticTools(reg *tools.Registry, cfg StaticRegistryConfig, selected
 		))
 	}
 
+	contactSendOpts := builtin.ContactsSendToolOptions{
+		Enabled:          true,
+		ContactsDir:      cfg.ContactsSend.ContactsDir,
+		TelegramBotToken: strings.TrimSpace(cfg.ContactsSend.TelegramBotToken),
+		TelegramBaseURL:  strings.TrimSpace(cfg.ContactsSend.TelegramBaseURL),
+		SlackBotToken:    strings.TrimSpace(cfg.ContactsSend.SlackBotToken),
+		SlackBaseURL:     strings.TrimSpace(cfg.ContactsSend.SlackBaseURL),
+		LineChannelToken: strings.TrimSpace(cfg.ContactsSend.LineChannelToken),
+		LineBaseURL:      strings.TrimSpace(cfg.ContactsSend.LineBaseURL),
+		LarkAppID:        strings.TrimSpace(cfg.ContactsSend.LarkAppID),
+		LarkAppSecret:    strings.TrimSpace(cfg.ContactsSend.LarkAppSecret),
+		LarkBaseURL:      strings.TrimSpace(cfg.ContactsSend.LarkBaseURL),
+		FailureCooldown:  cfg.ContactsSend.FailureCooldown,
+	}
+	if isSelected(BuiltinAgentSend) {
+		available, err := builtin.AgentSendAvailable(context.Background(), cfg.ContactsSend.ContactsDir)
+		if err == nil && available {
+			_ = reg.Replace(builtin.NewAgentSendTool(contactSendOpts))
+		}
+	}
+
 	contactsSendEnabled := cfg.Common.Awareness && cfg.ContactsSend.Enabled
 	if isSelected(BuiltinContactsSend) && isEnabled(BuiltinContactsSend, contactsSendEnabled) {
-		_ = reg.Replace(builtin.NewContactsSendTool(builtin.ContactsSendToolOptions{
-			Enabled:          true,
-			ContactsDir:      cfg.ContactsSend.ContactsDir,
-			TelegramBotToken: strings.TrimSpace(cfg.ContactsSend.TelegramBotToken),
-			TelegramBaseURL:  strings.TrimSpace(cfg.ContactsSend.TelegramBaseURL),
-			SlackBotToken:    strings.TrimSpace(cfg.ContactsSend.SlackBotToken),
-			SlackBaseURL:     strings.TrimSpace(cfg.ContactsSend.SlackBaseURL),
-			LineChannelToken: strings.TrimSpace(cfg.ContactsSend.LineChannelToken),
-			LineBaseURL:      strings.TrimSpace(cfg.ContactsSend.LineBaseURL),
-			LarkAppID:        strings.TrimSpace(cfg.ContactsSend.LarkAppID),
-			LarkAppSecret:    strings.TrimSpace(cfg.ContactsSend.LarkAppSecret),
-			LarkBaseURL:      strings.TrimSpace(cfg.ContactsSend.LarkBaseURL),
-			FailureCooldown:  cfg.ContactsSend.FailureCooldown,
-		}))
+		_ = reg.Replace(builtin.NewContactsSendTool(contactSendOpts))
 	}
 }

--- a/internal/toolsutil/static_register_test.go
+++ b/internal/toolsutil/static_register_test.go
@@ -1,10 +1,13 @@
 package toolsutil
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/quailyquaily/mistermorph/contacts"
 	"github.com/quailyquaily/mistermorph/tools"
 	"github.com/spf13/viper"
 )
@@ -197,5 +200,50 @@ func TestRegisterStaticToolsContactsSendDisabledRequiresExplicitTrigger(t *testi
 
 	if _, ok := reg.Get(BuiltinContactsSend); !ok {
 		t.Fatalf("explicit contacts_send trigger did not register tool")
+	}
+}
+
+func TestRegisterStaticToolsAgentSendRequiresActiveAgent(t *testing.T) {
+	ctx := context.Background()
+	contactsDir := filepath.Join(t.TempDir(), "contacts")
+	cfg := StaticRegistryConfig{
+		ContactsSend: StaticContactsSendConfig{ContactsDir: contactsDir},
+	}
+
+	reg := tools.NewRegistry()
+	RegisterStaticTools(reg, cfg, nil, nil)
+	if _, ok := reg.Get(BuiltinAgentSend); ok {
+		t.Fatal("agent_send registered without an active Agent")
+	}
+
+	svc := contacts.NewService(contacts.NewFileStore(contactsDir))
+	if _, err := svc.UpsertContact(ctx, contacts.Contact{
+		ContactID: "contact:alice",
+		Kind:      contacts.KindHuman,
+		Channel:   contacts.ChannelTelegram,
+	}, time.Now().UTC()); err != nil {
+		t.Fatalf("UpsertContact(human) error = %v", err)
+	}
+	reg = tools.NewRegistry()
+	RegisterStaticTools(reg, cfg, nil, nil)
+	if _, ok := reg.Get(BuiltinAgentSend); ok {
+		t.Fatal("agent_send registered with only active humans")
+	}
+
+	if _, err := svc.UpsertContact(ctx, contacts.Contact{
+		ContactID:  "contact:smith",
+		Kind:       contacts.KindAgent,
+		Channel:    contacts.ChannelTelegram,
+		TGUsername: "smith_bot",
+	}, time.Now().UTC()); err != nil {
+		t.Fatalf("UpsertContact(agent) error = %v", err)
+	}
+	reg = tools.NewRegistry()
+	RegisterStaticTools(reg, cfg, nil, nil)
+	if _, ok := reg.Get(BuiltinAgentSend); !ok {
+		t.Fatal("agent_send not registered with an active Agent")
+	}
+	if _, ok := reg.Get(BuiltinContactsSend); ok {
+		t.Fatal("agent_send availability changed contacts_send registration")
 	}
 }

--- a/llm/model_context_window_catalog_test.go
+++ b/llm/model_context_window_catalog_test.go
@@ -1,10 +1,7 @@
 package llm
 
 import (
-	"strings"
 	"testing"
-
-	uniaiapi "github.com/quailyquaily/uniai"
 )
 
 func TestResolveModelContextWindow(t *testing.T) {
@@ -33,21 +30,6 @@ func TestResolveModelContextWindow(t *testing.T) {
 func TestResolveModelContextWindowUnknown(t *testing.T) {
 	if _, ok := ResolveModelContextWindow("unknown-model"); ok {
 		t.Fatalf("ResolveModelContextWindow(unknown-model) found = true, want false")
-	}
-}
-
-func TestResolveModelContextWindowCatalogCoversUniaiDefaultChatPricing(t *testing.T) {
-	catalog := uniaiapi.DefaultPricingCatalog()
-	var missing []string
-	for _, rule := range catalog.Chat {
-		for _, model := range append([]string{rule.Model}, rule.Aliases...) {
-			if _, ok := ResolveModelContextWindow(model); !ok {
-				missing = append(missing, model)
-			}
-		}
-	}
-	if len(missing) > 0 {
-		t.Fatalf("missing context window metadata for uniai chat pricing models: %s", strings.Join(missing, ", "))
 	}
 }
 

--- a/tools/builtin/agent_send.go
+++ b/tools/builtin/agent_send.go
@@ -1,0 +1,85 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/quailyquaily/mistermorph/contacts"
+	"github.com/quailyquaily/mistermorph/internal/pathutil"
+)
+
+type AgentSendTool struct {
+	opts ContactsSendToolOptions
+}
+
+func NewAgentSendTool(opts ContactsSendToolOptions) *AgentSendTool {
+	return &AgentSendTool{opts: opts}
+}
+
+func (t *AgentSendTool) Name() string { return "agent_send" }
+
+func (t *AgentSendTool) Description() string {
+	return `Sends a message to one or more active Agent contacts.
+		IF sending to multiple Agents THEN pass comma-separated contact_id values.
+		Message routes automatically across Slack, Telegram, LINE, and Lark based on chat_id/contact reachability.
+		Only target Agents explicitly referenced in the current task.`
+}
+
+func (t *AgentSendTool) ParameterSchema() string {
+	return contactSendParameterSchema()
+}
+
+func (t *AgentSendTool) Execute(ctx context.Context, params map[string]any) (string, error) {
+	if t == nil {
+		return "", fmt.Errorf("agent_send tool is disabled")
+	}
+	return executeContactSendTool(ctx, params, t.opts, contactSendExecutionPolicy{
+		toolName:         "agent_send",
+		activeAgentsOnly: true,
+	})
+}
+
+func AgentSendAvailable(ctx context.Context, contactsDir string) (bool, error) {
+	contactsDir = pathutil.ExpandHomePath(strings.TrimSpace(contactsDir))
+	if contactsDir == "" {
+		return false, nil
+	}
+	ids, err := loadActiveAgentContactIDs(ctx, contacts.NewFileStore(contactsDir))
+	if err != nil {
+		return false, err
+	}
+	return len(ids) > 0, nil
+}
+
+func loadActiveAgentContactIDs(ctx context.Context, store contacts.ContactStore) (map[string]struct{}, error) {
+	if store == nil {
+		return nil, fmt.Errorf("contacts store is required")
+	}
+	active, err := store.ListContacts(ctx, contacts.StatusActive)
+	if err != nil {
+		return nil, fmt.Errorf("load active Agents: %w", err)
+	}
+	ids := make(map[string]struct{})
+	for _, contact := range active {
+		if contact.Kind != contacts.KindAgent {
+			continue
+		}
+		if id := normalizeAgentSendContactID(contact.ContactID); id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	return ids, nil
+}
+
+func validateActiveAgentRecipient(activeAgentIDs map[string]struct{}, contactID string, contact contacts.Contact) error {
+	_, active := activeAgentIDs[normalizeAgentSendContactID(contact.ContactID)]
+	if contact.Kind != contacts.KindAgent || !active {
+		return fmt.Errorf("agent_send target %q is not an active Agent", strings.TrimSpace(contactID))
+	}
+	return nil
+}
+
+func normalizeAgentSendContactID(contactID string) string {
+	return strings.ToLower(strings.TrimSpace(contactID))
+}

--- a/tools/builtin/agent_send_test.go
+++ b/tools/builtin/agent_send_test.go
@@ -1,0 +1,100 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/quailyquaily/mistermorph/contacts"
+)
+
+func TestAgentSendToolUsesContactsSendParameters(t *testing.T) {
+	contactsTool := NewContactsSendTool(ContactsSendToolOptions{Enabled: true})
+	agentTool := NewAgentSendTool(ContactsSendToolOptions{Enabled: true})
+
+	if agentTool.ParameterSchema() != contactsTool.ParameterSchema() {
+		t.Fatal("agent_send and contacts_send parameter schemas differ")
+	}
+}
+
+func TestAgentSendToolOnlySendsToActiveAgents(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
+	contactsDir := filepath.Join(t.TempDir(), "contacts")
+	svc := contacts.NewService(contacts.NewFileStore(contactsDir))
+	for _, contact := range []contacts.Contact{
+		{
+			ContactID:      "contact:smith",
+			Kind:           contacts.KindAgent,
+			Channel:        contacts.ChannelTelegram,
+			TGUsername:     "smith_bot",
+			TGGroupChatIDs: []int64{-1001},
+		},
+		{
+			ContactID:      "tg:@alice",
+			Kind:           contacts.KindHuman,
+			Channel:        contacts.ChannelTelegram,
+			TGUsername:     "alice",
+			TGGroupChatIDs: []int64{-1001},
+		},
+	} {
+		if _, err := svc.UpsertContact(ctx, contact, now); err != nil {
+			t.Fatalf("UpsertContact(%q) error = %v", contact.ContactID, err)
+		}
+	}
+
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":     true,
+			"result": map[string]any{"message_id": 1},
+		})
+	}))
+	defer server.Close()
+
+	tool := NewAgentSendTool(ContactsSendToolOptions{
+		Enabled:          true,
+		ContactsDir:      contactsDir,
+		TelegramBotToken: "token",
+		TelegramBaseURL:  server.URL,
+	})
+
+	_, err := tool.Execute(ctx, map[string]any{
+		"contact_id":   "tg:@smith_bot,tg:@alice",
+		"message_text": "continue",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not an active Agent") {
+		t.Fatalf("mixed recipient Execute() error = %v, want active Agent rejection", err)
+	}
+	if got := requestCount.Load(); got != 0 {
+		t.Fatalf("mixed recipient request count = %d, want 0", got)
+	}
+	_, err = tool.Execute(ctx, map[string]any{
+		"contact_id":   "tg:-1001",
+		"message_text": "continue",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not an active Agent") {
+		t.Fatalf("raw chat target Execute() error = %v, want active Agent rejection", err)
+	}
+	if got := requestCount.Load(); got != 0 {
+		t.Fatalf("raw chat target request count = %d, want 0", got)
+	}
+
+	if _, err := tool.Execute(ctx, map[string]any{
+		"contact_id":   "tg:@smith_bot",
+		"message_text": "continue",
+	}); err != nil {
+		t.Fatalf("active Agent Execute() error = %v", err)
+	}
+	if got := requestCount.Load(); got != 1 {
+		t.Fatalf("active Agent request count = %d, want 1", got)
+	}
+}

--- a/tools/builtin/contacts_send.go
+++ b/tools/builtin/contacts_send.go
@@ -55,6 +55,10 @@ func (t *ContactsSendTool) Description() string {
 }
 
 func (t *ContactsSendTool) ParameterSchema() string {
+	return contactSendParameterSchema()
+}
+
+func contactSendParameterSchema() string {
 	s := map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -94,8 +98,27 @@ func (t *ContactsSendTool) ParameterSchema() string {
 }
 
 func (t *ContactsSendTool) Execute(ctx context.Context, params map[string]any) (string, error) {
-	if t == nil || !t.opts.Enabled {
+	if t == nil {
 		return "", fmt.Errorf("contacts_send tool is disabled")
+	}
+	return executeContactSendTool(ctx, params, t.opts, contactsSendPolicy)
+}
+
+type contactSendExecutionPolicy struct {
+	toolName                 string
+	blockCurrentConversation bool
+	activeAgentsOnly         bool
+	activeAgentIDs           map[string]struct{}
+}
+
+var contactsSendPolicy = contactSendExecutionPolicy{
+	toolName:                 "contacts_send",
+	blockCurrentConversation: true,
+}
+
+func executeContactSendTool(ctx context.Context, params map[string]any, opts ContactsSendToolOptions, policy contactSendExecutionPolicy) (string, error) {
+	if !opts.Enabled {
+		return "", fmt.Errorf("%s tool is disabled", policy.toolName)
 	}
 	contactIDs, err := parseContactsSendContactIDs(params)
 	if err != nil {
@@ -105,28 +128,36 @@ func (t *ContactsSendTool) Execute(ctx context.Context, params map[string]any) (
 	if err != nil {
 		return "", err
 	}
-	if len(contactIDs) == 1 {
+	if policy.blockCurrentConversation && len(contactIDs) == 1 {
 		if runtimeCtx, ok := ContactsSendRuntimeContextFromContext(ctx); ok {
 			if field, target, blocked := contactsSendBlockedTarget(contactIDs[0], chatID, runtimeCtx); blocked {
-				return "", fmt.Errorf("contacts_send blocked: %s %q matches current conversation counterpart", field, target)
+				return "", fmt.Errorf("%s blocked: %s %q matches current conversation counterpart", policy.toolName, field, target)
 			}
 		}
 	}
-	contactsDir := pathutil.ExpandHomePath(strings.TrimSpace(t.opts.ContactsDir))
+	contactsDir := pathutil.ExpandHomePath(strings.TrimSpace(opts.ContactsDir))
 	if contactsDir == "" {
 		return "", fmt.Errorf("contacts dir is not configured")
 	}
+	store := contacts.NewFileStore(contactsDir)
+	if policy.activeAgentsOnly {
+		activeAgentIDs, err := loadActiveAgentContactIDs(ctx, store)
+		if err != nil {
+			return "", err
+		}
+		policy.activeAgentIDs = activeAgentIDs
+	}
 
 	sender, err := contactsruntime.NewRoutingSender(ctx, contactsruntime.SenderOptions{
-		TelegramBotToken: strings.TrimSpace(t.opts.TelegramBotToken),
-		TelegramBaseURL:  strings.TrimSpace(t.opts.TelegramBaseURL),
-		SlackBotToken:    strings.TrimSpace(t.opts.SlackBotToken),
-		SlackBaseURL:     strings.TrimSpace(t.opts.SlackBaseURL),
-		LineChannelToken: strings.TrimSpace(t.opts.LineChannelToken),
-		LineBaseURL:      strings.TrimSpace(t.opts.LineBaseURL),
-		LarkAppID:        strings.TrimSpace(t.opts.LarkAppID),
-		LarkAppSecret:    strings.TrimSpace(t.opts.LarkAppSecret),
-		LarkBaseURL:      strings.TrimSpace(t.opts.LarkBaseURL),
+		TelegramBotToken: strings.TrimSpace(opts.TelegramBotToken),
+		TelegramBaseURL:  strings.TrimSpace(opts.TelegramBaseURL),
+		SlackBotToken:    strings.TrimSpace(opts.SlackBotToken),
+		SlackBaseURL:     strings.TrimSpace(opts.SlackBaseURL),
+		LineChannelToken: strings.TrimSpace(opts.LineChannelToken),
+		LineBaseURL:      strings.TrimSpace(opts.LineBaseURL),
+		LarkAppID:        strings.TrimSpace(opts.LarkAppID),
+		LarkAppSecret:    strings.TrimSpace(opts.LarkAppSecret),
+		LarkBaseURL:      strings.TrimSpace(opts.LarkBaseURL),
 	})
 	if err != nil {
 		return "", err
@@ -134,12 +165,12 @@ func (t *ContactsSendTool) Execute(ctx context.Context, params map[string]any) (
 	defer sender.Close()
 
 	svc := contacts.NewServiceWithOptions(
-		contacts.NewFileStore(contactsDir),
+		store,
 		contacts.ServiceOptions{
-			FailureCooldown: t.opts.FailureCooldown,
+			FailureCooldown: opts.FailureCooldown,
 		},
 	)
-	return executeContactsSendResolved(ctx, params, contactIDs, chatID, svc, sender, time.Now().UTC())
+	return executeContactsSendResolved(ctx, params, contactIDs, chatID, svc, sender, time.Now().UTC(), policy)
 }
 
 func executeContactsSendResolved(
@@ -150,6 +181,7 @@ func executeContactsSendResolved(
 	svc *contacts.Service,
 	sender contacts.Sender,
 	now time.Time,
+	policy contactSendExecutionPolicy,
 ) (string, error) {
 	if svc == nil {
 		return "", fmt.Errorf("contacts service is required")
@@ -158,13 +190,13 @@ func executeContactsSendResolved(
 		return "", fmt.Errorf("contacts sender is required")
 	}
 	if len(contactIDs) == 1 {
-		return executeContactsSendSingle(ctx, params, strings.TrimSpace(contactIDs[0]), chatID, svc, sender, now)
+		return executeContactsSendSingle(ctx, params, strings.TrimSpace(contactIDs[0]), chatID, svc, sender, now, policy)
 	}
 	baseText, err := contactsSendBaseMessageText(params)
 	if err != nil {
 		return "", err
 	}
-	recipients, err := resolveContactsSendRecipients(ctx, svc, contactIDs)
+	recipients, err := resolveContactsSendRecipients(ctx, svc, contactIDs, policy)
 	if err != nil {
 		return "", err
 	}
@@ -172,9 +204,11 @@ func executeContactsSendResolved(
 	if err != nil {
 		return "", err
 	}
-	if runtimeCtx, ok := ContactsSendRuntimeContextFromContext(ctx); ok {
-		if err := checkContactsSendPlanBlocked(plan, runtimeCtx); err != nil {
-			return "", err
+	if policy.blockCurrentConversation {
+		if runtimeCtx, ok := ContactsSendRuntimeContextFromContext(ctx); ok {
+			if err := checkContactsSendPlanBlocked(plan, runtimeCtx, policy.toolName); err != nil {
+				return "", err
+			}
 		}
 	}
 
@@ -220,12 +254,22 @@ func executeContactsSendSingle(
 	svc *contacts.Service,
 	sender contacts.Sender,
 	now time.Time,
+	policy contactSendExecutionPolicy,
 ) (string, error) {
 	resolvedChatID, err := resolveContactsSendChatTargetHint(contactID, chatID)
 	if err != nil {
 		return "", err
 	}
-	sendParams, err := contactsSendParamsWithSingleMention(ctx, params, contactID, resolvedChatID, svc)
+	contact, err := svc.ResolveSendContact(ctx, contactID)
+	if err != nil {
+		return "", err
+	}
+	if policy.activeAgentsOnly {
+		if err := validateActiveAgentRecipient(policy.activeAgentIDs, contactID, contact); err != nil {
+			return "", err
+		}
+	}
+	sendParams, err := contactsSendParamsWithSingleMention(params, contactID, resolvedChatID, contact)
 	if err != nil {
 		return "", err
 	}
@@ -271,16 +315,9 @@ func resolveContactsSendChatTargetHint(contactID string, chatID string) (string,
 	return targetChatID, nil
 }
 
-func contactsSendParamsWithSingleMention(ctx context.Context, params map[string]any, contactID string, chatID string, svc *contacts.Service) (map[string]any, error) {
-	if svc == nil {
-		return nil, fmt.Errorf("contacts service is required")
-	}
-	contact, err := svc.ResolveSendContact(ctx, contactID)
-	if err != nil {
-		return nil, err
-	}
+func contactsSendParamsWithSingleMention(params map[string]any, contactID string, chatID string, contact contacts.Contact) (map[string]any, error) {
 	channel, err := contacts.ResolveDecisionChannel(contact, contacts.ShareDecision{
-		ContactID: contact.ContactID,
+		ContactID: contactID,
 		ChatID:    chatID,
 	})
 	if err != nil {
@@ -368,12 +405,17 @@ type contactsSendRouteCandidate struct {
 	Key     string
 }
 
-func resolveContactsSendRecipients(ctx context.Context, svc *contacts.Service, contactIDs []string) ([]contactsSendRecipient, error) {
+func resolveContactsSendRecipients(ctx context.Context, svc *contacts.Service, contactIDs []string, policy contactSendExecutionPolicy) ([]contactsSendRecipient, error) {
 	recipients := make([]contactsSendRecipient, 0, len(contactIDs))
 	for _, contactID := range contactIDs {
 		contact, err := svc.ResolveSendContact(ctx, contactID)
 		if err != nil {
 			return nil, err
+		}
+		if policy.activeAgentsOnly {
+			if err := validateActiveAgentRecipient(policy.activeAgentIDs, contactID, contact); err != nil {
+				return nil, err
+			}
 		}
 		if err := validateContactsSendDefaultRoute(contact); err != nil {
 			return nil, err
@@ -797,11 +839,11 @@ func contactsSendSessionIDFromMessageBase64(params map[string]any) string {
 	return strings.TrimSpace(sessionID)
 }
 
-func checkContactsSendPlanBlocked(plan []contactsSendPlanItem, runtimeCtx ContactsSendRuntimeContext) error {
+func checkContactsSendPlanBlocked(plan []contactsSendPlanItem, runtimeCtx ContactsSendRuntimeContext, toolName string) error {
 	for _, item := range plan {
 		for _, contactID := range item.RecipientContactIDs {
 			if field, target, blocked := contactsSendBlockedTarget(contactID, item.ChatID, runtimeCtx); blocked {
-				return fmt.Errorf("contacts_send blocked: %s %q matches current conversation counterpart", field, target)
+				return fmt.Errorf("%s blocked: %s %q matches current conversation counterpart", toolName, field, target)
 			}
 		}
 	}

--- a/tools/builtin/contacts_send_test.go
+++ b/tools/builtin/contacts_send_test.go
@@ -470,7 +470,7 @@ func TestExecuteContactsSendBatchLoopsAndMentionsSharedTelegramChats(t *testing.
 	_, err = executeContactsSendResolved(ctx, map[string]any{
 		"contact_id":   "tg:@john_wick,tg:@rose,tg:@ada",
 		"message_text": "Hello, world",
-	}, contactIDs, "", svc, sender, now)
+	}, contactIDs, "", svc, sender, now, contactsSendPolicy)
 	if err != nil {
 		t.Fatalf("executeContactsSendResolved() error = %v", err)
 	}
@@ -550,7 +550,7 @@ func TestExecuteContactsSendBatchHonorsExplicitTelegramChatID(t *testing.T) {
 		t.Fatalf("parseContactsSendContactIDs() error = %v", err)
 	}
 	sender := &recordingContactsSendSender{}
-	_, err = executeContactsSendResolved(ctx, params, contactIDs, "tg:-5002", svc, sender, now)
+	_, err = executeContactsSendResolved(ctx, params, contactIDs, "tg:-5002", svc, sender, now, contactsSendPolicy)
 	if err != nil {
 		t.Fatalf("executeContactsSendResolved() error = %v", err)
 	}
@@ -599,7 +599,7 @@ func TestExecuteContactsSendBatchRejectsExplicitChatUnavailableToRecipient(t *te
 		t.Fatalf("parseContactsSendContactIDs() error = %v", err)
 	}
 	sender := &recordingContactsSendSender{}
-	_, err = executeContactsSendResolved(ctx, params, contactIDs, "tg:-2001", svc, sender, now)
+	_, err = executeContactsSendResolved(ctx, params, contactIDs, "tg:-2001", svc, sender, now, contactsSendPolicy)
 	if err == nil {
 		t.Fatalf("executeContactsSendResolved() expected unavailable chat_id error")
 	}
@@ -647,7 +647,7 @@ func TestExecuteContactsSendBatchRecordsFailureCooldownForAllMergedRecipients(t 
 	_, err = executeContactsSendResolved(ctx, map[string]any{
 		"contact_id":   "tg:@john_wick,tg:@rose",
 		"message_text": "Hello, world",
-	}, contactIDs, "", svc, sender, now)
+	}, contactIDs, "", svc, sender, now, contactsSendPolicy)
 	if err != nil {
 		t.Fatalf("executeContactsSendResolved() error = %v", err)
 	}
@@ -695,7 +695,7 @@ func TestExecuteContactsSendSinglePrefixesTelegramMention(t *testing.T) {
 	_, err = executeContactsSendResolved(ctx, map[string]any{
 		"contact_id":   "tg:@ballcatcat",
 		"message_text": "看电视哦！👀",
-	}, contactIDs, "", svc, sender, now)
+	}, contactIDs, "", svc, sender, now, contactsSendPolicy)
 	if err != nil {
 		t.Fatalf("executeContactsSendResolved() error = %v", err)
 	}
@@ -705,6 +705,40 @@ func TestExecuteContactsSendSinglePrefixesTelegramMention(t *testing.T) {
 	}
 	if got := decodeEnvelopePayload(t, sender.calls[0].decision.PayloadBase64)["text"]; got != "@ballcatcat 看电视哦！👀" {
 		t.Fatalf("text = %v", got)
+	}
+}
+
+func TestExecuteContactsSendSingleKeepsExplicitTelegramRoute(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)
+	store := contacts.NewFileStore(filepath.Join(t.TempDir(), "contacts"))
+	svc := contacts.NewService(store)
+	if _, err := svc.UpsertContact(ctx, contacts.Contact{
+		ContactID:        "contact:smith",
+		Kind:             contacts.KindAgent,
+		Channel:          contacts.ChannelSlack,
+		ContactNickname:  "Smith",
+		TGUsername:       "smith_bot",
+		SlackTeamID:      "T1",
+		SlackUserID:      "U1",
+		SlackDMChannelID: "D1",
+	}, now); err != nil {
+		t.Fatalf("UpsertContact() error = %v", err)
+	}
+
+	sender := &recordingContactsSendSender{}
+	_, err := executeContactsSendResolved(ctx, map[string]any{
+		"contact_id":   "tg:@smith_bot",
+		"message_text": "continue",
+	}, []string{"tg:@smith_bot"}, "", svc, sender, now, contactsSendPolicy)
+	if err != nil {
+		t.Fatalf("executeContactsSendResolved() error = %v", err)
+	}
+	if len(sender.calls) != 1 {
+		t.Fatalf("sender calls len = %d, want 1", len(sender.calls))
+	}
+	if got := decodeEnvelopePayload(t, sender.calls[0].decision.PayloadBase64)["text"]; got != "@smith_bot continue" {
+		t.Fatalf("text = %#v, want %q", got, "@smith_bot continue")
 	}
 }
 
@@ -720,7 +754,7 @@ func TestExecuteContactsSendSingleChatIDTarget(t *testing.T) {
 		"contact_id":   "tg:-100123",
 		"chat_id":      "tg:-100123",
 		"message_text": "hello room",
-	}, []string{"tg:-100123"}, "tg:-100123", svc, sender, now)
+	}, []string{"tg:-100123"}, "tg:-100123", svc, sender, now, contactsSendPolicy)
 	if err != nil {
 		t.Fatalf("executeContactsSendResolved() error = %v", err)
 	}
@@ -751,7 +785,7 @@ func TestExecuteContactsSendSingleChatIDTargetUsesContactIDWhenChatIDEmpty(t *te
 	_, err := executeContactsSendResolved(ctx, map[string]any{
 		"contact_id":   "tg:-100123_77",
 		"message_text": "hello topic",
-	}, []string{"tg:-100123_77"}, "", svc, sender, now)
+	}, []string{"tg:-100123_77"}, "", svc, sender, now, contactsSendPolicy)
 	if err != nil {
 		t.Fatalf("executeContactsSendResolved() error = %v", err)
 	}
@@ -774,7 +808,7 @@ func TestExecuteContactsSendSingleChatIDTargetRejectsMismatchedHint(t *testing.T
 		"contact_id":   "tg:-100123",
 		"chat_id":      "tg:-100456",
 		"message_text": "hello room",
-	}, []string{"tg:-100123"}, "tg:-100456", svc, sender, now)
+	}, []string{"tg:-100123"}, "tg:-100456", svc, sender, now, contactsSendPolicy)
 	if err == nil {
 		t.Fatalf("executeContactsSendResolved() expected mismatched chat_id error")
 	}

--- a/web/console/src/components/AppNavList.js
+++ b/web/console/src/components/AppNavList.js
@@ -62,7 +62,7 @@ const AppNavList = {
       return value || "/";
     },
     shouldRenderBeforeRuntimeSlot(item) {
-      return !!this.sidebarBeforeRuntimeSlot && item?.id === "/settings";
+      return !!this.sidebarBeforeRuntimeSlot && item?.pagePath === "/settings";
     },
     onNavigate(item) {
       this.$emit("navigate", item);

--- a/web/console/src/composables/useAppShell.js
+++ b/web/console/src/composables/useAppShell.js
@@ -5,6 +5,12 @@ import defaultEndpointAvatarURL from "../assets/images/app_logo_current.svg";
 import { lastTopicID } from "../core/chat-topic-memory";
 import { endpointDisplayItem, visibleEndpoints } from "../core/endpoints";
 import {
+  endpointPagePath,
+  endpointRefFromRouteParam,
+  endpointRoutePath,
+  endpointSwitchPath,
+} from "../core/endpoint-routes";
+import {
   authValid,
   endpointState,
   ensureEndpointsLoaded,
@@ -15,7 +21,7 @@ import { NAV_ITEMS_META, preloadRouteComponent } from "../router";
 import { useContactsStore } from "../stores/contactsStore";
 import { usePersonaStore } from "../stores/personaStore";
 
-function chatRoutePath(topicID = "") {
+function chatPagePath(topicID = "") {
   const normalizedTopicID = String(topicID || "").trim();
   return normalizedTopicID ? `/chat/${encodeURIComponent(normalizedTopicID)}` : "/chat";
 }
@@ -41,17 +47,26 @@ function useAppShell() {
   const inLogin = computed(() => route.path === "/login");
   const inShellless = computed(() => route.meta && route.meta.shellless === true);
   const inOverview = computed(() => route.path === "/overview");
-  const inSetup = computed(() => route.path === "/setup" || route.path.startsWith("/setup/"));
+  const inSetup = computed(() => {
+    const pagePath = endpointPagePath(route.path) || route.path;
+    return pagePath === "/setup" || pagePath.startsWith("/setup/");
+  });
   const inAgentDesk = computed(() => route.path === "/chat/desk");
   const inStandalone = computed(() => inOverview.value || inSetup.value || inAgentDesk.value);
   const inWorkspacePage = computed(() => !inShellless.value && !inStandalone.value);
   const currentPath = computed(() => route.path);
+  const endpointViewKey = computed(() =>
+    route.meta?.endpointScoped
+      ? endpointRefFromRouteParam(route.params.endpoint_ref)
+      : String(route.name || route.path),
+  );
   const navItems = computed(() =>
     NAV_ITEMS_META.map((item) =>
       item.separator
         ? { id: item.id, separator: true }
         : {
-            id: item.id,
+            id: endpointRoutePath(endpointState.selectedRef, item.id),
+            pagePath: item.id,
             title: t(item.titleKey),
             icon: item.icon || "",
           }
@@ -138,8 +153,11 @@ function useAppShell() {
     if (!item || typeof item.id !== "string" || !item.id) {
       return "";
     }
-    if (item.id === "/chat") {
-      return chatRoutePath(lastTopicID(chatSubmitEndpointRef(endpointState.selectedRef)));
+    if (item.pagePath === "/chat") {
+      return endpointRoutePath(
+        endpointState.selectedRef,
+        chatPagePath(lastTopicID(chatSubmitEndpointRef(endpointState.selectedRef))),
+      );
     }
     return item.id;
   }
@@ -205,20 +223,28 @@ function useAppShell() {
 
   function onEndpointChange(item) {
     mobileNavOpen.value = false;
-    if (item && typeof item === "object" && typeof item.value === "string") {
-      const canSelect = visibleEndpoints(endpointState.items, { connectedOnly: true }).some(
-        (endpoint) => endpoint.endpoint_ref === item.value && endpoint.connected === true
-      );
-      endpointState.setSelectedEndpointRef(canSelect ? item.value : "");
+    const targetRef = typeof item?.value === "string" ? item.value.trim() : "";
+    const canSelect = visibleEndpoints(endpointState.items, { connectedOnly: true }).some(
+      (endpoint) => endpoint.endpoint_ref === targetRef,
+    );
+    if (!canSelect) {
       return;
     }
-    endpointState.setSelectedEndpointRef("");
+    const nextPath = endpointSwitchPath(
+      targetRef,
+      route.path,
+      lastTopicID(chatSubmitEndpointRef(targetRef)),
+    );
+    if (nextPath && route.path !== nextPath) {
+      router.push(nextPath);
+    }
   }
 
   function goSettings() {
     mobileNavOpen.value = false;
-    if (route.path !== "/settings") {
-      router.push("/settings");
+    const nextPath = endpointRoutePath(endpointState.selectedRef, "/settings");
+    if (nextPath && route.path !== nextPath) {
+      router.push(nextPath);
     }
   }
 
@@ -231,6 +257,7 @@ function useAppShell() {
     inStandalone,
     inWorkspacePage,
     currentPath,
+    endpointViewKey,
     navItems,
     goTo,
     preloadNavItem,

--- a/web/console/src/composables/useProAuthFlow.js
+++ b/web/console/src/composables/useProAuthFlow.js
@@ -1,6 +1,6 @@
 import { computed, onBeforeUnmount, reactive, ref, watch } from "vue";
 
-import { apiFetch, formatTime, translate } from "../core/context";
+import { formatTime, translate } from "../core/context";
 import {
   canOpenExternalURLInDesktop,
   openExternalPlaceholder,
@@ -46,12 +46,8 @@ function delayFromIntervalSeconds(intervalSeconds = 5) {
   return Math.max(2, Number(intervalSeconds) || 5) * 1000;
 }
 
-export function useProAuthFlow(options = {}) {
+function useProAuthFlow({ request, getEndpointRef, onSettingsUpdated }) {
   const t = translate;
-  const request = typeof options.request === "function" ? options.request : apiFetch;
-  const getEndpointRef = typeof options.getEndpointRef === "function" ? options.getEndpointRef : () => "";
-  const onSettingsUpdated =
-    typeof options.onSettingsUpdated === "function" ? options.onSettingsUpdated : async () => {};
 
   const proAuthLoading = ref(false);
   const proAuthBusy = ref(false);
@@ -125,7 +121,7 @@ export function useProAuthFlow(options = {}) {
     proAuthLoading.value = true;
     proAuthError.value = "";
     try {
-      const payload = await request("/auth/pro/status", undefined, targetEndpointRef);
+      const payload = await request(targetEndpointRef, "/auth/pro/status");
       if (!isCurrentRequest(generation, targetEndpointRef)) {
         return;
       }
@@ -192,7 +188,7 @@ export function useProAuthFlow(options = {}) {
     resetProLoginSession();
     let authWindowUsed = false;
     try {
-      const payload = await request("/auth/pro/login/start", { method: "POST" }, targetEndpointRef);
+      const payload = await request(targetEndpointRef, "/auth/pro/login/start", { method: "POST" });
       if (!isCurrentRequest(generation, targetEndpointRef)) {
         return;
       }
@@ -240,12 +236,12 @@ export function useProAuthFlow(options = {}) {
     proAuthError.value = "";
     try {
       const payload = await request(
+        targetEndpointRef,
         "/auth/pro/login/poll",
         {
           method: "POST",
           body: { session_id: sessionID, set_default: true },
-        },
-        targetEndpointRef
+        }
       );
       if (
         !isCurrentRequest(generation, targetEndpointRef) ||
@@ -284,7 +280,7 @@ export function useProAuthFlow(options = {}) {
     proAuthBusy.value = true;
     proAuthError.value = "";
     try {
-      const payload = await request("/auth/pro/logout", { method: "POST" }, targetEndpointRef);
+      const payload = await request(targetEndpointRef, "/auth/pro/logout", { method: "POST" });
       if (!isCurrentRequest(generation, targetEndpointRef)) {
         return;
       }

--- a/web/console/src/composables/useXAIAuthFlow.js
+++ b/web/console/src/composables/useXAIAuthFlow.js
@@ -1,6 +1,6 @@
 import { computed, onBeforeUnmount, reactive, ref, watch } from "vue";
 
-import { apiFetch, formatTime, translate } from "../core/context";
+import { formatTime, translate } from "../core/context";
 import {
   canOpenExternalURLInDesktop,
   openExternalPlaceholder,
@@ -34,12 +34,8 @@ function normalizeXAIAuthStatus(payload) {
   };
 }
 
-export function useXAIAuthFlow(options = {}) {
+function useXAIAuthFlow({ request, getEndpointRef, onSettingsUpdated }) {
   const t = translate;
-  const request = typeof options.request === "function" ? options.request : apiFetch;
-  const getEndpointRef = typeof options.getEndpointRef === "function" ? options.getEndpointRef : () => "";
-  const onSettingsUpdated =
-    typeof options.onSettingsUpdated === "function" ? options.onSettingsUpdated : async () => {};
 
   const xaiAuthLoading = ref(false);
   const xaiAuthBusy = ref(false);
@@ -115,7 +111,7 @@ export function useXAIAuthFlow(options = {}) {
     xaiAuthLoading.value = true;
     xaiAuthError.value = "";
     try {
-      const payload = await request("/auth/xai/status", undefined, targetEndpointRef);
+      const payload = await request(targetEndpointRef, "/auth/xai/status");
       if (!isCurrentRequest(generation, targetEndpointRef)) {
         return;
       }
@@ -184,7 +180,7 @@ export function useXAIAuthFlow(options = {}) {
     resetXAILoginSession();
     let authWindowUsed = false;
     try {
-      const payload = await request("/auth/xai/login/start", { method: "POST" }, targetEndpointRef);
+      const payload = await request(targetEndpointRef, "/auth/xai/login/start", { method: "POST" });
       if (!isCurrentRequest(generation, targetEndpointRef)) {
         return;
       }
@@ -234,12 +230,12 @@ export function useXAIAuthFlow(options = {}) {
     xaiAuthError.value = "";
     try {
       const payload = await request(
+        targetEndpointRef,
         "/auth/xai/login/poll",
         {
           method: "POST",
           body: { session_id: sessionID, set_default: xaiSetDefault.value },
-        },
-        targetEndpointRef
+        }
       );
       if (
         !isCurrentRequest(generation, targetEndpointRef) ||
@@ -278,7 +274,7 @@ export function useXAIAuthFlow(options = {}) {
     xaiAuthBusy.value = true;
     xaiAuthError.value = "";
     try {
-      const payload = await request("/auth/xai/logout", { method: "POST" }, targetEndpointRef);
+      const payload = await request(targetEndpointRef, "/auth/xai/logout", { method: "POST" });
       if (!isCurrentRequest(generation, targetEndpointRef)) {
         return;
       }

--- a/web/console/src/core/context.js
+++ b/web/console/src/core/context.js
@@ -1,5 +1,6 @@
 import { currentLocale, localeState, translate } from "../i18n";
 import { authState, authValid, endpointState } from "../stores";
+import { CONSOLE_LOCAL_ENDPOINT_REF } from "./endpoints";
 import { recordApiRequest } from "./performance";
 import { loadResource, resourceKey } from "./resources";
 
@@ -319,6 +320,14 @@ async function runtimeApiFetchForEndpoint(endpointRef, pathname, options = {}) {
   return apiFetch(`/proxy?${q.toString()}`, options);
 }
 
+function endpointApiFetch(endpointRef, pathname, options = {}) {
+  const ref = String(endpointRef || "").trim();
+  if (ref === CONSOLE_LOCAL_ENDPOINT_REF) {
+    return apiFetch(pathname, options);
+  }
+  return runtimeApiFetchForEndpoint(ref, pathname, options);
+}
+
 async function runtimeApiDownloadForEndpoint(endpointRef, pathname, options = {}) {
   endpointRef = String(endpointRef || "").trim();
   if (!endpointRef) {
@@ -521,6 +530,7 @@ export {
   ensureEndpointsLoaded,
   runtimeApiFetch,
   runtimeApiFetchForEndpoint,
+  endpointApiFetch,
   runtimeApiDownloadForEndpoint,
   createArtifactPreviewTicket,
   renewArtifactPreviewTicket,

--- a/web/console/src/core/endpoint-router-integration.test.mjs
+++ b/web/console/src/core/endpoint-router-integration.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const routerSource = new URL("../router/index.js", import.meta.url);
+const appShellSource = new URL("../composables/useAppShell.js", import.meta.url);
+const appLayoutSource = new URL("../layouts/AppLayout.js", import.meta.url);
+
+test("endpoint-owned pages are mounted under the endpoint route scope", async () => {
+  const source = await readFile(routerSource, "utf8");
+
+  for (const suffix of [
+    "/chat",
+    "/chat/:topic_id",
+    "/contacts",
+    "/memory",
+    "/todo",
+    "/stats",
+    "/audit",
+    "/logs",
+    "/settings",
+    "/settings/:section",
+    "/setup",
+    "/setup/llm",
+    "/setup/persona",
+    "/setup/soul",
+    "/setup/done",
+    "/setup/repair",
+  ]) {
+    assert.ok(
+      source.includes(`\`\${ENDPOINT_SCOPE_PATH}${suffix}\``),
+      `missing scoped route ${suffix}`,
+    );
+  }
+  assert.match(source, /endpointRefFromRouteParam\(to\.params\.endpoint_ref\)/);
+  assert.match(source, /endpointState\.setSelectedEndpointRef\(requestedEndpointRef\)/);
+});
+
+test("old endpoint-owned paths redirect to the local console scope", async () => {
+  const source = await readFile(routerSource, "utf8");
+
+  assert.match(source, /legacyEndpointRedirect\("\/todo"\)/);
+  assert.match(source, /legacyEndpointRedirect\("\/chat\/:topic_id"\)/);
+});
+
+test("agent switching navigates through the route and endpoint changes remount the page", async () => {
+  const [shell, layout] = await Promise.all([
+    readFile(appShellSource, "utf8"),
+    readFile(appLayoutSource, "utf8"),
+  ]);
+
+  assert.match(shell, /endpointSwitchPath\(/);
+  assert.match(shell, /router\.push\(nextPath\)/);
+  assert.doesNotMatch(
+    shell,
+    /function onEndpointChange[\s\S]*?endpointState\.setSelectedEndpointRef[\s\S]*?\n  }/,
+  );
+  assert.match(layout, /<RouterView :key="endpointViewKey" \/>/);
+});

--- a/web/console/src/core/endpoint-routes.js
+++ b/web/console/src/core/endpoint-routes.js
@@ -1,0 +1,71 @@
+import { CONSOLE_LOCAL_ENDPOINT_REF } from "./endpoints.js";
+
+const DEFAULT_ENDPOINT_ROUTE_REF = "default";
+const ENDPOINT_ROUTE_PREFIX = "/e";
+
+function normalizeRouteParam(value) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  return String(raw || "").trim();
+}
+
+function endpointRouteRef(endpointRef) {
+  const ref = normalizeRouteParam(endpointRef);
+  if (!ref) {
+    return "";
+  }
+  return ref === CONSOLE_LOCAL_ENDPOINT_REF ? DEFAULT_ENDPOINT_ROUTE_REF : ref;
+}
+
+function endpointRefFromRouteParam(routeRef) {
+  const ref = normalizeRouteParam(routeRef);
+  if (!ref) {
+    return "";
+  }
+  return ref.toLowerCase() === DEFAULT_ENDPOINT_ROUTE_REF
+    ? CONSOLE_LOCAL_ENDPOINT_REF
+    : ref;
+}
+
+function endpointRoutePath(endpointRef, pagePath) {
+  const routeRef = endpointRouteRef(endpointRef);
+  if (!routeRef) {
+    return "";
+  }
+  let suffix = String(pagePath || "").trim();
+  if (!suffix || suffix === "/") {
+    suffix = "";
+  } else if (!suffix.startsWith("/")) {
+    suffix = `/${suffix}`;
+  }
+  return `${ENDPOINT_ROUTE_PREFIX}/${encodeURIComponent(routeRef)}${suffix}`;
+}
+
+function endpointPagePath(path) {
+  const value = String(path || "").trim();
+  const match = value.match(/^\/e\/[^/]+(?=\/|$)/);
+  if (!match) {
+    return "";
+  }
+  return value.slice(match[0].length) || "/";
+}
+
+function endpointSwitchPath(endpointRef, currentPath, chatTopicID = "") {
+  let pagePath = endpointPagePath(currentPath);
+  if (!pagePath) {
+    pagePath = "/chat";
+  }
+  if (pagePath === "/chat" || pagePath.startsWith("/chat/")) {
+    const topicID = String(chatTopicID || "").trim();
+    pagePath = topicID ? `/chat/${encodeURIComponent(topicID)}` : "/chat";
+  }
+  return endpointRoutePath(endpointRef, pagePath);
+}
+
+export {
+  ENDPOINT_ROUTE_PREFIX,
+  endpointPagePath,
+  endpointRefFromRouteParam,
+  endpointRoutePath,
+  endpointRouteRef,
+  endpointSwitchPath,
+};

--- a/web/console/src/core/endpoint-routes.test.mjs
+++ b/web/console/src/core/endpoint-routes.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  endpointPagePath,
+  endpointRefFromRouteParam,
+  endpointRoutePath,
+  endpointRouteRef,
+  endpointSwitchPath,
+} from "./endpoint-routes.js";
+
+test("local console uses the reserved default route ref", () => {
+  assert.equal(endpointRouteRef("ep_console_local"), "default");
+  assert.equal(endpointRefFromRouteParam("default"), "ep_console_local");
+  assert.equal(endpointRoutePath("ep_console_local", "/todo"), "/e/default/todo");
+});
+
+test("remote endpoints keep their endpoint ref in scoped paths", () => {
+  assert.equal(endpointRouteRef("ep_remote_b"), "ep_remote_b");
+  assert.equal(endpointRefFromRouteParam("ep_remote_b"), "ep_remote_b");
+  assert.equal(endpointRoutePath("ep_remote_b", "/settings/channels"), "/e/ep_remote_b/settings/channels");
+});
+
+test("endpoint page paths can be retained while switching agents", () => {
+  assert.equal(endpointPagePath("/e/default/memory"), "/memory");
+  assert.equal(endpointPagePath("/e/ep_remote_b/chat/topic_123"), "/chat/topic_123");
+  assert.equal(endpointPagePath("/overview"), "");
+  assert.equal(endpointPagePath("/e/default/setup/llm"), "/setup/llm");
+  assert.equal(endpointPagePath("/chat/desk"), "");
+});
+
+test("switching agents retains the page but uses the target agent's chat topic", () => {
+  assert.equal(
+    endpointSwitchPath("ep_remote_b", "/e/default/settings/channels"),
+    "/e/ep_remote_b/settings/channels",
+  );
+  assert.equal(
+    endpointSwitchPath("ep_remote_b", "/e/default/chat/topic_from_a", "topic_from_b"),
+    "/e/ep_remote_b/chat/topic_from_b",
+  );
+  assert.equal(endpointSwitchPath("ep_remote_b", "/overview", "topic_from_b"), "/e/ep_remote_b/chat/topic_from_b");
+});

--- a/web/console/src/core/endpoint-view-navigation.test.mjs
+++ b/web/console/src/core/endpoint-view-navigation.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+async function viewSource(name) {
+  return readFile(new URL(`../views/${name}.js`, import.meta.url), "utf8");
+}
+
+test("endpoint entry points navigate directly to scoped chat routes", async () => {
+  const [overview, desk, login, setup] = await Promise.all([
+    viewSource("OverviewView"),
+    viewSource("AgentDeskView"),
+    viewSource("LoginView"),
+    viewSource("SetupView"),
+  ]);
+
+  assert.match(overview, /endpointRoutePath\(item\.endpoint_ref, "\/chat"\)/);
+  assert.match(desk, /endpointRoutePath\(endpointRef, chatPagePath\)/);
+  assert.match(login, /endpointRoutePath\(targetRef, "\/chat"\)/);
+  assert.match(setup, /endpointRoutePath\(setupEndpointRef\.value, "\/chat"\)/);
+});
+
+test("endpoint-owned views keep their current endpoint in internal links", async () => {
+  const [audit, chat, settings, setup] = await Promise.all([
+    viewSource("AuditView"),
+    viewSource("ChatView"),
+    viewSource("SettingsView"),
+    viewSource("SetupView"),
+  ]);
+
+  assert.match(audit, /endpointRoutePath\(endpointState\.selectedRef, "\/chat"\)/);
+  assert.match(chat, /endpointRoutePath\(endpointState\.selectedRef, chatPagePath\)/);
+  assert.match(settings, /endpointRoutePath\(endpointState\.selectedRef, "\/logs"\)/);
+  assert.match(setup, /endpointPagePath\(route\.path\)/);
+});
+
+test("setup reads, writes, and advances only within its route endpoint", async () => {
+  const [setup, repair, setupCore] = await Promise.all([
+    viewSource("SetupView"),
+    viewSource("RepairView"),
+    readFile(new URL("./setup.js", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(
+    setup,
+    /endpointRefFromRouteParam\(route\.params\.endpoint_ref\)/,
+  );
+  assert.match(
+    setup,
+    /endpointApiFetch\(setupEndpointRef\.value, "\/settings\/agent"/,
+  );
+  assert.equal(setup.match(/request: endpointApiFetch/g)?.length, 2);
+  assert.match(
+    setup,
+    /runtimeApiFetchForEndpoint\(setupEndpointRef\.value, PERSONA_IDENTITY_ENDPOINT/,
+  );
+  assert.match(
+    setup,
+    /setupStagePath\([^\n]+, setupEndpointRef\.value\)/,
+  );
+  assert.doesNotMatch(
+    setup,
+    /runtimeApi(?:Fetch|Download)ForEndpoint\(CONSOLE_LOCAL_ENDPOINT_REF/,
+  );
+  assert.match(repair, /fetchConsoleSetupIntegrity\(\{[\s\S]*endpointRef: setupEndpointRef\.value/);
+  assert.match(
+    repair,
+    /endpointApiFetch\([\s\S]*?setupEndpointRef\.value,[\s\S]*?`\/setup\/file/,
+  );
+  assert.match(setupCore, /const endpointRef = String\(options\.endpointRef/);
+  assert.match(setupCore, /consoleStateFilesIndex\(targetEndpointRef\)/);
+});

--- a/web/console/src/core/endpoints.js
+++ b/web/console/src/core/endpoints.js
@@ -12,6 +12,13 @@ function isConsoleLocalEndpoint(item) {
   return normalizeEndpointRef(item?.endpoint_ref) === CONSOLE_LOCAL_ENDPOINT_REF;
 }
 
+function isEndpointSelectable(item) {
+  return Boolean(
+    normalizeEndpointRef(item?.endpoint_ref) &&
+      (item?.connected === true || item?.health_pending === true),
+  );
+}
+
 function visibleEndpoints(items, options = {}) {
   const connectedOnly = Boolean(options.connectedOnly);
   const rows = Array.isArray(items)
@@ -30,7 +37,7 @@ function rootEntryEndpoint(items) {
     return null;
   }
   const [endpoint] = endpoints;
-  if (endpoint?.connected !== true && endpoint?.health_pending !== true) {
+  if (!isEndpointSelectable(endpoint)) {
     return null;
   }
   return endpoint;
@@ -128,6 +135,7 @@ export {
   endpointChannelLabel,
   endpointDisplayItem,
   isConsoleLocalEndpoint,
+  isEndpointSelectable,
   rootEntryEndpoint,
   visibleEndpoints,
 };

--- a/web/console/src/core/endpoints.test.mjs
+++ b/web/console/src/core/endpoints.test.mjs
@@ -1,7 +1,19 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { rootEntryEndpoint } from "./endpoints.js";
+import { isEndpointSelectable, rootEntryEndpoint } from "./endpoints.js";
+
+test("connected and health-pending endpoints are selectable", () => {
+  assert.equal(isEndpointSelectable({ endpoint_ref: "ep_connected", connected: true }), true);
+  assert.equal(
+    isEndpointSelectable({ endpoint_ref: "ep_pending", connected: false, health_pending: true }),
+    true,
+  );
+  assert.equal(
+    isEndpointSelectable({ endpoint_ref: "ep_offline", connected: false, health_pending: false }),
+    false,
+  );
+});
 
 test("root entry accepts a sole endpoint while its health check is pending", () => {
   const endpoint = {

--- a/web/console/src/core/settings-remote-endpoint.test.mjs
+++ b/web/console/src/core/settings-remote-endpoint.test.mjs
@@ -12,7 +12,7 @@ test("Settings uses one selected endpoint ref for endpoint-owned settings", asyn
   assert.match(source, /const consoleEndpointRef = computed\(/);
   assert.match(source, /watch\(consoleEndpointRef,/);
   assert.equal(source.match(/getEndpointRef: \(\) => settingsEndpointRef\.value/g)?.length, 2);
-  assert.equal(source.match(/return endpointApiFetch\(endpointRef, path, options\)/g)?.length, 2);
+  assert.equal(source.match(/request: endpointApiFetch/g)?.length, 2);
 });
 
 for (const provider of ["XAI", "Pro"]) {
@@ -20,10 +20,15 @@ for (const provider of ["XAI", "Pro"]) {
     const source = await readFile(new URL(`../composables/use${provider}AuthFlow.js`, import.meta.url), "utf8");
     const prefix = provider === "XAI" ? "xai" : "pro";
 
-    assert.match(source, /const getEndpointRef =/);
+    assert.match(
+      source,
+      new RegExp(`function use${provider}AuthFlow\\(\\{ request, getEndpointRef, onSettingsUpdated \\}\\)`),
+    );
+    assert.doesNotMatch(source, new RegExp(`export function use${provider}AuthFlow`));
+    assert.doesNotMatch(source, /options = \{\}|: apiFetch|async \(\) => \{\}/);
     assert.match(source, new RegExp(`let ${prefix}LoginEndpointRef = ""`));
-    assert.match(source, new RegExp(`request\\(\\s*"/auth/${prefix}/login/start",[\\s\\S]*?, targetEndpointRef\\)`));
-    assert.match(source, new RegExp(`request\\(\\s*"/auth/${prefix}/login/poll",[\\s\\S]*?,\\s*targetEndpointRef\\s*\\)`));
+    assert.match(source, new RegExp(`request\\(targetEndpointRef,\\s*"/auth/${prefix}/login/start"`));
+    assert.match(source, new RegExp(`request\\(\\s*targetEndpointRef,\\s*"/auth/${prefix}/login/poll"`));
     assert.match(source, /targetEndpointRef !== currentEndpointRef\(\)/);
   });
 }

--- a/web/console/src/core/setup.js
+++ b/web/console/src/core/setup.js
@@ -1,4 +1,5 @@
-import { apiFetch, runtimeApiFetchForEndpoint } from "./context";
+import { endpointApiFetch, runtimeApiFetchForEndpoint } from "./context";
+import { endpointRoutePath } from "./endpoint-routes";
 import { CONSOLE_LOCAL_ENDPOINT_REF, visibleEndpoints } from "./endpoints";
 import {
   PERSONA_IDENTITY_ENDPOINT,
@@ -61,27 +62,28 @@ function consoleSetupTargetEndpointRef(state) {
   return state?.primaryChatReadyEndpoint?.endpoint_ref || "";
 }
 
-function setupStagePath(stage) {
+function setupStagePath(stage, endpointRef = CONSOLE_LOCAL_ENDPOINT_REF) {
   if (stage === "repair") {
-    return "/setup/repair";
+    return endpointRoutePath(endpointRef, "/setup/repair");
   }
   if (stage === "persona") {
-    return "/setup/persona";
+    return endpointRoutePath(endpointRef, "/setup/persona");
   }
   if (stage === "soul") {
-    return "/setup/soul";
+    return endpointRoutePath(endpointRef, "/setup/soul");
   }
   if (stage === "done") {
-    return "/setup/done";
+    return endpointRoutePath(endpointRef, "/setup/done");
   }
-  return "/setup/llm";
+  return endpointRoutePath(endpointRef, "/setup/llm");
 }
 
 async function fetchConsoleSetupIntegrity(options = {}) {
+  const endpointRef = String(options.endpointRef || "").trim() || CONSOLE_LOCAL_ENDPOINT_REF;
   return loadResource(
-    resourceKey("setup", "integrity"),
+    resourceKey("setup", "integrity", endpointRef),
     async () => {
-      const data = await apiFetch("/setup/integrity");
+      const data = await endpointApiFetch(endpointRef, "/setup/integrity");
       return Array.isArray(data?.items) ? data.items : [];
     },
     {
@@ -335,29 +337,45 @@ function clearSetupStageSession() {
   }
 }
 
-async function resolveConsoleSetupStageUncached(items) {
+async function resolveConsoleSetupStageUncached(items, endpointRef) {
   const setup = buildConsoleSetupState(items);
-  if (setup.requiresSetup) {
-    return { stage: "llm", setup };
-  }
-  const local = setup?.consoleLocalEndpoint;
-  if (local?.connected === true && local?.can_submit === true) {
-    const stateFilesIndex = await consoleStateFilesIndex(CONSOLE_LOCAL_ENDPOINT_REF);
-    const hasIdentity = await consoleIdentityExists(CONSOLE_LOCAL_ENDPOINT_REF, stateFilesIndex);
-    if (hasIdentity !== true) {
-      return { stage: "persona", setup };
+  let targetEndpointRef = endpointRef;
+  if (targetEndpointRef) {
+    const endpoint = setup.endpoints.find((item) => item.endpoint_ref === targetEndpointRef);
+    if (!endpoint || endpoint.connected !== true || endpoint.can_submit !== true) {
+      return { stage: "llm", setup };
     }
-    const hasSoul = await consoleSoulExists(CONSOLE_LOCAL_ENDPOINT_REF, stateFilesIndex);
-    if (hasSoul !== true) {
-      return { stage: "soul", setup };
+  } else {
+    if (setup.requiresSetup) {
+      return { stage: "llm", setup };
     }
-    await ensureConsoleDeferredSetupFiles(CONSOLE_LOCAL_ENDPOINT_REF, stateFilesIndex);
+    const local = setup.consoleLocalEndpoint;
+    if (local?.connected !== true || local?.can_submit !== true) {
+      return { stage: "ready", setup };
+    }
+    targetEndpointRef = local.endpoint_ref;
   }
+  const stateFilesIndex = await consoleStateFilesIndex(targetEndpointRef);
+  const hasIdentity = await consoleIdentityExists(targetEndpointRef, stateFilesIndex);
+  if (hasIdentity !== true) {
+    return { stage: "persona", setup };
+  }
+  const hasSoul = await consoleSoulExists(targetEndpointRef, stateFilesIndex);
+  if (hasSoul !== true) {
+    return { stage: "soul", setup };
+  }
+  await ensureConsoleDeferredSetupFiles(targetEndpointRef, stateFilesIndex);
   return { stage: "ready", setup };
 }
 
 async function resolveConsoleSetupStage(items, options = {}) {
-  const cacheKey = resourceKey("setup", "stage", setupReadinessSignature(items));
+  const endpointRef = String(options.endpointRef || "").trim();
+  const cacheKey = resourceKey(
+    "setup",
+    "stage",
+    endpointRef,
+    setupReadinessSignature(items),
+  );
   const forceFresh = options.force === true || setupStageSessionPrimed !== true;
   return loadResource(
     cacheKey,
@@ -368,7 +386,7 @@ async function resolveConsoleSetupStage(items, options = {}) {
           return cached;
         }
       }
-      const value = await resolveConsoleSetupStageUncached(items);
+      const value = await resolveConsoleSetupStageUncached(items, endpointRef);
       setupStageSessionPrimed = true;
       writeSetupStageSession(cacheKey, value);
       return value;

--- a/web/console/src/layouts/AppLayout.js
+++ b/web/console/src/layouts/AppLayout.js
@@ -22,7 +22,7 @@ const AppLayout = {
   template: `
     <div>
       <section v-if="inShellless">
-        <RouterView />
+        <RouterView :key="endpointViewKey" />
       </section>
       <section v-else class="app-shell">
         <div :class="mobileMode || inStandalone ? 'workspace is-mobile' : 'workspace'">
@@ -47,7 +47,7 @@ const AppLayout = {
               },
             ]"
           >
-            <RouterView />
+            <RouterView :key="endpointViewKey" />
           </main>
         </div>
         <AppMobileNavDrawer

--- a/web/console/src/router/index.js
+++ b/web/console/src/router/index.js
@@ -11,13 +11,23 @@ import {
 } from "../core/context";
 import {
   blockingSetupIntegrityItems,
-  consoleSetupTargetEndpointRef,
   fetchConsoleSetupIntegrity,
   isAllowedRepairSetupRoute,
   resolveConsoleSetupStage,
   setupStagePath,
 } from "../core/setup";
-import { rootEntryEndpoint } from "../core/endpoints";
+import {
+  CONSOLE_LOCAL_ENDPOINT_REF,
+  isEndpointSelectable,
+  rootEntryEndpoint,
+} from "../core/endpoints";
+import {
+  ENDPOINT_ROUTE_PREFIX,
+  endpointPagePath,
+  endpointRefFromRouteParam,
+  endpointRoutePath,
+  endpointRouteRef,
+} from "../core/endpoint-routes";
 import { markRouteInteractive, markRouteStart } from "../core/performance";
 import { routeExtensions } from "../core/route-extensions";
 import "../views/common.css";
@@ -61,14 +71,10 @@ const RootRedirectView = {
   template: `<div aria-hidden="true"></div>`,
 };
 
-function isSetupPath(path) {
-  const value = String(path || "").trim();
-  return value === "/setup" || value.startsWith("/setup/");
-}
+const ENDPOINT_SCOPE_PATH = `${ENDPOINT_ROUTE_PREFIX}/:endpoint_ref`;
 
-function isChatPath(path) {
-  const value = String(path || "").trim();
-  return value === "/chat" || value.startsWith("/chat/");
+function pagePath(path) {
+  return endpointPagePath(path) || String(path || "").trim();
 }
 
 function isDesktopWindowPath(path) {
@@ -77,7 +83,7 @@ function isDesktopWindowPath(path) {
 }
 
 function preloadKeyForPath(path) {
-  const value = String(path || "").trim();
+  const value = pagePath(path);
   if (value === "/chat/desk") {
     return "agentDesk";
   }
@@ -156,40 +162,95 @@ const SETUP_FREE_PATHS = new Set([
   ...extensionSetupFreePaths,
 ]);
 
-function selectedEndpointCanChat() {
-  const selectedRef = typeof endpointState.selectedRef === "string" ? endpointState.selectedRef.trim() : "";
-  if (!selectedRef) {
-    return false;
-  }
-  return endpointState.items.some(
-    (item) => item && item.endpoint_ref === selectedRef && item.connected === true && item.can_submit === true
-  );
+function legacyEndpointRedirect(pattern) {
+  return (to) => {
+    const targetPagePath = pattern.replace(/:([A-Za-z_][A-Za-z0-9_]*)/g, (_match, name) =>
+      encodeURIComponent(String(to.params?.[name] || "")),
+    );
+    return {
+      path: endpointRoutePath(CONSOLE_LOCAL_ENDPOINT_REF, targetPagePath),
+      query: to.query,
+      hash: to.hash,
+    };
+  };
 }
 
 const routes = [
   { path: "/login", component: LoginView, meta: { public: true, shellless: true } },
   { path: "/__boot-preview", component: BootPreviewView, meta: { public: true, shellless: true } },
-  { path: "/setup", component: SetupView },
-  { path: "/setup/llm", component: SetupView, meta: { setupStage: "llm" } },
-  { path: "/setup/persona", component: SetupView, meta: { setupStage: "persona" } },
-  { path: "/setup/soul", component: SetupView, meta: { setupStage: "soul" } },
-  { path: "/setup/done", component: SetupView, meta: { setupStage: "done" } },
-  { path: "/setup/repair", component: RepairView },
   { path: "/overview", component: OverviewView },
-  { path: "/chat", component: ChatView },
   { path: "/chat/desk", component: AgentDeskView },
-  { path: "/chat/:topic_id", component: ChatView },
-  { path: "/runtime", redirect: "/settings/runtime" },
-  { path: "/dashboard", redirect: "/settings/runtime" },
-  { path: "/stats", component: StatsView },
-  { path: "/audit", component: AuditView },
-  { path: "/logs", component: LogsView },
-  { path: "/memory", component: MemoryView },
-  { path: "/todo", component: TodoView },
-  { path: "/files", redirect: "/todo" },
-  { path: "/contacts", component: ContactsView },
-  { path: "/settings/:section", component: SettingsView },
-  { path: "/settings", component: SettingsView },
+  { path: `${ENDPOINT_SCOPE_PATH}/setup`, component: SetupView, meta: { endpointScoped: true } },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/setup/llm`,
+    component: SetupView,
+    meta: { endpointScoped: true, setupStage: "llm" },
+  },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/setup/persona`,
+    component: SetupView,
+    meta: { endpointScoped: true, setupStage: "persona" },
+  },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/setup/soul`,
+    component: SetupView,
+    meta: { endpointScoped: true, setupStage: "soul" },
+  },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/setup/done`,
+    component: SetupView,
+    meta: { endpointScoped: true, setupStage: "done" },
+  },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/setup/repair`,
+    component: RepairView,
+    meta: { endpointScoped: true },
+  },
+  { path: `${ENDPOINT_SCOPE_PATH}/chat`, component: ChatView, meta: { endpointScoped: true } },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/chat/:topic_id`,
+    component: ChatView,
+    meta: { endpointScoped: true },
+  },
+  { path: `${ENDPOINT_SCOPE_PATH}/stats`, component: StatsView, meta: { endpointScoped: true } },
+  { path: `${ENDPOINT_SCOPE_PATH}/audit`, component: AuditView, meta: { endpointScoped: true } },
+  { path: `${ENDPOINT_SCOPE_PATH}/logs`, component: LogsView, meta: { endpointScoped: true } },
+  { path: `${ENDPOINT_SCOPE_PATH}/memory`, component: MemoryView, meta: { endpointScoped: true } },
+  { path: `${ENDPOINT_SCOPE_PATH}/todo`, component: TodoView, meta: { endpointScoped: true } },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/contacts`,
+    component: ContactsView,
+    meta: { endpointScoped: true },
+  },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/settings/:section`,
+    component: SettingsView,
+    meta: { endpointScoped: true },
+  },
+  {
+    path: `${ENDPOINT_SCOPE_PATH}/settings`,
+    component: SettingsView,
+    meta: { endpointScoped: true },
+  },
+  { path: "/setup", redirect: legacyEndpointRedirect("/setup") },
+  { path: "/setup/llm", redirect: legacyEndpointRedirect("/setup/llm") },
+  { path: "/setup/persona", redirect: legacyEndpointRedirect("/setup/persona") },
+  { path: "/setup/soul", redirect: legacyEndpointRedirect("/setup/soul") },
+  { path: "/setup/done", redirect: legacyEndpointRedirect("/setup/done") },
+  { path: "/setup/repair", redirect: legacyEndpointRedirect("/setup/repair") },
+  { path: "/chat", redirect: legacyEndpointRedirect("/chat") },
+  { path: "/chat/:topic_id", redirect: legacyEndpointRedirect("/chat/:topic_id") },
+  { path: "/runtime", redirect: legacyEndpointRedirect("/settings/runtime") },
+  { path: "/dashboard", redirect: legacyEndpointRedirect("/settings/runtime") },
+  { path: "/stats", redirect: legacyEndpointRedirect("/stats") },
+  { path: "/audit", redirect: legacyEndpointRedirect("/audit") },
+  { path: "/logs", redirect: legacyEndpointRedirect("/logs") },
+  { path: "/memory", redirect: legacyEndpointRedirect("/memory") },
+  { path: "/todo", redirect: legacyEndpointRedirect("/todo") },
+  { path: "/files", redirect: legacyEndpointRedirect("/todo") },
+  { path: "/contacts", redirect: legacyEndpointRedirect("/contacts") },
+  { path: "/settings/:section", redirect: legacyEndpointRedirect("/settings/:section") },
+  { path: "/settings", redirect: legacyEndpointRedirect("/settings") },
   { path: "/window/:window_id?", component: DesktopWindowView, meta: { shellless: true } },
   ...extensionRoutes,
   { path: "/", component: RootRedirectView, meta: { shellless: true } },
@@ -216,6 +277,24 @@ router.beforeEach(async (to) => {
   markRouteStart(to);
   if (to.meta && to.meta.public === true) {
     return true;
+  }
+  const toPagePath = pagePath(to.path);
+  const requestedEndpointRef = to.meta?.endpointScoped
+    ? endpointRefFromRouteParam(to.params.endpoint_ref)
+    : "";
+  if (to.meta?.endpointScoped) {
+    if (!requestedEndpointRef) {
+      return { path: "/overview" };
+    }
+    const canonicalRouteRef = endpointRouteRef(requestedEndpointRef);
+    const currentRouteRef = String(to.params.endpoint_ref || "").trim();
+    if (currentRouteRef !== canonicalRouteRef) {
+      return {
+        path: endpointRoutePath(requestedEndpointRef, toPagePath),
+        query: to.query,
+        hash: to.hash,
+      };
+    }
   }
   if (!authValid.value) {
     try {
@@ -251,40 +330,35 @@ router.beforeEach(async (to) => {
   try {
     const integrityItems = blockingSetupIntegrityItems(await fetchConsoleSetupIntegrity().catch(() => []));
     if (integrityItems.length > 0) {
-      if (to.path === "/setup/repair" || isAllowedRepairSetupRoute(to, integrityItems)) {
+      if (toPagePath === "/setup/repair" || isAllowedRepairSetupRoute(to, integrityItems)) {
         return true;
       }
-      return { path: "/setup/repair", query: { redirect: to.fullPath } };
-    }
-    if (to.path === "/setup/repair") {
-      return { path: "/setup", query: to.query };
+      return { path: setupStagePath("repair"), query: { redirect: to.fullPath } };
     }
     await ensureEndpointsLoaded();
   } catch {
     endpointState.items = [];
   }
+  if (requestedEndpointRef) {
+    const endpoint = endpointState.items.find(
+      (item) => item?.endpoint_ref === requestedEndpointRef,
+    );
+    if (!isEndpointSelectable(endpoint)) {
+      return { path: "/overview" };
+    }
+    endpointState.setSelectedEndpointRef(requestedEndpointRef);
+  }
   const setupState = await resolveConsoleSetupStage(endpointState.items);
   if (setupState.stage !== "ready") {
-    if (SETUP_FREE_PATHS.has(to.path) || isDesktopWindowPath(to.path)) {
+    if (SETUP_FREE_PATHS.has(toPagePath) || isDesktopWindowPath(to.path)) {
       return true;
     }
     return { path: setupStagePath(setupState.stage), query: { redirect: to.fullPath } };
   }
-  if (to.path === "/setup") {
-    return { path: "/setup/done", query: to.query };
-  }
-  if (isSetupPath(to.path)) {
-    const targetRef = consoleSetupTargetEndpointRef(setupState.setup);
-    if (targetRef && !selectedEndpointCanChat()) {
-      endpointState.setSelectedEndpointRef(targetRef);
-    }
-    return true;
-  }
   if (to.path === "/") {
     const endpoint = rootEntryEndpoint(endpointState.items);
     if (endpoint?.endpoint_ref) {
-      endpointState.setSelectedEndpointRef(endpoint.endpoint_ref);
-      return { path: "/chat", query: to.query };
+      return { path: endpointRoutePath(endpoint.endpoint_ref, "/chat"), query: to.query };
     }
     return { path: "/overview", query: to.query };
   }

--- a/web/console/src/stores/endpointStore.js
+++ b/web/console/src/stores/endpointStore.js
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 
-import { visibleEndpoints } from "../core/endpoints";
+import { isEndpointSelectable, visibleEndpoints } from "../core/endpoints";
 import { pinia } from "./pinia";
 
 const ENDPOINT_STORAGE_KEY = "mistermorph_console_endpoint_ref_v1";
@@ -29,10 +29,12 @@ const useEndpointStore = defineStore("endpoint", {
         return;
       }
 
-      const canSelect = visibleEndpoints(items, { connectedOnly: true }).some(
-        (item) => item.endpoint_ref === next && isConnectedEndpoint(item)
+      const endpointItems = visibleEndpoints(items);
+      const canSelect = endpointItems.some(
+        (item) => item.endpoint_ref === next && isEndpointSelectable(item)
       );
-      this.selectedRef = canSelect ? next : firstConnectedEndpointRef(items);
+      const fallback = endpointItems.find(isEndpointSelectable);
+      this.selectedRef = canSelect ? next : fallback?.endpoint_ref || "";
       this.saveSelectedEndpointRef();
     },
     hydrateEndpointSelection() {
@@ -41,32 +43,20 @@ const useEndpointStore = defineStore("endpoint", {
     },
     ensureEndpointSelection() {
       const items = Array.isArray(this.items) ? this.items : [];
-      const connectedItems = visibleEndpoints(items, { connectedOnly: true }).filter((item) =>
-        isConnectedEndpoint(item)
-      );
-      if (connectedItems.length === 0) {
+      const endpointItems = visibleEndpoints(items);
+      const current = this.selectedRef.trim();
+      if (current && endpointItems.some((item) => item.endpoint_ref === current)) {
+        return;
+      }
+      const selectableItems = endpointItems.filter(isEndpointSelectable);
+      if (selectableItems.length === 0) {
         this.setSelectedEndpointRef("");
         return;
       }
-      const current = this.selectedRef.trim();
-      if (current && connectedItems.find((item) => item.endpoint_ref === current)) {
-        return;
-      }
-      this.setSelectedEndpointRef(connectedItems[0].endpoint_ref);
+      this.setSelectedEndpointRef(selectableItems[0].endpoint_ref);
     },
   },
 });
-
-function isConnectedEndpoint(item) {
-  return Boolean(item && item.endpoint_ref && item.connected);
-}
-
-function firstConnectedEndpointRef(items) {
-  const connected = visibleEndpoints(items, { connectedOnly: true }).find((item) =>
-    isConnectedEndpoint(item)
-  );
-  return connected ? connected.endpoint_ref : "";
-}
 
 const endpointState = useEndpointStore(pinia);
 

--- a/web/console/src/views/AgentDeskView.js
+++ b/web/console/src/views/AgentDeskView.js
@@ -17,6 +17,7 @@ import { resolveDeskShortcut } from "../core/agent-desk-shortcuts";
 import { createEmptyDeskTab, normalizeDeskTabs } from "../core/agent-desk-tabs";
 import { rememberLastTopicID } from "../core/chat-topic-memory";
 import { endpointDisplayItem, visibleEndpoints } from "../core/endpoints";
+import { endpointRoutePath } from "../core/endpoint-routes";
 import { endpointState, ensureEndpointsLoaded, translate } from "../core/context";
 import "./AgentDeskView.css";
 
@@ -538,12 +539,12 @@ const AgentDeskView = {
       if (!endpoint) {
         return;
       }
-      endpointState.setSelectedEndpointRef(endpointRef);
       const submitRef = endpointSubmitRef(endpoint);
       if (submitRef && topicID) {
         rememberLastTopicID(submitRef, topicID);
       }
-      router.push(topicID ? `/chat/${encodeURIComponent(topicID)}` : "/chat");
+      const chatPagePath = topicID ? `/chat/${encodeURIComponent(topicID)}` : "/chat";
+      router.push(endpointRoutePath(endpointRef, chatPagePath));
     }
 
     function exitDesk() {
@@ -552,7 +553,8 @@ const AgentDeskView = {
         openFullChat({ paneID: pane.id, topicID: pane.topicID });
         return;
       }
-      router.push("/chat");
+      const path = endpointRoutePath(endpointState.selectedRef, "/chat");
+      router.push(path || "/overview");
     }
 
     function setKeyboardPrefix(active) {

--- a/web/console/src/views/AuditView.js
+++ b/web/console/src/views/AuditView.js
@@ -6,6 +6,7 @@ import AppPage from "../components/AppPage";
 import RawJsonDialog from "../components/RawJsonDialog";
 import { openRawJsonDesktopWindow } from "../core/desktop-windows";
 import { endpointChannelLabel } from "../core/endpoints";
+import { endpointRoutePath } from "../core/endpoint-routes";
 import { loadResource, resourceKey, useResource } from "../core/resources";
 import {
   TASK_STATUS_META,
@@ -701,7 +702,7 @@ const AuditView = {
     }
 
     function goChat() {
-      router.push("/chat");
+      router.push(endpointRoutePath(endpointState.selectedRef, "/chat"));
     }
 
     async function loadFiles(endpointRef = currentEndpointRef(), token = null) {

--- a/web/console/src/views/ChatView.js
+++ b/web/console/src/views/ChatView.js
@@ -42,6 +42,7 @@ import {
 } from "../core/chat-task-history";
 import { openRawJsonDesktopWindow } from "../core/desktop-windows";
 import { endpointChannelLabel } from "../core/endpoints";
+import { endpointRoutePath } from "../core/endpoint-routes";
 import { modelVendorMeta } from "../core/model-vendor";
 import { loadResource, resourceKey } from "../core/resources";
 import { workspaceTreeIcon } from "../core/workspace-icons";
@@ -2342,7 +2343,8 @@ const ChatView = {
 
     function chatRoutePath(topicID = "") {
       const normalized = normalizeTopicID(topicID);
-      return normalized ? `/chat/${encodeURIComponent(normalized)}` : "/chat";
+      const chatPagePath = normalized ? `/chat/${encodeURIComponent(normalized)}` : "/chat";
+      return endpointRoutePath(endpointState.selectedRef, chatPagePath);
     }
 
     function syncChatRoute(topicID, options = {}) {

--- a/web/console/src/views/LoginView.js
+++ b/web/console/src/views/LoginView.js
@@ -12,6 +12,7 @@ import {
   localeState,
   translate,
 } from "../core/context";
+import { endpointRoutePath } from "../core/endpoint-routes";
 import { consoleSetupTargetEndpointRef, resolveConsoleSetupStage, setupStagePath } from "../core/setup";
 
 const LoginView = {
@@ -38,15 +39,12 @@ const LoginView = {
         return;
       }
       const targetRef = consoleSetupTargetEndpointRef(setupState.setup);
-      if (targetRef) {
-        endpointState.setSelectedEndpointRef(targetRef);
-      }
       if (redirect && redirect !== "/overview" && redirect !== "/") {
         router.replace(redirect);
         return;
       }
       if (targetRef) {
-        router.replace("/chat");
+        router.replace(endpointRoutePath(targetRef, "/chat"));
         return;
       }
       router.replace("/overview");

--- a/web/console/src/views/OverviewView.js
+++ b/web/console/src/views/OverviewView.js
@@ -6,6 +6,7 @@ import logoMarkup from "../assets/images/app_logo_current.svg?raw";
 import AppKicker from "../components/AppKicker";
 import AppPage from "../components/AppPage";
 import { endpointDisplayItem, visibleEndpoints } from "../core/endpoints";
+import { endpointRoutePath } from "../core/endpoint-routes";
 import { endpointState, ensureEndpointsLoaded, loadEndpoints, toBool, translate } from "../core/context";
 
 function endpointSortKey(item) {
@@ -76,8 +77,7 @@ const OverviewView = {
       ) {
         return;
       }
-      endpointState.setSelectedEndpointRef(item.endpoint_ref);
-      router.push("/chat");
+      router.push(endpointRoutePath(item.endpoint_ref, "/chat"));
     }
 
     function channelBadgeType(badge) {

--- a/web/console/src/views/RepairView.js
+++ b/web/console/src/views/RepairView.js
@@ -1,10 +1,14 @@
 import { computed, onMounted, ref } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useToast } from "quail-ui";
 import "./RepairView.css";
 
 import RawTextEditorDialog from "../components/RawTextEditorDialog";
-import { apiFetch, translate } from "../core/context";
+import { endpointApiFetch, translate } from "../core/context";
+import {
+  endpointRefFromRouteParam,
+  endpointRoutePath,
+} from "../core/endpoint-routes";
 import {
   fetchConsoleSetupIntegrity,
   invalidateConsoleSetupReadiness,
@@ -18,7 +22,11 @@ const RepairView = {
   setup() {
     const t = translate;
     const toast = useToast();
+    const route = useRoute();
     const router = useRouter();
+    const setupEndpointRef = computed(() =>
+      endpointRefFromRouteParam(route.params.endpoint_ref),
+    );
     const loading = ref(false);
     const saving = ref(false);
     const err = ref("");
@@ -36,10 +44,13 @@ const RepairView = {
       loading.value = true;
       err.value = "";
       try {
-        const nextItems = await fetchConsoleSetupIntegrity({ force: true });
+        const nextItems = await fetchConsoleSetupIntegrity({
+          force: true,
+          endpointRef: setupEndpointRef.value,
+        });
         items.value = nextItems;
         if (nextItems.length === 0) {
-          await router.replace("/setup");
+          await router.replace(endpointRoutePath(setupEndpointRef.value, "/setup"));
         }
       } catch (e) {
         err.value = e.message || t("msg_load_failed");
@@ -56,7 +67,10 @@ const RepairView = {
       loading.value = true;
       err.value = "";
       try {
-        const payload = await apiFetch(`/setup/file?key=${encodeURIComponent(key)}`);
+        const payload = await endpointApiFetch(
+          setupEndpointRef.value,
+          `/setup/file?key=${encodeURIComponent(key)}`,
+        );
         editorItem.value = {
           key,
           name: typeof payload?.name === "string" ? payload.name : item.name,
@@ -79,7 +93,7 @@ const RepairView = {
       saving.value = true;
       err.value = "";
       try {
-        await apiFetch(`/setup/file?key=${encodeURIComponent(key)}`, {
+        await endpointApiFetch(setupEndpointRef.value, `/setup/file?key=${encodeURIComponent(key)}`, {
           method: "PUT",
           body: {
             content: editorValue.value,
@@ -103,7 +117,7 @@ const RepairView = {
     }
 
     function goToSetup(item) {
-      const stage = setupStagePath(item?.stage);
+      const stage = setupStagePath(item?.stage, setupEndpointRef.value);
       const key = String(item?.key || "").trim();
       if (!stage || !key) {
         return;

--- a/web/console/src/views/SettingsView.js
+++ b/web/console/src/views/SettingsView.js
@@ -18,6 +18,7 @@ import defaultAvatarMarkup from "../assets/images/app_logo_current.svg?raw";
 import {
   apiFetch,
   authState,
+  endpointApiFetch,
   endpointState,
   formatTime,
   loadEndpoints,
@@ -60,6 +61,7 @@ import {
   setupOpenAICodexUsesAPIKey,
 } from "../core/setup-contract";
 import { invalidateConsoleSetupReadiness } from "../core/setup";
+import { endpointRoutePath } from "../core/endpoint-routes";
 import { openReentrantDialog } from "../core/reentrant-dialog";
 import {
   buildEmptyPersonaIdentityState,
@@ -125,9 +127,11 @@ function normalizeSettingsSectionID(value) {
   return SETTINGS_SECTION_IDS.has(id) ? id : SETTINGS_DEFAULT_SECTION_ID;
 }
 
-function settingsSectionPath(id) {
+function settingsSectionPath(endpointRef, id) {
   const sectionID = normalizeSettingsSectionID(id);
-  return sectionID === SETTINGS_DEFAULT_SECTION_ID ? "/settings" : `/settings/${sectionID}`;
+  const pagePath =
+    sectionID === SETTINGS_DEFAULT_SECTION_ID ? "/settings" : `/settings/${sectionID}`;
+  return endpointRoutePath(endpointRef, pagePath);
 }
 
 function buildEmptyLLMForm() {
@@ -915,9 +919,7 @@ const SettingsView = {
       resetProAuthEndpointState,
     } = useProAuthFlow({
       getEndpointRef: () => settingsEndpointRef.value,
-      request(path, options, endpointRef) {
-        return endpointApiFetch(endpointRef, path, options);
-      },
+      request: endpointApiFetch,
       async onSettingsUpdated(_payload, endpointRef) {
         await loadAgentSettings(endpointRef);
       },
@@ -946,9 +948,7 @@ const SettingsView = {
       resetXAIAuthEndpointState,
     } = useXAIAuthFlow({
       getEndpointRef: () => settingsEndpointRef.value,
-      request(path, options, endpointRef) {
-        return endpointApiFetch(endpointRef, path, options);
-      },
+      request: endpointApiFetch,
       async onSettingsUpdated(_payload, endpointRef) {
         await loadAgentSettings(endpointRef);
       },
@@ -1427,14 +1427,6 @@ const SettingsView = {
       agentValidationVisible.value = false;
       skillsValidationVisible.value = false;
       clearLoadedAgentSnapshots();
-    }
-
-    function endpointApiFetch(endpointRef, pathname, options = {}) {
-      const ref = trimText(endpointRef) || LOCAL_CONSOLE_ENDPOINT_REF;
-      if (ref === LOCAL_CONSOLE_ENDPOINT_REF) {
-        return apiFetch(pathname, options);
-      }
-      return runtimeApiFetchForEndpoint(ref, pathname, options);
     }
 
     function agentSettingsErrorMessage(err, endpointRef, fallbackKey) {
@@ -3498,7 +3490,7 @@ const SettingsView = {
     }
 
     function openLogsPage() {
-      router.push("/logs");
+      router.push(endpointRoutePath(endpointState.selectedRef, "/logs"));
     }
 
     function selectSection(id) {
@@ -3507,7 +3499,7 @@ const SettingsView = {
       if (isMobile.value) {
         mobilePanelVisible.value = true;
       }
-      const nextPath = settingsSectionPath(sectionID);
+      const nextPath = settingsSectionPath(endpointState.selectedRef, sectionID);
       if (route.path !== nextPath) {
         router.push(nextPath);
       }
@@ -3614,7 +3606,7 @@ const SettingsView = {
         selectedSectionID.value = sectionID;
         ensureSettingsSectionData(sectionID);
         if (routeSection && routeSection !== sectionID) {
-          router.replace(settingsSectionPath(sectionID));
+          router.replace(settingsSectionPath(endpointState.selectedRef, sectionID));
         }
         if (isMobile.value && routeSection) {
           mobilePanelVisible.value = true;
@@ -3629,7 +3621,7 @@ const SettingsView = {
         if (!items.some((item) => item.id === selectedSectionID.value)) {
           const sectionID = items[0]?.id || SETTINGS_DEFAULT_SECTION_ID;
           selectedSectionID.value = sectionID;
-          const nextPath = settingsSectionPath(sectionID);
+          const nextPath = settingsSectionPath(endpointState.selectedRef, sectionID);
           if (route.path !== nextPath) {
             router.replace(nextPath);
           }

--- a/web/console/src/views/SetupView.js
+++ b/web/console/src/views/SetupView.js
@@ -13,7 +13,7 @@ import SetupConnectionTestDialog from "../components/SetupConnectionTestDialog";
 import SetupPickerDialog from "../components/SetupPickerDialog";
 import defaultAvatarMarkup from "../assets/images/app_logo_current.svg?raw";
 import {
-  apiFetch,
+  endpointApiFetch,
   formatTime,
   loadEndpoints,
   runtimeApiDownloadForEndpoint,
@@ -37,9 +37,12 @@ import {
   llmFieldManagedHeadline as managedLLMFieldHeadline,
   llmFieldValue as managedLLMFieldValue,
 } from "../core/llm-env-managed";
-import { CONSOLE_LOCAL_ENDPOINT_REF } from "../core/endpoints";
 import {
-  consoleSetupTargetEndpointRef,
+  endpointPagePath,
+  endpointRefFromRouteParam,
+  endpointRoutePath,
+} from "../core/endpoint-routes";
+import {
   invalidateConsoleSetupReadiness,
   resolveConsoleSetupStage,
   setupStagePath,
@@ -89,13 +92,6 @@ const NEXT_STAGE = {
   persona: "soul",
   soul: "done",
 };
-const SETUP_STAGE_ORDER = {
-  llm: 1,
-  persona: 2,
-  soul: 3,
-  done: 4,
-};
-
 const STAGE_META = {
   llm: {
     index: 1,
@@ -218,10 +214,6 @@ function normalizeStage(value) {
   return "llm";
 }
 
-function setupStageIndex(stage) {
-  return SETUP_STAGE_ORDER[normalizeStage(stage)] || SETUP_STAGE_ORDER.llm;
-}
-
 function resolveDoneGreetingKey(date = new Date()) {
   const hour = date.getHours();
   if (hour >= 5 && hour < 10) {
@@ -252,6 +244,9 @@ const SetupView = {
     const toast = useToast();
     const route = useRoute();
     const router = useRouter();
+    const setupEndpointRef = computed(() =>
+      endpointRefFromRouteParam(route.params.endpoint_ref),
+    );
 
     const loading = ref(false);
     const saving = ref(false);
@@ -340,6 +335,8 @@ const SetupView = {
       logoutProAuth,
       resetProAuthFlow,
     } = useProAuthFlow({
+      getEndpointRef: () => setupEndpointRef.value,
+      request: endpointApiFetch,
       async onSettingsUpdated() {
         await loadLLMForm();
       },
@@ -367,6 +364,8 @@ const SetupView = {
       logoutXAIAuth,
       resetXAIAuthFlow,
     } = useXAIAuthFlow({
+      getEndpointRef: () => setupEndpointRef.value,
+      request: endpointApiFetch,
       async onSettingsUpdated() {
         await loadLLMForm();
       },
@@ -702,12 +701,7 @@ const SetupView = {
     const soulUsesCustomContent = computed(() => soulDocumentExists.value);
 
     async function enterChat() {
-      const setupState = await resolveConsoleSetupStage(endpointState.items);
-      const targetRef = consoleSetupTargetEndpointRef(setupState.setup) || CONSOLE_LOCAL_ENDPOINT_REF;
-      if (targetRef) {
-        endpointState.setSelectedEndpointRef(targetRef);
-      }
-      await router.replace("/chat");
+      await router.replace(endpointRoutePath(setupEndpointRef.value, "/chat"));
     }
 
     function applyPersonaContent(raw) {
@@ -739,7 +733,7 @@ const SetupView = {
 
     async function loadSetupTextFile(endpoint) {
       try {
-        const payload = await runtimeApiFetchForEndpoint(CONSOLE_LOCAL_ENDPOINT_REF, endpoint);
+        const payload = await runtimeApiFetchForEndpoint(setupEndpointRef.value, endpoint);
         return String(payload?.content || "");
       } catch (e) {
         if (e?.status === 404) {
@@ -751,7 +745,10 @@ const SetupView = {
 
     async function loadPersonaAvatar() {
       try {
-        const blob = await runtimeApiDownloadForEndpoint(CONSOLE_LOCAL_ENDPOINT_REF, PERSONA_AVATAR_ENDPOINT);
+        const blob = await runtimeApiDownloadForEndpoint(
+          setupEndpointRef.value,
+          PERSONA_AVATAR_ENDPOINT,
+        );
         setPersonaAvatarObjectURL(URL.createObjectURL(blob));
       } catch (e) {
         if (e?.status === 404) {
@@ -829,7 +826,7 @@ const SetupView = {
       loading.value = true;
       err.value = "";
       try {
-        const payload = await apiFetch("/settings/agent");
+        const payload = await endpointApiFetch(setupEndpointRef.value, "/settings/agent");
         applyLLMPayload(payload);
       } catch (e) {
         err.value = e.message || t("msg_load_failed");
@@ -854,7 +851,7 @@ const SetupView = {
       codexAuthLoading.value = true;
       codexAuthError.value = "";
       try {
-        let payload = await apiFetch("/auth/codex/status");
+        let payload = await endpointApiFetch(setupEndpointRef.value, "/auth/codex/status");
         applyCodexAuthStatus(payload);
         const status = payload && typeof payload.status === "object" ? payload.status : payload;
         if (
@@ -862,7 +859,9 @@ const SetupView = {
           status?.refresh_token_present === true &&
           (status?.access_token_present !== true || status?.access_token_expired === true)
         ) {
-          payload = await apiFetch("/auth/codex/refresh", { method: "POST" });
+          payload = await endpointApiFetch(setupEndpointRef.value, "/auth/codex/refresh", {
+            method: "POST",
+          });
           applyCodexAuthStatus(payload);
         }
       } catch (e) {
@@ -924,7 +923,11 @@ const SetupView = {
       resetCodexLoginSession();
       let authWindowUsed = false;
       try {
-        const payload = await apiFetch("/auth/codex/login/start", { method: "POST" });
+        const payload = await endpointApiFetch(
+          setupEndpointRef.value,
+          "/auth/codex/login/start",
+          { method: "POST" },
+        );
         codexLoginSession.value = String(payload?.session_id || "").trim();
         codexLoginVerificationURL.value = String(payload?.verification_url || "").trim();
         codexLoginUserCode.value = String(payload?.user_code || "").trim();
@@ -956,7 +959,7 @@ const SetupView = {
       codexAuthBusy.value = true;
       codexAuthError.value = "";
       try {
-        const payload = await apiFetch("/auth/codex/login/poll", {
+        const payload = await endpointApiFetch(setupEndpointRef.value, "/auth/codex/login/poll", {
           method: "POST",
           body: { session_id: sessionID, set_default: false },
         });
@@ -984,7 +987,9 @@ const SetupView = {
       codexAuthBusy.value = true;
       codexAuthError.value = "";
       try {
-        const payload = await apiFetch("/auth/codex/logout", { method: "POST" });
+        const payload = await endpointApiFetch(setupEndpointRef.value, "/auth/codex/logout", {
+          method: "POST",
+        });
         applyCodexAuthStatus(payload);
         resetCodexLoginSession();
       } catch (e) {
@@ -1049,61 +1054,61 @@ const SetupView = {
     }
 
     async function syncRoute(options = {}) {
+      const currentPagePath = endpointPagePath(route.path);
       if (inRepairMode.value) {
         if (options.loadStage !== false) {
           await loadStageForm(routeStage.value);
         }
-        return false;
+        return;
       }
       if (options.refreshEndpoints !== false) {
         await loadEndpoints();
       }
-      const setupState = await resolveConsoleSetupStage(endpointState.items);
-      if (route.path === "/setup") {
-        const target =
-          setupState.stage === "ready"
-            ? options.onReady === "done"
-              ? "/setup/done"
-              : "/setup/done"
-            : setupStagePath(setupState.stage);
+      if (currentPagePath === "/setup") {
+        const setupState = await resolveConsoleSetupStage(endpointState.items, {
+          endpointRef: setupEndpointRef.value,
+        });
+        const target = setupStagePath(
+          setupState.stage === "ready" ? "done" : setupState.stage,
+          setupEndpointRef.value,
+        );
         await router.replace({ path: target, query: route.query });
-        return false;
+        return;
       }
-      if (setupState.stage !== "ready") {
-        const targetPath = setupStagePath(setupState.stage);
-        const canStayOnCurrentSetupPath =
-          options.allowPrevious === true &&
-          route.path !== "/setup" &&
-          route.path.startsWith("/setup/") &&
-          setupStageIndex(routeStage.value) <= setupStageIndex(setupState.stage);
-        if (!canStayOnCurrentSetupPath && route.path !== targetPath) {
-          await router.replace({ path: targetPath, query: route.query });
-          return false;
-        }
-      }
-      if (options.onReady === "done" && route.path !== "/setup/done") {
+      if (options.onReady === "done" && currentPagePath !== "/setup/done") {
+        const setupState = await resolveConsoleSetupStage(endpointState.items, {
+          endpointRef: setupEndpointRef.value,
+        });
         if (setupState.stage === "ready") {
-          await router.replace({ path: "/setup/done", query: route.query });
-          return false;
+          await router.replace({
+            path: setupStagePath("done", setupEndpointRef.value),
+            query: route.query,
+          });
+          return;
         }
       }
       if (options.loadStage !== false) {
         await loadStageForm(routeStage.value);
       }
-      return false;
     }
 
     async function finishStep() {
       if (inRepairMode.value) {
-        await router.replace({ path: "/setup", query: {} });
+        await router.replace({
+          path: endpointRoutePath(setupEndpointRef.value, "/setup"),
+          query: {},
+        });
         return;
       }
       const nextStage = NEXT_STAGE[routeStage.value];
       if (nextStage) {
-        await router.replace({ path: setupStagePath(nextStage), query: route.query });
+        await router.replace({
+          path: setupStagePath(nextStage, setupEndpointRef.value),
+          query: route.query,
+        });
         return;
       }
-      await syncRoute({ refreshEndpoints: true, loadStage: false, onReady: "done" });
+      await syncRoute({ loadStage: false, onReady: "done" });
     }
 
     async function saveLLM() {
@@ -1118,7 +1123,7 @@ const SetupView = {
           await finishStep();
           return;
         }
-        const payload = await apiFetch("/settings/agent", {
+        const payload = await endpointApiFetch(setupEndpointRef.value, "/settings/agent", {
           method: "PUT",
           body: {
             llm,
@@ -1319,7 +1324,7 @@ const SetupView = {
       try {
         const content = buildPersonaIdentityYAML(personaForm, loadedIdentityRaw.value);
         loadedIdentityRaw.value = content;
-        await runtimeApiFetchForEndpoint(CONSOLE_LOCAL_ENDPOINT_REF, PERSONA_IDENTITY_ENDPOINT, {
+        await runtimeApiFetchForEndpoint(setupEndpointRef.value, PERSONA_IDENTITY_ENDPOINT, {
           method: "PUT",
           body: {
             content,
@@ -1339,7 +1344,7 @@ const SetupView = {
       personaAvatarBusy.value = true;
       err.value = "";
       try {
-        await runtimeApiFetchForEndpoint(CONSOLE_LOCAL_ENDPOINT_REF, PERSONA_AVATAR_ENDPOINT, {
+        await runtimeApiFetchForEndpoint(setupEndpointRef.value, PERSONA_AVATAR_ENDPOINT, {
           method: "PUT",
           headers: { "Content-Type": "image/webp" },
           body: blob,
@@ -1357,7 +1362,7 @@ const SetupView = {
       personaAvatarBusy.value = true;
       err.value = "";
       try {
-        await runtimeApiFetchForEndpoint(CONSOLE_LOCAL_ENDPOINT_REF, PERSONA_AVATAR_ENDPOINT, {
+        await runtimeApiFetchForEndpoint(setupEndpointRef.value, PERSONA_AVATAR_ENDPOINT, {
           method: "DELETE",
         });
         setPersonaAvatarObjectURL("");
@@ -1396,7 +1401,7 @@ const SetupView = {
         soulPresetId.value = "";
         soulSelectionKind.value = hasSoulDocument(content) ? "custom" : "";
         soulEditMode.value = false;
-        await runtimeApiFetchForEndpoint(CONSOLE_LOCAL_ENDPOINT_REF, PERSONA_SOUL_ENDPOINT, {
+        await runtimeApiFetchForEndpoint(setupEndpointRef.value, PERSONA_SOUL_ENDPOINT, {
           method: "PUT",
           body: {
             content,
@@ -1466,14 +1471,23 @@ const SetupView = {
       const provider = providerChoice.value;
       const apiKeyRaw = llmFieldEnvRawValue("api_key");
       try {
-        const payload = await apiFetch("/settings/agent/models", {
-          method: "POST",
-          body: {
-            inference_provider: provider,
-            endpoint: setupProviderSupportsCustomAPIBase(provider) ? llmFieldValue("endpoint") : "",
-            api_key: provider === SETUP_PROVIDER_MISTERMORPH_PRO ? "" : apiKeyRaw || llmFieldValue("api_key"),
+        const payload = await endpointApiFetch(
+          setupEndpointRef.value,
+          "/settings/agent/models",
+          {
+            method: "POST",
+            body: {
+              inference_provider: provider,
+              endpoint: setupProviderSupportsCustomAPIBase(provider)
+                ? llmFieldValue("endpoint")
+                : "",
+              api_key:
+                provider === SETUP_PROVIDER_MISTERMORPH_PRO
+                  ? ""
+                  : apiKeyRaw || llmFieldValue("api_key"),
+            },
           },
-        });
+        );
         const items = Array.isArray(payload?.items) ? payload.items : [];
         modelPickerItems.value = items.map((value) => ({
           id: value,
@@ -1522,12 +1536,16 @@ const SetupView = {
       const shouldReloadCodexAuthStatus = showCodexOAuthFields.value && !codexUsesAPIKey.value;
       testConnectionLoading.value = true;
       try {
-        const payload = await apiFetch("/settings/agent/test", {
-          method: "POST",
-          body: {
-            llm: nextPayload,
+        const payload = await endpointApiFetch(
+          setupEndpointRef.value,
+          "/settings/agent/test",
+          {
+            method: "POST",
+            body: {
+              llm: nextPayload,
+            },
           },
-        });
+        );
         testConnectionMeta.provider = String(payload?.provider || "").trim();
         const resolvedAPIBase = String(payload?.api_base || "").trim();
         if (resolvedAPIBase !== "") {
@@ -1588,7 +1606,10 @@ const SetupView = {
     }
 
     function goToStage(stage) {
-      void router.push({ path: setupStagePath(stage), query: route.query });
+      void router.push({
+        path: setupStagePath(stage, setupEndpointRef.value),
+        query: route.query,
+      });
     }
 
     function goPrevious() {
@@ -1620,7 +1641,7 @@ const SetupView = {
     watch(
       () => route.fullPath,
       () => {
-        void syncRoute({ refreshEndpoints: true, loadStage: true, allowPrevious: true });
+        void syncRoute();
       },
       { immediate: true }
     );


### PR DESCRIPTION
## What changed

- add `Contact(kind: agent)` handling and register `agent_send` only when active Agent contacts exist
- reuse existing Channel routing for Agent handoff across Telegram and Slack
- add administrator-controlled, reciprocal Agent pairing with five-minute offers and paired private-message authorization
- preserve Agent sender identity, first-mention routing, history context, and self-message filtering
- limit each conversation to 8 Agent-triggered interactions in a rolling 10-minute window
- document configuration, pairing, delivery, failure handling, and first-version boundaries

## Why

Morph could manage several endpoints, but those Agents had no supported way to hand work to one another. Reusing `contacts_send` directly was unsafe because it was not available in every Channel context and did not restrict recipients to Agents. Static Channel allowlists also made private Agent communication require manual platform-ID maintenance.

This change keeps Contacts and existing Channel delivery as the transport, adds the minimum Agent-specific permission checks, and avoids introducing a separate RPC or shared-state system.

## User and developer impact

Administrators can configure stable identities or existing Telegram Contact references in `admins`, then pair two Agents by sending reciprocal `/pair @Agent` commands. Paired active Agents can communicate in private chats without being added manually to Channel allowlists. Handoff uses the same parameters and routing behavior as `contacts_send`, while rejecting non-Agent and inactive recipients.

Pair completion follows persisted Contact state: a later Journal write failure is logged but no longer reports an already-effective pairing as failed.

## Validation

- `go test ./...`
- `go vet ./...`
