### PR TITLE
fix(deps): pin uniai to v0.1.52

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/nickalie/go-webpbin v0.0.0-20220110095747-f10016bf2dc1
 	github.com/openai/openai-go/v3 v3.42.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/quailyquaily/uniai v0.1.53
+	github.com/quailyquaily/uniai v0.1.52
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/quailyquaily/uniai v0.1.53 h1:zaWAah8QGjmpG2c/qUV7XEpbeZ/dcNoKMsIwpQ2a4+U=
-github.com/quailyquaily/uniai v0.1.53/go.mod h1:Fb1Un6LL7Ypr/a2V9cBPj2JU3yJ/mQVcFBq4tc45nSI=
+github.com/quailyquaily/uniai v0.1.52 h1:FCpF4hZqoUdWuX2GlzL1QEhVAA9Dw/f7eacEMRtP2D4=
+github.com/quailyquaily/uniai v0.1.52/go.mod h1:Fb1Un6LL7Ypr/a2V9cBPj2JU3yJ/mQVcFBq4tc45nSI=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
## Summary

- Downgrade `github.com/quailyquaily/uniai` from `v0.1.53` to `v0.1.52`.
- Reverts the dependency bump introduced in `fe8cc1d4` (`chore(deps): update uniai to v0.1.53`).

## Why v0.1.52 instead of v0.1.53?

`v0.1.53` is currently **broken for environments that fetch modules directly from GitHub** (`GOPROXY=direct`).

What we observed:

1. `go.mod` pins `uniai v0.1.53`, but `go mod download` fails with:
   ```text
   unknown revision v0.1.53
   ```
2. The tag **does not exist on GitHub** anymore (`v0.1.53` release returns 404; latest tag on GitHub is `v0.1.52`).
3. The version **still exists on `proxy.golang.org`** (likely cached from a brief publish), which is why the original upgrade succeeded on machines using the default Go proxy.
4. Both versions resolve to the **same commit**:
   ```text
   3736c30440ce90b8b62497f82bd49d3894cbcd1e
   ```
   So this is a fetchability fix, not a functional downgrade.

Pinning `v0.1.52` restores compatibility for `GOPROXY=direct` setups while keeping identical source code.

## Test plan

- [x] `go mod tidy`
- [x] `go build ./...`
- [x] `go test ./internal/jsonutil/...`

Made with [Cursor](https://cursor.com)